### PR TITLE
Documentation typo: checkCancelled  -> checkCanceled

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -52,12 +52,12 @@ public CompletableFuture<CompletionList> completion(
    return CompletableFutures.computeAsync(cancelToken -> {
       // the actual implementation should check for 
       // cancellation like this
-      cancelToken.checkCancelled();
+      cancelToken.checkCanceled();
       // more code...  and more cancel checking
    });
 }
 ```
-The method `checkCancelled` will throw a `CancellationException` in case the request was cancelled. So make sure you don't catch it accidentally.
+The method `checkCanceled` will throw a `CancellationException` in case the request was cancelled. So make sure you don't catch it accidentally.
 
 If you are on the other side and want to cancel a request you made, you need to call cancel on the returned future :
 

--- a/documentation/jsonrpc.md
+++ b/documentation/jsonrpc.md
@@ -45,7 +45,7 @@ public CompletableFuture<CompletionList> completion(
    return CompletableFutures.computeAsync(cancelToken -> {
       // the actual implementation should check for 
       // cancellation like this
-      cancelToken.checkCancelled();
+      cancelToken.checkCanceled();
       // more code...  and more cancel checking
       return completionList;
    });


### PR DESCRIPTION
Both are correct in English, but the compiler does not know that ;)