### PR TITLE
update link to jenkins p2 update site

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Snapshots are regularly deployed to
 
 Also, you can get them directly from the TypeFox Jenkins server:
  * http://services.typefox.io/open-source/jenkins/job/lsp4j/lastSuccessfulBuild/artifact/build/maven-repository/
- * http://services.typefox.io/open-source/jenkins/job/lsp4j/lastSuccessfulBuild/artifact/build/p2-repository/
+ * http://services.typefox.io/open-source/jenkins/job/lsp4j/job/master/lastSuccessfulBuild/artifact/build/p2-repository/
 
 ### Licenses
 


### PR DESCRIPTION
The link was not working, probably was old.

It's possible that the other link is bad too, I can't test it properly.