### PR TITLE
Created explicit parameter type for cancel requests

### DIFF
--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/MessageJsonHandler.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/MessageJsonHandler.java
@@ -16,6 +16,7 @@ import org.eclipse.lsp4j.jsonrpc.json.adapters.CollectionTypeAdapterFactory;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.EitherTypeAdapterFactory;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.EnumTypeAdapterFactory;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.MessageTypeAdapterFactory;
+import org.eclipse.lsp4j.jsonrpc.messages.CancelParams;
 import org.eclipse.lsp4j.jsonrpc.messages.Message;
 
 import com.google.gson.Gson;
@@ -26,6 +27,8 @@ import com.google.gson.GsonBuilder;
  * Override {@link #getDefaultGsonBuilder()} to replace or extend the default configuration.
  */
 public class MessageJsonHandler {
+	
+	public static final JsonRpcMethod CANCEL_METHOD = JsonRpcMethod.notification("$/cancelRequest", CancelParams.class);
 	
 	private final Gson gson;
 	
@@ -47,7 +50,12 @@ public class MessageJsonHandler {
 	}
 	
 	public JsonRpcMethod getJsonRpcMethod(String name) {
-		return supportedMethods.get(name);
+		JsonRpcMethod result = supportedMethods.get(name);
+		if (result != null)
+			return result;
+		else if (CANCEL_METHOD.getMethodName().equals(name))
+			return CANCEL_METHOD;
+		return null;
 	}
 	
 	public MethodProvider getMethodProvider() {

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/CancelParams.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/CancelParams.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2016 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.lsp4j.jsonrpc.messages;
+
+import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+
+/**
+ * To cancel a request a notification message with the following properties is sent.
+ */
+public class CancelParams {
+	
+	/**
+	 * The request id to cancel.
+	 */
+	@NonNull
+	private String id;
+	
+	public String getId() {
+		return this.id;
+	}
+	
+	public void setId(String id) {
+		this.id = id;
+	}
+	
+	@Override
+	public String toString() {
+		return MessageJsonHandler.toString(this);
+	}
+	
+}


### PR DESCRIPTION
RemoteEndpoint used to retrieve the request id from a cancel notification using the generic parameter parsing to Map. After the introduction of a type adapter for Message this had to be changed to support JsonElement as parameter type. With this change the MessageJsonHandler considers CancelParams if no specific method is registered for cancel notifications, so RemoteEndpoint can simply check for these CancelParams.