### PR TITLE
fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Java binding for the [Language Server Protocol](https://github.com/Microsoft/lan
 ### How To Use
 
 A brief overview of how to use LSP4J to implement a server or a client can be found here:
- * [Getting Started] (documentation/README.md)
- * [Core Concepts] (documentation/jsonrpc.md)
+
+ * [Getting Started](documentation/README.md)
+ * [Core Concepts](documentation/jsonrpc.md)
 
 ### p2 Update Sites
 


### PR DESCRIPTION
A couple of links are not displayed correctly

![screen shot 2017-04-05 at 17 10 57](https://cloud.githubusercontent.com/assets/439078/24712358/ee45b56e-1a22-11e7-971b-32505f7e2486.png)

Also, some markdown viewer will be not happy without a while line before the bullet points