### PR TITLE
Write constructors explicitly instead of generating them

### DIFF
--- a/org.eclipse.lsp4j.generator/src/main/xtend-gen/org/eclipse/lsp4j/generator/JsonRpcDataProcessor.java
+++ b/org.eclipse.lsp4j.generator/src/main/xtend-gen/org/eclipse/lsp4j/generator/JsonRpcDataProcessor.java
@@ -28,7 +28,6 @@ import org.eclipse.xtend.lib.macro.declaration.ClassDeclaration;
 import org.eclipse.xtend.lib.macro.declaration.CompilationStrategy;
 import org.eclipse.xtend.lib.macro.declaration.FieldDeclaration;
 import org.eclipse.xtend.lib.macro.declaration.MutableClassDeclaration;
-import org.eclipse.xtend.lib.macro.declaration.MutableConstructorDeclaration;
 import org.eclipse.xtend.lib.macro.declaration.MutableFieldDeclaration;
 import org.eclipse.xtend.lib.macro.declaration.MutableMethodDeclaration;
 import org.eclipse.xtend.lib.macro.declaration.Type;
@@ -48,10 +47,8 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 @SuppressWarnings("all")
 public class JsonRpcDataProcessor extends AbstractClassProcessor {
-  private final static int MAX_CONSTRUCTOR_ARGS = 3;
-  
   @Override
-  public void doTransform(final MutableClassDeclaration annotatedClass, @Extension final TransformationContext context) {
+  public void doTransform(final MutableClassDeclaration annotatedClass, final TransformationContext context) {
     this.generateImpl(annotatedClass, context);
   }
   
@@ -64,62 +61,22 @@ public class JsonRpcDataProcessor extends AbstractClassProcessor {
     impl.removeAnnotation(IterableExtensions.findFirst(impl.getAnnotations(), _function));
     JsonRpcDataTransformationContext _jsonRpcDataTransformationContext = new JsonRpcDataTransformationContext(context);
     this.generateImplMembers(impl, _jsonRpcDataTransformationContext);
-    final Function1<MutableFieldDeclaration, Boolean> _function_1 = (MutableFieldDeclaration it) -> {
-      boolean _isStatic = it.isStatic();
-      return Boolean.valueOf((!_isStatic));
-    };
-    final Iterable<? extends MutableFieldDeclaration> fields = IterableExtensions.filter(impl.getDeclaredFields(), _function_1);
-    boolean _isEmpty = IterableExtensions.isEmpty(fields);
-    boolean _not = (!_isEmpty);
-    if (_not) {
-      final Procedure1<MutableConstructorDeclaration> _function_2 = (MutableConstructorDeclaration it) -> {
-        StringConcatenationClient _client = new StringConcatenationClient() {
-          @Override
-          protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
-          }
-        };
-        it.setBody(_client);
-      };
-      impl.addConstructor(_function_2);
-      if (((IterableExtensions.size(fields) <= JsonRpcDataProcessor.MAX_CONSTRUCTOR_ARGS) && (impl.getExtendedClass() != context.getObject()))) {
-        final Procedure1<MutableConstructorDeclaration> _function_3 = (MutableConstructorDeclaration constructor) -> {
-          final Consumer<MutableFieldDeclaration> _function_4 = (MutableFieldDeclaration field) -> {
-            constructor.addParameter(field.getSimpleName(), field.getType());
-          };
-          fields.forEach(_function_4);
-          StringConcatenationClient _client = new StringConcatenationClient() {
-            @Override
-            protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
-              {
-                for(final MutableFieldDeclaration field : fields) {
-                  _builder.append("this.");
-                  String _simpleName = field.getSimpleName();
-                  _builder.append(_simpleName);
-                  _builder.append(" = ");
-                  String _simpleName_1 = field.getSimpleName();
-                  _builder.append(_simpleName_1);
-                  _builder.append(";");
-                  _builder.newLineIfNotEmpty();
-                }
-              }
-            }
-          };
-          constructor.setBody(_client);
-        };
-        impl.addConstructor(_function_3);
-      }
-    }
     this.generateToString(impl, context);
     Type _type = impl.getExtendedClass().getType();
     Type _type_1 = context.newTypeReference(Object.class).getType();
     final boolean shouldIncludeSuper = (!Objects.equal(_type, _type_1));
     final EqualsHashCodeProcessor.Util equalsHashCodeUtil = new EqualsHashCodeProcessor.Util(context);
+    final Function1<MutableFieldDeclaration, Boolean> _function_1 = (MutableFieldDeclaration it) -> {
+      boolean _isStatic = it.isStatic();
+      return Boolean.valueOf((!_isStatic));
+    };
+    final Iterable<? extends MutableFieldDeclaration> fields = IterableExtensions.filter(impl.getDeclaredFields(), _function_1);
     equalsHashCodeUtil.addEquals(impl, fields, shouldIncludeSuper);
     equalsHashCodeUtil.addHashCode(impl, fields, shouldIncludeSuper);
     return impl;
   }
   
-  private void generateImplMembers(final MutableClassDeclaration impl, @Extension final JsonRpcDataTransformationContext context) {
+  protected void generateImplMembers(final MutableClassDeclaration impl, @Extension final JsonRpcDataTransformationContext context) {
     final Function1<MutableFieldDeclaration, Boolean> _function = (MutableFieldDeclaration it) -> {
       boolean _isStatic = it.isStatic();
       return Boolean.valueOf((!_isStatic));
@@ -250,7 +207,7 @@ public class JsonRpcDataProcessor extends AbstractClassProcessor {
     return _xblockexpression;
   }
   
-  private MutableMethodDeclaration generateToString(final MutableClassDeclaration impl, @Extension final TransformationContext context) {
+  protected MutableMethodDeclaration generateToString(final MutableClassDeclaration impl, @Extension final TransformationContext context) {
     MutableMethodDeclaration _xblockexpression = null;
     {
       final ArrayList<FieldDeclaration> toStringFields = CollectionLiterals.<FieldDeclaration>newArrayList();

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -14,6 +14,13 @@ class DynamicRegistrationCapabilities {
      * Supports dynamic registration.
      */
     Boolean dynamicRegistration
+    
+    new() {
+    }
+    
+    new(Boolean dynamicRegistration) {
+    	this.dynamicRegistration = dynamicRegistration
+    }
 }
 
 @JsonRpcData
@@ -22,6 +29,13 @@ class WorkspaceEditCapabilites {
 	 * The client supports versioned document changes in `WorkspaceEdit`s
 	 */
 	Boolean documentChanges
+    
+    new() {
+    }
+    
+    new(Boolean documentChanges) {
+    	this.documentChanges = documentChanges
+    }
 }
 
 @JsonRpcData
@@ -95,6 +109,15 @@ class SynchronizationCapabilities extends DynamicRegistrationCapabilities {
      * The client supports did save notifications.
      */
     Boolean didSave
+    
+    new() {
+    }
+    
+    new(Boolean willSave, Boolean willSaveWaitUntil, Boolean didSave) {
+    	this.willSave = willSave
+    	this.willSaveWaitUntil = willSaveWaitUntil
+    	this.didSave = didSave
+    }
 }
 
 @JsonRpcData
@@ -108,6 +131,13 @@ class CompletionItemCapabilities {
      * that is typing in one will update others too.
      */
     Boolean snippetSupport
+    
+    new() {
+    }
+    
+    new(Boolean snippetSupport) {
+    	this.snippetSupport = snippetSupport
+    }
 }
 
 @JsonRpcData
@@ -117,6 +147,13 @@ class CompletionCapabilities extends DynamicRegistrationCapabilities {
 	 * capabilities.
 	 */
 	CompletionItemCapabilities completionItem
+    
+    new() {
+    }
+    
+    new(CompletionItemCapabilities completionItem) {
+    	this.completionItem = completionItem
+    }
 }
 
 @JsonRpcData
@@ -272,6 +309,15 @@ class ClientCapabilities {
      * Experimental client capabilities.
      */
     Object experimental
+    
+    new() {
+    }
+    
+    new(WorkspaceClientCapabilites workspace,  TextDocumentClientCapabilities textDocument, Object experimental) {
+    	this.workspace = workspace
+    	this.textDocument = textDocument
+    	this.experimental = experimental
+    }
 }
 
 /**
@@ -283,7 +329,15 @@ class CodeActionContext {
 	 * An array of diagnostics.
 	 */
 	@NonNull
-	List<Diagnostic> diagnostics = newArrayList
+	List<Diagnostic> diagnostics
+    
+    new() {
+    	this.diagnostics = new ArrayList
+    }
+    
+    new(List<Diagnostic> diagnostics) {
+    	this.diagnostics = diagnostics
+    }
 }
 
 /**
@@ -310,6 +364,15 @@ class CodeActionParams {
 	 */
 	@NonNull
 	CodeActionContext context
+    
+    new() {
+    }
+    
+    new(TextDocumentIdentifier textDocument, Range range, CodeActionContext context) {
+    	this.textDocument = textDocument
+    	this.range = range
+    	this.context = context
+    }
 }
 
 /**
@@ -336,6 +399,15 @@ class CodeLens {
 	 * An data entry field that is preserved on a code lens item between a code lens and a code lens resolve request.
 	 */
 	Object data
+    
+    new() {
+    }
+    
+    new(Range range, Command command, Object data) {
+    	this.range = range
+    	this.command = command
+    	this.data = data
+    }
 }
 
 /**
@@ -347,6 +419,13 @@ class CodeLensOptions {
 	 * Code lens has a resolve provider as well.
 	 */
 	boolean resolveProvider
+    
+    new() {
+    }
+    
+    new(boolean resolveProvider) {
+    	this.resolveProvider = resolveProvider
+    }
 }
 
 /**
@@ -359,6 +438,13 @@ class CodeLensParams {
 	 */
 	@NonNull
 	TextDocumentIdentifier textDocument
+    
+    new() {
+    }
+    
+    new(TextDocumentIdentifier textDocument) {
+    	this.textDocument = textDocument
+    }
 }
 
 /**
@@ -383,6 +469,15 @@ class Command {
 	 * Arguments that the command handler should be invoked with.
 	 */
 	List<Object> arguments
+    
+    new() {
+    }
+    
+    new(String title, String command, List<Object> arguments) {
+    	this.title = title
+    	this.command = command
+    	this.arguments = arguments
+    }
 }
 
 /**
@@ -478,7 +573,16 @@ class CompletionList {
 	 * The completion items.
 	 */
 	@NonNull
-	List<CompletionItem> items = newArrayList
+	List<CompletionItem> items
+    
+    new() {
+    	this.items = new ArrayList
+    }
+    
+    new(boolean isIncomplete, List<CompletionItem> items) {
+    	this.isIncomplete = isIncomplete
+    	this.items = items
+    }
 }
 
 /**
@@ -495,6 +599,14 @@ class CompletionOptions {
 	 * The characters that trigger completion automatically.
 	 */
 	List<String> triggerCharacters
+    
+    new() {
+    }
+    
+    new(Boolean resolveProvider, List<String> triggerCharacters) {
+    	this.resolveProvider = resolveProvider
+    	this.triggerCharacters = triggerCharacters
+    }
 }
 
 /**
@@ -538,6 +650,13 @@ class Diagnostic {
 class DidChangeConfigurationParams {
 	@NonNull
 	Object settings
+    
+    new() {
+    }
+    
+    new(Object settings) {
+    	this.settings = settings
+    }
 }
 
 /**
@@ -563,6 +682,15 @@ class DidChangeTextDocumentParams {
 	 */
 	@NonNull
 	List<TextDocumentContentChangeEvent> contentChanges = new ArrayList
+    
+    new() {
+    }
+    
+    new(VersionedTextDocumentIdentifier textDocument, String uri, List<TextDocumentContentChangeEvent> contentChanges) {
+    	this.textDocument = textDocument
+    	this.uri = uri
+    	this.contentChanges = contentChanges
+    }
 }
 
 /**
@@ -575,7 +703,15 @@ class DidChangeWatchedFilesParams {
 	 * The actual file events.
 	 */
 	@NonNull
-	List<FileEvent> changes = new ArrayList
+	List<FileEvent> changes
+    
+    new() {
+    	this.changes = new ArrayList
+    }
+    
+    new(List<FileEvent> changes) {
+    	this.changes = changes
+    }
 }
 
 /**
@@ -590,6 +726,13 @@ class DidCloseTextDocumentParams {
 	 */
 	@NonNull
 	TextDocumentIdentifier textDocument
+    
+    new() {
+    }
+    
+    new(TextDocumentIdentifier textDocument) {
+    	this.textDocument = textDocument
+    }
 }
 
 /**
@@ -610,6 +753,14 @@ class DidOpenTextDocumentParams {
 	 */
 	@Deprecated
 	String text
+    
+    new() {
+    }
+    
+    new(TextDocumentItem textDocument, String text) {
+    	this.textDocument = textDocument
+    	this.text = text
+    }
 }
 
 /**
@@ -628,6 +779,14 @@ class DidSaveTextDocumentParams {
      * when the save notification was requested.
      */
     String text
+    
+    new() {
+    }
+    
+    new(TextDocumentIdentifier textDocument, String text) {
+    	this.textDocument = textDocument
+    	this.text = text
+    }
 }
 
 
@@ -644,6 +803,14 @@ class WillSaveTextDocumentParams {
 	 */
 	@NonNull
 	TextDocumentSaveReason reason
+    
+    new() {
+    }
+    
+    new(TextDocumentIdentifier textDocument, TextDocumentSaveReason reason) {
+    	this.textDocument = textDocument
+    	this.reason = reason
+    }
 }
 
 /**
@@ -662,6 +829,14 @@ class DocumentFormattingParams {
 	 */
 	@NonNull
 	FormattingOptions options
+    
+    new() {
+    }
+    
+    new(TextDocumentIdentifier textDocument, FormattingOptions options) {
+    	this.textDocument = textDocument
+    	this.options = options
+    }
 }
 
 /**
@@ -680,6 +855,14 @@ class DocumentHighlight {
 	 * The highlight kind, default is {@link DocumentHighlightKind#Text}.
 	 */
 	DocumentHighlightKind kind
+    
+    new() {
+    }
+    
+    new(Range range, DocumentHighlightKind kind) {
+    	this.range = range
+    	this.kind = kind
+    }
 }
 
 /**
@@ -691,12 +874,21 @@ class DocumentLink {
     /**
      * The range this link applies to.
      */
-    @NonNull Range range
+    @NonNull
+    Range range
     
     /**
      * The uri this link points to. If missing a resolve request is sent later.
      */
     String target
+    
+    new() {
+    }
+    
+    new(Range range, String target) {
+    	this.range = range
+    	this.target = target
+    }
 }
 
 @JsonRpcData
@@ -705,6 +897,13 @@ class DocumentLinkParams {
      * The document to provide document links for.
      */
     TextDocumentIdentifier textDocument
+    
+    new() {
+    }
+    
+    new(TextDocumentIdentifier textDocument) {
+    	this.textDocument = textDocument
+    }
 }
 
 /**
@@ -716,6 +915,13 @@ class DocumentLinkOptions {
      * Document links have a resolve provider as well.
      */
     Boolean resolveProvider
+    
+    new() {
+    }
+    
+    new(Boolean resolveProvider) {
+    	this.resolveProvider = resolveProvider
+    }
 }
 
 /**
@@ -727,7 +933,15 @@ class ExecuteCommandOptions {
      * The commands to be executed on the server
      */
     @NonNull
-    List<String> commands = newArrayList
+    List<String> commands
+    
+    new() {
+    	this.commands = new ArrayList
+    }
+    
+    new(List<String> commands) {
+    	this.commands = commands
+    }
 }
 
 /**
@@ -738,7 +952,14 @@ class SaveOptions {
 	/**
      * The client is supposed to include the content on save.
      */
-    Boolean includeText	
+    Boolean includeText
+    
+    new() {
+    }
+    
+    new(Boolean includeText) {
+    	this.includeText = includeText
+    }
 }
 
 @JsonRpcData
@@ -781,6 +1002,14 @@ class DocumentOnTypeFormattingOptions {
 	 * More trigger characters.
 	 */
 	List<String> moreTriggerCharacter
+    
+    new() {
+    }
+    
+    new(String firstTriggerCharacter, List<String> moreTriggerCharacter) {
+    	this.firstTriggerCharacter = firstTriggerCharacter
+    	this.moreTriggerCharacter = moreTriggerCharacter
+    }
 }
 
 /**
@@ -799,6 +1028,14 @@ class DocumentOnTypeFormattingParams extends DocumentFormattingParams {
 	 */
 	@NonNull
 	String ch
+    
+    new() {
+    }
+    
+    new(Position position, String ch) {
+    	this.position = position
+    	this.ch = ch
+    }
 }
 
 /**
@@ -811,6 +1048,13 @@ class DocumentRangeFormattingParams extends DocumentFormattingParams {
 	 */
 	@NonNull
 	Range range
+    
+    new() {
+    }
+    
+    new(Range range) {
+    	this.range = range
+    }
 }
 
 /**
@@ -823,6 +1067,13 @@ class DocumentSymbolParams {
 	 */
 	@NonNull
 	TextDocumentIdentifier textDocument
+    
+    new() {
+    }
+    
+    new(TextDocumentIdentifier textDocument) {
+    	this.textDocument = textDocument
+    }
 }
 
 /**
@@ -841,6 +1092,14 @@ class FileEvent {
 	 */
 	@NonNull
 	FileChangeType type
+    
+    new() {
+    }
+    
+    new(String uri, FileChangeType type) {
+    	this.uri = uri
+    	this.type = type
+    }
 }
 
 /**
@@ -862,6 +1121,15 @@ class FormattingOptions {
 	 * Signature for further properties.
 	 */
 	Map<String, String> properties
+    
+    new() {
+    }
+    
+    new(int tabSize, boolean insertSpaces, Map<String, String> properties) {
+    	this.tabSize = tabSize
+    	this.insertSpaces = insertSpaces
+    	this.properties = properties
+    }
 }
 
 /**
@@ -879,6 +1147,14 @@ class Hover {
 	 * An optional range
 	 */
 	Range range
+    
+    new() {
+    }
+    
+    new(List<Either<String, MarkedString>> contents, Range range) {
+    	this.contents = contents
+    	this.range = range
+    }
 }
 
 /**
@@ -898,8 +1174,17 @@ class Hover {
 class MarkedString {
 	@NonNull
 	String language
+	
 	@NonNull
 	String value
+    
+    new() {
+    }
+    
+    new(String language, String value) {
+    	this.language = language
+    	this.value = value
+    }
 }
 
 @JsonRpcData
@@ -909,6 +1194,13 @@ class InitializeError {
 	 * in the ResponseError.
 	 */
 	boolean retry
+    
+    new() {
+    }
+    
+    new(boolean retry) {
+    	this.retry = retry
+    }
 }
 
 /**
@@ -981,6 +1273,13 @@ class InitializeResult {
 	 */
 	@NonNull
 	ServerCapabilities capabilities
+    
+    new() {
+    }
+    
+    new(ServerCapabilities capabilities) {
+    	this.capabilities = capabilities
+    }
 }
 
 /**
@@ -993,6 +1292,14 @@ class Location {
 
 	@NonNull
 	Range range
+    
+    new() {
+    }
+    
+    new(String uri, Range range) {
+    	this.uri = uri
+    	this.range = range
+    }
 }
 
 /**
@@ -1007,6 +1314,13 @@ class MessageActionItem {
 	 */
 	@NonNull
 	String title
+    
+    new() {
+    }
+    
+    new(String title) {
+    	this.title = title
+    }
 }
 
 /**
@@ -1028,6 +1342,14 @@ class MessageParams {
 	 */
 	@NonNull
 	String message
+    
+    new() {
+    }
+    
+    new(MessageType type, String message) {
+    	this.type = type
+    	this.message = message
+    }
 }
 
 /**
@@ -1045,6 +1367,14 @@ class ParameterInformation {
 	 * The human-readable doc-comment of this signature. Will be shown in the UI but can be omitted.
 	 */
 	String documentation
+    
+    new() {
+    }
+    
+    new(String label, String documentation) {
+    	this.label = label
+    	this.documentation = documentation
+    }
 }
 
 /**
@@ -1061,6 +1391,14 @@ class Position {
 	 * Character offset on a line in a document (zero-based).
 	 */
 	int character
+    
+    new() {
+    }
+    
+    new(int line, int character) {
+    	this.line = line
+    	this.character = character
+    }
 }
 
 /**
@@ -1078,7 +1416,16 @@ class PublishDiagnosticsParams {
 	 * An array of diagnostic information items.
 	 */
 	@NonNull
-	List<Diagnostic> diagnostics = new ArrayList
+	List<Diagnostic> diagnostics
+    
+    new() {
+    	this.diagnostics = new ArrayList
+    }
+    
+    new(String uri, List<Diagnostic> diagnostics) {
+    	this.uri = uri
+    	this.diagnostics = diagnostics
+    }
 }
 
 /**
@@ -1097,6 +1444,14 @@ class Range {
 	 */
 	@NonNull
 	Position end
+    
+    new() {
+    }
+    
+    new(Position start, Position end) {
+    	this.start = start
+    	this.end = end
+    }
 }
 
 /**
@@ -1109,6 +1464,13 @@ class ReferenceContext {
 	 * Include the declaration of the current symbol.
 	 */
 	boolean includeDeclaration
+    
+    new() {
+    }
+    
+    new(boolean includeDeclaration) {
+    	this.includeDeclaration = includeDeclaration
+    }
 }
 
 /**
@@ -1119,6 +1481,13 @@ class ReferenceContext {
 class ReferenceParams extends TextDocumentPositionParams {
 	@NonNull
 	ReferenceContext context
+    
+    new() {
+    }
+    
+    new(ReferenceContext context) {
+    	this.context = context
+    }
 }
 
 /**
@@ -1144,6 +1513,15 @@ class RenameParams {
 	 */
 	@NonNull
 	String newName
+    
+    new() {
+    }
+    
+    new(TextDocumentIdentifier textDocument, Position position, String newName) {
+    	this.textDocument = textDocument
+    	this.position = position
+    	this.newName = newName
+    }
 }
 
 @JsonRpcData
@@ -1251,6 +1629,13 @@ class ShowMessageRequestParams extends MessageParams {
 	 * The message action items to present.
 	 */
 	List<MessageActionItem> actions
+    
+    new() {
+    }
+    
+    new(List<MessageActionItem> actions) {
+    	this.actions = actions
+    }
 }
 
 /**
@@ -1263,7 +1648,7 @@ class SignatureHelp {
 	 * One or more signatures.
 	 */
 	@NonNull
-	List<SignatureInformation> signatures = new ArrayList
+	List<SignatureInformation> signatures
 
 	/**
 	 * The active signature.
@@ -1274,6 +1659,16 @@ class SignatureHelp {
 	 * The active parameter of the active signature.
 	 */
 	Integer activeParameter
+    
+    new() {
+    	this.signatures = new ArrayList
+    }
+    
+    new(List<SignatureInformation> signatures, Integer activeSignature, Integer activeParameter) {
+    	this.signatures = signatures
+    	this.activeSignature = activeSignature
+    	this.activeParameter = activeParameter
+    }
 }
 
 /**
@@ -1285,6 +1680,13 @@ class SignatureHelpOptions {
 	 * The characters that trigger signature help automatically.
 	 */
 	List<String> triggerCharacters
+    
+    new() {
+    }
+    
+    new(List<String> triggerCharacters) {
+    	this.triggerCharacters = triggerCharacters
+    }
 }
 
 /**
@@ -1308,6 +1710,15 @@ class SignatureInformation {
 	 * The parameters of this signature.
 	 */
 	List<ParameterInformation> parameters
+    
+    new() {
+    }
+    
+    new(String label, String documentation, List<ParameterInformation> parameters) {
+    	this.label = label
+    	this.documentation = documentation
+    	this.parameters = parameters
+    }
 }
 
 /**
@@ -1360,6 +1771,15 @@ class TextDocumentContentChangeEvent {
 	 */
 	@NonNull
 	String text
+    
+    new() {
+    }
+    
+    new(Range range, Integer rangeLength, String text) {
+    	this.range = range
+    	this.rangeLength = rangeLength
+    	this.text = text
+    }
 }
 
 /**
@@ -1372,6 +1792,13 @@ class TextDocumentIdentifier {
 	 */
 	@NonNull
 	String uri
+    
+    new() {
+    }
+    
+    new(String uri) {
+    	this.uri = uri
+    }
 }
 
 /**
@@ -1425,6 +1852,15 @@ class TextDocumentPositionParams {
 	 */
 	@NonNull
 	Position position
+    
+    new() {
+    }
+    
+    new(TextDocumentIdentifier textDocument, String uri, Position position) {
+    	this.textDocument = textDocument
+    	this.uri = uri
+    	this.position = position
+    }
 }
 
 /**
@@ -1443,6 +1879,14 @@ class TextEdit {
 	 */
 	@NonNull
 	String newText
+    
+    new() {
+    }
+    
+    new(Range range, String newText) {
+    	this.range = range
+    	this.newText = newText
+    }
 }
 
 /**
@@ -1454,6 +1898,13 @@ class VersionedTextDocumentIdentifier extends TextDocumentIdentifier {
 	 * The version number of this document.
 	 */
 	int version
+    
+    new() {
+    }
+    
+    new(int version) {
+    	this.version = version
+    }
 }
 
 /**
@@ -1474,6 +1925,14 @@ class TextDocumentEdit {
 	 */
 	@NonNull
 	List<TextEdit> edits
+    
+    new() {
+    }
+    
+    new(VersionedTextDocumentIdentifier textDocument, List<TextEdit> edits) {
+    	this.textDocument = textDocument
+    	this.edits = edits
+    }
 }
 
 /**
@@ -1487,7 +1946,7 @@ class WorkspaceEdit {
 	/**
 	 * Holds changes to existing resources.
 	 */
-	Map<String, List<TextEdit>> changes = new LinkedHashMap
+	Map<String, List<TextEdit>> changes
 
 	/**
 	 * An array of `TextDocumentEdit`s to express changes to specific a specific
@@ -1495,6 +1954,15 @@ class WorkspaceEdit {
 	 * edits is expressed via `WorkspaceClientCapabilites.versionedWorkspaceEdit`.
 	 */
 	List<TextDocumentEdit> documentChanges
+    
+    new() {
+    	this.changes = new LinkedHashMap
+    }
+    
+    new(Map<String, List<TextEdit>> changes, List<TextDocumentEdit> documentChanges) {
+    	this.changes = changes
+    	this.documentChanges = documentChanges
+    }
 }
 
 /**
@@ -1507,6 +1975,13 @@ class WorkspaceSymbolParams {
 	 */
 	@NonNull
 	String query
+    
+    new() {
+    }
+    
+    new(String query) {
+    	this.query = query
+    }
 }
 
 /**
@@ -1531,12 +2006,29 @@ class Registration {
      * Options necessary for the registration.
      */
     Object registerOptions
+    
+    new() {
+    }
+    
+    new(String id, String method, Object registerOptions) {
+    	this.id = id
+    	this.method = method
+    	this.registerOptions = registerOptions
+    }
 }
 
 @JsonRpcData
 class RegistrationParams {
 	@NonNull
-	List<Registration> registrations = newArrayList
+	List<Registration> registrations
+    
+    new() {
+    	this.registrations = new ArrayList
+    }
+    
+    new(List<Registration> registrations) {
+    	this.registrations = registrations
+    }
 }
 
 /**
@@ -1558,6 +2050,15 @@ class DocumentFilter {
      * A glob pattern, like `*.{ts,js}`.
      */
     String pattern
+    
+    new() {
+    }
+    
+    new(String language, String schema, String pattern) {
+    	this.language = language
+    	this.schema = schema
+    	this.pattern = pattern
+    }
 }
 
 /**
@@ -1576,6 +2077,13 @@ class TextDocumentRegistrationOptions {
      * the document selector provided on the client side will be used.
      */
     DocumentSelector documentSelector
+    
+    new() {
+    }
+    
+    new(DocumentSelector documentSelector) {
+    	this.documentSelector = documentSelector
+    }
 }
 
 /**
@@ -1595,12 +2103,28 @@ class Unregistration {
      */
     @NonNull
 	String method
+    
+    new() {
+    }
+    
+    new(String id, String method) {
+    	this.id = id
+    	this.method = method
+    }
 }
 
 @JsonRpcData
 class UnregistrationParams {
 	@NonNull
-	List<Unregistration> unregisterations = newArrayList
+	List<Unregistration> unregisterations
+    
+    new() {
+    	this.unregisterations = new ArrayList
+    }
+    
+    new(List<Unregistration> unregisterations) {
+    	this.unregisterations = unregisterations
+    }
 }
 
 /**
@@ -1613,7 +2137,14 @@ class TextDocumentChangeRegistrationOptions extends TextDocumentRegistrationOpti
      * and TextDocumentSyncKind.Incremental.
      */
     @NonNull
-	TextDocumentSyncKind syncKind	
+	TextDocumentSyncKind syncKind
+    
+    new() {
+    }
+    
+    new(TextDocumentSyncKind syncKind) {
+    	this.syncKind = syncKind
+    }
 }
 
 @JsonRpcData
@@ -1622,6 +2153,13 @@ class TextDocumentSaveRegistrationOptions extends TextDocumentRegistrationOption
 	 * The client is supposed to include the content on save.
 	 */
 	Boolean includeText
+    
+    new() {
+    }
+    
+    new(Boolean includeText) {
+    	this.includeText = includeText
+    }
 }
 
 @JsonRpcData
@@ -1635,6 +2173,14 @@ class CompletionRegistrationOptions extends TextDocumentRegistrationOptions {
      * The server provides support to resolve additional information for a completion item.
      */
     Boolean resolveProvider
+    
+    new() {
+    }
+    
+    new(List<String> triggerCharacters, Boolean resolveProvider) {
+    	this.triggerCharacters = triggerCharacters
+    	this.resolveProvider = resolveProvider
+    }
 }
 
 @JsonRpcData
@@ -1643,6 +2189,13 @@ class SignatureHelpRegistrationOptions extends TextDocumentRegistrationOptions {
      * The characters that trigger signature help automatically.
      */
     List<String> triggerCharacters
+    
+    new() {
+    }
+    
+    new(List<String> triggerCharacters) {
+    	this.triggerCharacters = triggerCharacters
+    }
 }
 
 @JsonRpcData
@@ -1651,6 +2204,13 @@ class CodeLensRegistrationOptions extends TextDocumentRegistrationOptions {
      * Code lens has a resolve provider as well.
      */
     Boolean resolveProvider
+    
+    new() {
+    }
+    
+    new(Boolean resolveProvider) {
+    	this.resolveProvider = resolveProvider
+    }
 }
 
 @JsonRpcData
@@ -1659,6 +2219,13 @@ class DocumentLinkRegistrationOptions extends TextDocumentRegistrationOptions {
      * Document links have a resolve provider as well.
      */
     Boolean resolveProvider
+    
+    new() {
+    }
+    
+    new(Boolean resolveProvider) {
+    	this.resolveProvider = resolveProvider
+    }
 }
 
 @JsonRpcData
@@ -1670,7 +2237,15 @@ class DocumentOnTypeFormattingRegistrationOptions extends TextDocumentRegistrati
 	/**
      * More trigger characters.
      */
-    List<String> moreTriggerCharacter	
+    List<String> moreTriggerCharacter
+    
+    new() {
+    }
+    
+    new(String firstTriggerCharacter, List<String> moreTriggerCharacter) {
+    	this.firstTriggerCharacter = firstTriggerCharacter
+    	this.moreTriggerCharacter = moreTriggerCharacter
+    }
 }
 
 @JsonRpcData
@@ -1687,6 +2262,14 @@ class ExecuteCommandParams {
      * Example requests that return a command are textDocument/codeAction or textDocument/codeLens.
      */
     List<Object> arguments
+    
+    new() {
+    }
+    
+    new(String command, List<Object> arguments) {
+    	this.command = command
+    	this.arguments = arguments
+    }
 }
 
 /**
@@ -1698,6 +2281,13 @@ class ExecuteCommandRegistrationOptions {
      * The commands to be executed on the server
      */
     List<String> commands
+    
+    new() {
+    }
+    
+    new(List<String> commands) {
+    	this.commands = commands
+    }
 }
 
 @JsonRpcData
@@ -1706,6 +2296,13 @@ class ApplyWorkspaceEditParams {
      * The edits to apply.
      */
     WorkspaceEdit edit
+    
+    new() {
+    }
+    
+    new(WorkspaceEdit edit) {
+    	this.edit = edit
+    }
 }
 
 @JsonRpcData
@@ -1713,5 +2310,12 @@ class ApplyWorkspaceEditResponse {
 	/**
      * Indicates whether the edit was applied or not.
      */
-    Boolean applied	
+    Boolean applied
+    
+    new() {
+    }
+    
+    new(Boolean applied) {
+    	this.applied = applied
+    }
 }

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/ProtocolExtensions.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/ProtocolExtensions.xtend
@@ -16,14 +16,22 @@ class ColoringParams {
 	 * The URI for which coloring information is reported.
 	 */
 	@NonNull
-	String uri;
+	String uri
 
 	/**
 	 * A list of coloring information instances.
 	 */
 	@NonNull
-	List<? extends ColoringInformation> infos = new ArrayList;
-
+	List<? extends ColoringInformation> infos
+	
+	new() {
+		this.infos = new ArrayList
+	}
+	
+	new(String uri, List<? extends ColoringInformation> infos) {
+		this.uri = uri
+		this.infos = infos
+	}
 }
 
 
@@ -38,7 +46,7 @@ class ColoringInformation {
 	 * The range that should be highlighted on the client-side.
 	 */
 	@NonNull
-	Range range;
+	Range range
 
 	/**
 	 * A list of highlighting styles, that should be applied on
@@ -46,8 +54,16 @@ class ColoringInformation {
 	 * applying all styles on the range. 
 	 */
 	@NonNull
-	List<Integer> styles = new ArrayList;
-
+	List<Integer> styles
+	
+	new() {
+		this.styles = new ArrayList
+	}
+	
+	new(Range range, List<Integer> styles) {
+		this.range = range
+		this.styles = styles
+	}
 }
 
 class ColoringStyle {

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ApplyWorkspaceEditParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ApplyWorkspaceEditParams.java
@@ -11,6 +11,13 @@ public class ApplyWorkspaceEditParams {
    */
   private WorkspaceEdit edit;
   
+  public ApplyWorkspaceEditParams() {
+  }
+  
+  public ApplyWorkspaceEditParams(final WorkspaceEdit edit) {
+    this.edit = edit;
+  }
+  
   /**
    * The edits to apply.
    */
@@ -23,14 +30,6 @@ public class ApplyWorkspaceEditParams {
    * The edits to apply.
    */
   public void setEdit(final WorkspaceEdit edit) {
-    this.edit = edit;
-  }
-  
-  public ApplyWorkspaceEditParams() {
-    
-  }
-  
-  public ApplyWorkspaceEditParams(final WorkspaceEdit edit) {
     this.edit = edit;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ApplyWorkspaceEditResponse.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ApplyWorkspaceEditResponse.java
@@ -10,6 +10,13 @@ public class ApplyWorkspaceEditResponse {
    */
   private Boolean applied;
   
+  public ApplyWorkspaceEditResponse() {
+  }
+  
+  public ApplyWorkspaceEditResponse(final Boolean applied) {
+    this.applied = applied;
+  }
+  
   /**
    * Indicates whether the edit was applied or not.
    */
@@ -22,14 +29,6 @@ public class ApplyWorkspaceEditResponse {
    * Indicates whether the edit was applied or not.
    */
   public void setApplied(final Boolean applied) {
-    this.applied = applied;
-  }
-  
-  public ApplyWorkspaceEditResponse() {
-    
-  }
-  
-  public ApplyWorkspaceEditResponse(final Boolean applied) {
     this.applied = applied;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ClientCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ClientCapabilities.java
@@ -29,6 +29,15 @@ public class ClientCapabilities {
    */
   private Object experimental;
   
+  public ClientCapabilities() {
+  }
+  
+  public ClientCapabilities(final WorkspaceClientCapabilites workspace, final TextDocumentClientCapabilities textDocument, final Object experimental) {
+    this.workspace = workspace;
+    this.textDocument = textDocument;
+    this.experimental = experimental;
+  }
+  
   /**
    * Workspace specific client capabilities.
    */
@@ -71,16 +80,6 @@ public class ClientCapabilities {
    * Experimental client capabilities.
    */
   public void setExperimental(final Object experimental) {
-    this.experimental = experimental;
-  }
-  
-  public ClientCapabilities() {
-    
-  }
-  
-  public ClientCapabilities(final WorkspaceClientCapabilites workspace, final TextDocumentClientCapabilities textDocument, final Object experimental) {
-    this.workspace = workspace;
-    this.textDocument = textDocument;
     this.experimental = experimental;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeActionContext.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeActionContext.java
@@ -1,9 +1,9 @@
 package org.eclipse.lsp4j;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
-import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -16,7 +16,16 @@ public class CodeActionContext {
    * An array of diagnostics.
    */
   @NonNull
-  private List<Diagnostic> diagnostics = CollectionLiterals.<Diagnostic>newArrayList();
+  private List<Diagnostic> diagnostics;
+  
+  public CodeActionContext() {
+    ArrayList<Diagnostic> _arrayList = new ArrayList<Diagnostic>();
+    this.diagnostics = _arrayList;
+  }
+  
+  public CodeActionContext(final List<Diagnostic> diagnostics) {
+    this.diagnostics = diagnostics;
+  }
   
   /**
    * An array of diagnostics.
@@ -31,14 +40,6 @@ public class CodeActionContext {
    * An array of diagnostics.
    */
   public void setDiagnostics(@NonNull final List<Diagnostic> diagnostics) {
-    this.diagnostics = diagnostics;
-  }
-  
-  public CodeActionContext() {
-    
-  }
-  
-  public CodeActionContext(final List<Diagnostic> diagnostics) {
     this.diagnostics = diagnostics;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeActionParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeActionParams.java
@@ -32,6 +32,15 @@ public class CodeActionParams {
   @NonNull
   private CodeActionContext context;
   
+  public CodeActionParams() {
+  }
+  
+  public CodeActionParams(final TextDocumentIdentifier textDocument, final Range range, final CodeActionContext context) {
+    this.textDocument = textDocument;
+    this.range = range;
+    this.context = context;
+  }
+  
   /**
    * The document in which the command was invoked.
    */
@@ -77,16 +86,6 @@ public class CodeActionParams {
    * Context carrying additional information.
    */
   public void setContext(@NonNull final CodeActionContext context) {
-    this.context = context;
-  }
-  
-  public CodeActionParams() {
-    
-  }
-  
-  public CodeActionParams(final TextDocumentIdentifier textDocument, final Range range, final CodeActionContext context) {
-    this.textDocument = textDocument;
-    this.range = range;
     this.context = context;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeLens.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeLens.java
@@ -31,6 +31,15 @@ public class CodeLens {
    */
   private Object data;
   
+  public CodeLens() {
+  }
+  
+  public CodeLens(final Range range, final Command command, final Object data) {
+    this.range = range;
+    this.command = command;
+    this.data = data;
+  }
+  
   /**
    * The range in which this code lens is valid. Should only span a single line.
    */
@@ -74,16 +83,6 @@ public class CodeLens {
    * An data entry field that is preserved on a code lens item between a code lens and a code lens resolve request.
    */
   public void setData(final Object data) {
-    this.data = data;
-  }
-  
-  public CodeLens() {
-    
-  }
-  
-  public CodeLens(final Range range, final Command command, final Object data) {
-    this.range = range;
-    this.command = command;
     this.data = data;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeLensOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeLensOptions.java
@@ -13,6 +13,13 @@ public class CodeLensOptions {
    */
   private boolean resolveProvider;
   
+  public CodeLensOptions() {
+  }
+  
+  public CodeLensOptions(final boolean resolveProvider) {
+    this.resolveProvider = resolveProvider;
+  }
+  
   /**
    * Code lens has a resolve provider as well.
    */
@@ -25,14 +32,6 @@ public class CodeLensOptions {
    * Code lens has a resolve provider as well.
    */
   public void setResolveProvider(final boolean resolveProvider) {
-    this.resolveProvider = resolveProvider;
-  }
-  
-  public CodeLensOptions() {
-    
-  }
-  
-  public CodeLensOptions(final boolean resolveProvider) {
     this.resolveProvider = resolveProvider;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeLensParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeLensParams.java
@@ -16,6 +16,13 @@ public class CodeLensParams {
   @NonNull
   private TextDocumentIdentifier textDocument;
   
+  public CodeLensParams() {
+  }
+  
+  public CodeLensParams(final TextDocumentIdentifier textDocument) {
+    this.textDocument = textDocument;
+  }
+  
   /**
    * The document to request code lens for.
    */
@@ -29,14 +36,6 @@ public class CodeLensParams {
    * The document to request code lens for.
    */
   public void setTextDocument(@NonNull final TextDocumentIdentifier textDocument) {
-    this.textDocument = textDocument;
-  }
-  
-  public CodeLensParams() {
-    
-  }
-  
-  public CodeLensParams(final TextDocumentIdentifier textDocument) {
     this.textDocument = textDocument;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeLensRegistrationOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeLensRegistrationOptions.java
@@ -11,6 +11,13 @@ public class CodeLensRegistrationOptions extends TextDocumentRegistrationOptions
    */
   private Boolean resolveProvider;
   
+  public CodeLensRegistrationOptions() {
+  }
+  
+  public CodeLensRegistrationOptions(final Boolean resolveProvider) {
+    this.resolveProvider = resolveProvider;
+  }
+  
   /**
    * Code lens has a resolve provider as well.
    */
@@ -23,14 +30,6 @@ public class CodeLensRegistrationOptions extends TextDocumentRegistrationOptions
    * Code lens has a resolve provider as well.
    */
   public void setResolveProvider(final Boolean resolveProvider) {
-    this.resolveProvider = resolveProvider;
-  }
-  
-  public CodeLensRegistrationOptions() {
-    
-  }
-  
-  public CodeLensRegistrationOptions(final Boolean resolveProvider) {
     this.resolveProvider = resolveProvider;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ColoringInformation.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ColoringInformation.java
@@ -25,7 +25,17 @@ public class ColoringInformation {
    * applying all styles on the range.
    */
   @NonNull
-  private List<Integer> styles = new ArrayList<Integer>();
+  private List<Integer> styles;
+  
+  public ColoringInformation() {
+    ArrayList<Integer> _arrayList = new ArrayList<Integer>();
+    this.styles = _arrayList;
+  }
+  
+  public ColoringInformation(final Range range, final List<Integer> styles) {
+    this.range = range;
+    this.styles = styles;
+  }
   
   /**
    * The range that should be highlighted on the client-side.
@@ -60,15 +70,6 @@ public class ColoringInformation {
    * applying all styles on the range.
    */
   public void setStyles(@NonNull final List<Integer> styles) {
-    this.styles = styles;
-  }
-  
-  public ColoringInformation() {
-    
-  }
-  
-  public ColoringInformation(final Range range, final List<Integer> styles) {
-    this.range = range;
     this.styles = styles;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ColoringParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ColoringParams.java
@@ -23,7 +23,17 @@ public class ColoringParams {
    * A list of coloring information instances.
    */
   @NonNull
-  private List<? extends ColoringInformation> infos = new ArrayList<ColoringInformation>();
+  private List<? extends ColoringInformation> infos;
+  
+  public ColoringParams() {
+    ArrayList<ColoringInformation> _arrayList = new ArrayList<ColoringInformation>();
+    this.infos = _arrayList;
+  }
+  
+  public ColoringParams(final String uri, final List<? extends ColoringInformation> infos) {
+    this.uri = uri;
+    this.infos = infos;
+  }
   
   /**
    * The URI for which coloring information is reported.
@@ -54,15 +64,6 @@ public class ColoringParams {
    * A list of coloring information instances.
    */
   public void setInfos(@NonNull final List<? extends ColoringInformation> infos) {
-    this.infos = infos;
-  }
-  
-  public ColoringParams() {
-    
-  }
-  
-  public ColoringParams(final String uri, final List<? extends ColoringInformation> infos) {
-    this.uri = uri;
     this.infos = infos;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Command.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Command.java
@@ -28,6 +28,15 @@ public class Command {
    */
   private List<Object> arguments;
   
+  public Command() {
+  }
+  
+  public Command(final String title, final String command, final List<Object> arguments) {
+    this.title = title;
+    this.command = command;
+    this.arguments = arguments;
+  }
+  
   /**
    * Title of the command, like `save`.
    */
@@ -72,16 +81,6 @@ public class Command {
    * Arguments that the command handler should be invoked with.
    */
   public void setArguments(final List<Object> arguments) {
-    this.arguments = arguments;
-  }
-  
-  public Command() {
-    
-  }
-  
-  public Command(final String title, final String command, final List<Object> arguments) {
-    this.title = title;
-    this.command = command;
     this.arguments = arguments;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionCapabilities.java
@@ -13,6 +13,13 @@ public class CompletionCapabilities extends DynamicRegistrationCapabilities {
    */
   private CompletionItemCapabilities completionItem;
   
+  public CompletionCapabilities() {
+  }
+  
+  public CompletionCapabilities(final CompletionItemCapabilities completionItem) {
+    this.completionItem = completionItem;
+  }
+  
   /**
    * The client supports the following `CompletionItem` specific
    * capabilities.
@@ -27,14 +34,6 @@ public class CompletionCapabilities extends DynamicRegistrationCapabilities {
    * capabilities.
    */
   public void setCompletionItem(final CompletionItemCapabilities completionItem) {
-    this.completionItem = completionItem;
-  }
-  
-  public CompletionCapabilities() {
-    
-  }
-  
-  public CompletionCapabilities(final CompletionItemCapabilities completionItem) {
     this.completionItem = completionItem;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionItem.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionItem.java
@@ -286,10 +286,6 @@ public class CompletionItem {
     this.data = data;
   }
   
-  public CompletionItem() {
-    
-  }
-  
   @Override
   @Pure
   public String toString() {

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionItemCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionItemCapabilities.java
@@ -15,6 +15,13 @@ public class CompletionItemCapabilities {
    */
   private Boolean snippetSupport;
   
+  public CompletionItemCapabilities() {
+  }
+  
+  public CompletionItemCapabilities(final Boolean snippetSupport) {
+    this.snippetSupport = snippetSupport;
+  }
+  
   /**
    * Client supports snippets as insert text.
    * 
@@ -37,14 +44,6 @@ public class CompletionItemCapabilities {
    * that is typing in one will update others too.
    */
   public void setSnippetSupport(final Boolean snippetSupport) {
-    this.snippetSupport = snippetSupport;
-  }
-  
-  public CompletionItemCapabilities() {
-    
-  }
-  
-  public CompletionItemCapabilities(final Boolean snippetSupport) {
     this.snippetSupport = snippetSupport;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionList.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionList.java
@@ -1,9 +1,9 @@
 package org.eclipse.lsp4j;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
-import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -21,7 +21,17 @@ public class CompletionList {
    * The completion items.
    */
   @NonNull
-  private List<CompletionItem> items = CollectionLiterals.<CompletionItem>newArrayList();
+  private List<CompletionItem> items;
+  
+  public CompletionList() {
+    ArrayList<CompletionItem> _arrayList = new ArrayList<CompletionItem>();
+    this.items = _arrayList;
+  }
+  
+  public CompletionList(final boolean isIncomplete, final List<CompletionItem> items) {
+    this.isIncomplete = isIncomplete;
+    this.items = items;
+  }
   
   /**
    * This list it not complete. Further typing should result in recomputing this list.
@@ -51,15 +61,6 @@ public class CompletionList {
    * The completion items.
    */
   public void setItems(@NonNull final List<CompletionItem> items) {
-    this.items = items;
-  }
-  
-  public CompletionList() {
-    
-  }
-  
-  public CompletionList(final boolean isIncomplete, final List<CompletionItem> items) {
-    this.isIncomplete = isIncomplete;
     this.items = items;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionOptions.java
@@ -19,6 +19,14 @@ public class CompletionOptions {
    */
   private List<String> triggerCharacters;
   
+  public CompletionOptions() {
+  }
+  
+  public CompletionOptions(final Boolean resolveProvider, final List<String> triggerCharacters) {
+    this.resolveProvider = resolveProvider;
+    this.triggerCharacters = triggerCharacters;
+  }
+  
   /**
    * The server provides support to resolve additional information for a completion item.
    */
@@ -46,15 +54,6 @@ public class CompletionOptions {
    * The characters that trigger completion automatically.
    */
   public void setTriggerCharacters(final List<String> triggerCharacters) {
-    this.triggerCharacters = triggerCharacters;
-  }
-  
-  public CompletionOptions() {
-    
-  }
-  
-  public CompletionOptions(final Boolean resolveProvider, final List<String> triggerCharacters) {
-    this.resolveProvider = resolveProvider;
     this.triggerCharacters = triggerCharacters;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionRegistrationOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionRegistrationOptions.java
@@ -17,6 +17,14 @@ public class CompletionRegistrationOptions extends TextDocumentRegistrationOptio
    */
   private Boolean resolveProvider;
   
+  public CompletionRegistrationOptions() {
+  }
+  
+  public CompletionRegistrationOptions(final List<String> triggerCharacters, final Boolean resolveProvider) {
+    this.triggerCharacters = triggerCharacters;
+    this.resolveProvider = resolveProvider;
+  }
+  
   /**
    * The characters that trigger completion automatically.
    */
@@ -44,15 +52,6 @@ public class CompletionRegistrationOptions extends TextDocumentRegistrationOptio
    * The server provides support to resolve additional information for a completion item.
    */
   public void setResolveProvider(final Boolean resolveProvider) {
-    this.resolveProvider = resolveProvider;
-  }
-  
-  public CompletionRegistrationOptions() {
-    
-  }
-  
-  public CompletionRegistrationOptions(final List<String> triggerCharacters, final Boolean resolveProvider) {
-    this.triggerCharacters = triggerCharacters;
     this.resolveProvider = resolveProvider;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Diagnostic.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Diagnostic.java
@@ -118,10 +118,6 @@ public class Diagnostic {
     this.message = message;
   }
   
-  public Diagnostic() {
-    
-  }
-  
   @Override
   @Pure
   public String toString() {

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidChangeConfigurationParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidChangeConfigurationParams.java
@@ -12,6 +12,13 @@ public class DidChangeConfigurationParams {
   @NonNull
   private Object settings;
   
+  public DidChangeConfigurationParams() {
+  }
+  
+  public DidChangeConfigurationParams(final Object settings) {
+    this.settings = settings;
+  }
+  
   @Pure
   @NonNull
   public Object getSettings() {
@@ -19,14 +26,6 @@ public class DidChangeConfigurationParams {
   }
   
   public void setSettings(@NonNull final Object settings) {
-    this.settings = settings;
-  }
-  
-  public DidChangeConfigurationParams() {
-    
-  }
-  
-  public DidChangeConfigurationParams(final Object settings) {
     this.settings = settings;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidChangeTextDocumentParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidChangeTextDocumentParams.java
@@ -32,6 +32,15 @@ public class DidChangeTextDocumentParams {
   @NonNull
   private List<TextDocumentContentChangeEvent> contentChanges = new ArrayList<TextDocumentContentChangeEvent>();
   
+  public DidChangeTextDocumentParams() {
+  }
+  
+  public DidChangeTextDocumentParams(final VersionedTextDocumentIdentifier textDocument, final String uri, final List<TextDocumentContentChangeEvent> contentChanges) {
+    this.textDocument = textDocument;
+    this.uri = uri;
+    this.contentChanges = contentChanges;
+  }
+  
   /**
    * The document that did change. The version number points to the version after all provided content changes have
    * been applied.
@@ -80,16 +89,6 @@ public class DidChangeTextDocumentParams {
    * The actual content changes.
    */
   public void setContentChanges(@NonNull final List<TextDocumentContentChangeEvent> contentChanges) {
-    this.contentChanges = contentChanges;
-  }
-  
-  public DidChangeTextDocumentParams() {
-    
-  }
-  
-  public DidChangeTextDocumentParams(final VersionedTextDocumentIdentifier textDocument, final String uri, final List<TextDocumentContentChangeEvent> contentChanges) {
-    this.textDocument = textDocument;
-    this.uri = uri;
     this.contentChanges = contentChanges;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidChangeWatchedFilesParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidChangeWatchedFilesParams.java
@@ -17,7 +17,16 @@ public class DidChangeWatchedFilesParams {
    * The actual file events.
    */
   @NonNull
-  private List<FileEvent> changes = new ArrayList<FileEvent>();
+  private List<FileEvent> changes;
+  
+  public DidChangeWatchedFilesParams() {
+    ArrayList<FileEvent> _arrayList = new ArrayList<FileEvent>();
+    this.changes = _arrayList;
+  }
+  
+  public DidChangeWatchedFilesParams(final List<FileEvent> changes) {
+    this.changes = changes;
+  }
   
   /**
    * The actual file events.
@@ -32,14 +41,6 @@ public class DidChangeWatchedFilesParams {
    * The actual file events.
    */
   public void setChanges(@NonNull final List<FileEvent> changes) {
-    this.changes = changes;
-  }
-  
-  public DidChangeWatchedFilesParams() {
-    
-  }
-  
-  public DidChangeWatchedFilesParams(final List<FileEvent> changes) {
     this.changes = changes;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidCloseTextDocumentParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidCloseTextDocumentParams.java
@@ -18,6 +18,13 @@ public class DidCloseTextDocumentParams {
   @NonNull
   private TextDocumentIdentifier textDocument;
   
+  public DidCloseTextDocumentParams() {
+  }
+  
+  public DidCloseTextDocumentParams(final TextDocumentIdentifier textDocument) {
+    this.textDocument = textDocument;
+  }
+  
   /**
    * The document that was closed.
    */
@@ -31,14 +38,6 @@ public class DidCloseTextDocumentParams {
    * The document that was closed.
    */
   public void setTextDocument(@NonNull final TextDocumentIdentifier textDocument) {
-    this.textDocument = textDocument;
-  }
-  
-  public DidCloseTextDocumentParams() {
-    
-  }
-  
-  public DidCloseTextDocumentParams(final TextDocumentIdentifier textDocument) {
     this.textDocument = textDocument;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidOpenTextDocumentParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidOpenTextDocumentParams.java
@@ -24,6 +24,14 @@ public class DidOpenTextDocumentParams {
   @Deprecated
   private String text;
   
+  public DidOpenTextDocumentParams() {
+  }
+  
+  public DidOpenTextDocumentParams(final TextDocumentItem textDocument, final String text) {
+    this.textDocument = textDocument;
+    this.text = text;
+  }
+  
   /**
    * The document that was opened.
    */
@@ -54,15 +62,6 @@ public class DidOpenTextDocumentParams {
    */
   @Deprecated
   public void setText(final String text) {
-    this.text = text;
-  }
-  
-  public DidOpenTextDocumentParams() {
-    
-  }
-  
-  public DidOpenTextDocumentParams(final TextDocumentItem textDocument, final String text) {
-    this.textDocument = textDocument;
     this.text = text;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidSaveTextDocumentParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidSaveTextDocumentParams.java
@@ -22,6 +22,14 @@ public class DidSaveTextDocumentParams {
    */
   private String text;
   
+  public DidSaveTextDocumentParams() {
+  }
+  
+  public DidSaveTextDocumentParams(final TextDocumentIdentifier textDocument, final String text) {
+    this.textDocument = textDocument;
+    this.text = text;
+  }
+  
   /**
    * The document that was closed.
    */
@@ -52,15 +60,6 @@ public class DidSaveTextDocumentParams {
    * when the save notification was requested.
    */
   public void setText(final String text) {
-    this.text = text;
-  }
-  
-  public DidSaveTextDocumentParams() {
-    
-  }
-  
-  public DidSaveTextDocumentParams(final TextDocumentIdentifier textDocument, final String text) {
-    this.textDocument = textDocument;
     this.text = text;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentFilter.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentFilter.java
@@ -23,6 +23,15 @@ public class DocumentFilter {
    */
   private String pattern;
   
+  public DocumentFilter() {
+  }
+  
+  public DocumentFilter(final String language, final String schema, final String pattern) {
+    this.language = language;
+    this.schema = schema;
+    this.pattern = pattern;
+  }
+  
   /**
    * A language id, like `typescript`.
    */
@@ -65,16 +74,6 @@ public class DocumentFilter {
    * A glob pattern, like `*.{ts,js}`.
    */
   public void setPattern(final String pattern) {
-    this.pattern = pattern;
-  }
-  
-  public DocumentFilter() {
-    
-  }
-  
-  public DocumentFilter(final String language, final String schema, final String pattern) {
-    this.language = language;
-    this.schema = schema;
     this.pattern = pattern;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentFormattingParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentFormattingParams.java
@@ -23,6 +23,14 @@ public class DocumentFormattingParams {
   @NonNull
   private FormattingOptions options;
   
+  public DocumentFormattingParams() {
+  }
+  
+  public DocumentFormattingParams(final TextDocumentIdentifier textDocument, final FormattingOptions options) {
+    this.textDocument = textDocument;
+    this.options = options;
+  }
+  
   /**
    * The document to format.
    */
@@ -52,15 +60,6 @@ public class DocumentFormattingParams {
    * The format options
    */
   public void setOptions(@NonNull final FormattingOptions options) {
-    this.options = options;
-  }
-  
-  public DocumentFormattingParams() {
-    
-  }
-  
-  public DocumentFormattingParams(final TextDocumentIdentifier textDocument, final FormattingOptions options) {
-    this.textDocument = textDocument;
     this.options = options;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentHighlight.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentHighlight.java
@@ -23,6 +23,14 @@ public class DocumentHighlight {
    */
   private DocumentHighlightKind kind;
   
+  public DocumentHighlight() {
+  }
+  
+  public DocumentHighlight(final Range range, final DocumentHighlightKind kind) {
+    this.range = range;
+    this.kind = kind;
+  }
+  
   /**
    * The range this highlight applies to.
    */
@@ -51,15 +59,6 @@ public class DocumentHighlight {
    * The highlight kind, default is {@link DocumentHighlightKind#Text}.
    */
   public void setKind(final DocumentHighlightKind kind) {
-    this.kind = kind;
-  }
-  
-  public DocumentHighlight() {
-    
-  }
-  
-  public DocumentHighlight(final Range range, final DocumentHighlightKind kind) {
-    this.range = range;
     this.kind = kind;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentLink.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentLink.java
@@ -22,6 +22,14 @@ public class DocumentLink {
    */
   private String target;
   
+  public DocumentLink() {
+  }
+  
+  public DocumentLink(final Range range, final String target) {
+    this.range = range;
+    this.target = target;
+  }
+  
   /**
    * The range this link applies to.
    */
@@ -50,15 +58,6 @@ public class DocumentLink {
    * The uri this link points to. If missing a resolve request is sent later.
    */
   public void setTarget(final String target) {
-    this.target = target;
-  }
-  
-  public DocumentLink() {
-    
-  }
-  
-  public DocumentLink(final Range range, final String target) {
-    this.range = range;
     this.target = target;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentLinkOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentLinkOptions.java
@@ -13,6 +13,13 @@ public class DocumentLinkOptions {
    */
   private Boolean resolveProvider;
   
+  public DocumentLinkOptions() {
+  }
+  
+  public DocumentLinkOptions(final Boolean resolveProvider) {
+    this.resolveProvider = resolveProvider;
+  }
+  
   /**
    * Document links have a resolve provider as well.
    */
@@ -25,14 +32,6 @@ public class DocumentLinkOptions {
    * Document links have a resolve provider as well.
    */
   public void setResolveProvider(final Boolean resolveProvider) {
-    this.resolveProvider = resolveProvider;
-  }
-  
-  public DocumentLinkOptions() {
-    
-  }
-  
-  public DocumentLinkOptions(final Boolean resolveProvider) {
     this.resolveProvider = resolveProvider;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentLinkParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentLinkParams.java
@@ -11,6 +11,13 @@ public class DocumentLinkParams {
    */
   private TextDocumentIdentifier textDocument;
   
+  public DocumentLinkParams() {
+  }
+  
+  public DocumentLinkParams(final TextDocumentIdentifier textDocument) {
+    this.textDocument = textDocument;
+  }
+  
   /**
    * The document to provide document links for.
    */
@@ -23,14 +30,6 @@ public class DocumentLinkParams {
    * The document to provide document links for.
    */
   public void setTextDocument(final TextDocumentIdentifier textDocument) {
-    this.textDocument = textDocument;
-  }
-  
-  public DocumentLinkParams() {
-    
-  }
-  
-  public DocumentLinkParams(final TextDocumentIdentifier textDocument) {
     this.textDocument = textDocument;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentLinkRegistrationOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentLinkRegistrationOptions.java
@@ -11,6 +11,13 @@ public class DocumentLinkRegistrationOptions extends TextDocumentRegistrationOpt
    */
   private Boolean resolveProvider;
   
+  public DocumentLinkRegistrationOptions() {
+  }
+  
+  public DocumentLinkRegistrationOptions(final Boolean resolveProvider) {
+    this.resolveProvider = resolveProvider;
+  }
+  
   /**
    * Document links have a resolve provider as well.
    */
@@ -23,14 +30,6 @@ public class DocumentLinkRegistrationOptions extends TextDocumentRegistrationOpt
    * Document links have a resolve provider as well.
    */
   public void setResolveProvider(final Boolean resolveProvider) {
-    this.resolveProvider = resolveProvider;
-  }
-  
-  public DocumentLinkRegistrationOptions() {
-    
-  }
-  
-  public DocumentLinkRegistrationOptions(final Boolean resolveProvider) {
     this.resolveProvider = resolveProvider;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentOnTypeFormattingOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentOnTypeFormattingOptions.java
@@ -21,6 +21,14 @@ public class DocumentOnTypeFormattingOptions {
    */
   private List<String> moreTriggerCharacter;
   
+  public DocumentOnTypeFormattingOptions() {
+  }
+  
+  public DocumentOnTypeFormattingOptions(final String firstTriggerCharacter, final List<String> moreTriggerCharacter) {
+    this.firstTriggerCharacter = firstTriggerCharacter;
+    this.moreTriggerCharacter = moreTriggerCharacter;
+  }
+  
   /**
    * A character on which formatting should be triggered, like `}`.
    */
@@ -49,15 +57,6 @@ public class DocumentOnTypeFormattingOptions {
    * More trigger characters.
    */
   public void setMoreTriggerCharacter(final List<String> moreTriggerCharacter) {
-    this.moreTriggerCharacter = moreTriggerCharacter;
-  }
-  
-  public DocumentOnTypeFormattingOptions() {
-    
-  }
-  
-  public DocumentOnTypeFormattingOptions(final String firstTriggerCharacter, final List<String> moreTriggerCharacter) {
-    this.firstTriggerCharacter = firstTriggerCharacter;
     this.moreTriggerCharacter = moreTriggerCharacter;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentOnTypeFormattingParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentOnTypeFormattingParams.java
@@ -23,6 +23,14 @@ public class DocumentOnTypeFormattingParams extends DocumentFormattingParams {
   @NonNull
   private String ch;
   
+  public DocumentOnTypeFormattingParams() {
+  }
+  
+  public DocumentOnTypeFormattingParams(final Position position, final String ch) {
+    this.position = position;
+    this.ch = ch;
+  }
+  
   /**
    * The position at which this request was send.
    */
@@ -52,15 +60,6 @@ public class DocumentOnTypeFormattingParams extends DocumentFormattingParams {
    * The character that has been typed.
    */
   public void setCh(@NonNull final String ch) {
-    this.ch = ch;
-  }
-  
-  public DocumentOnTypeFormattingParams() {
-    
-  }
-  
-  public DocumentOnTypeFormattingParams(final Position position, final String ch) {
-    this.position = position;
     this.ch = ch;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentOnTypeFormattingRegistrationOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentOnTypeFormattingRegistrationOptions.java
@@ -17,6 +17,14 @@ public class DocumentOnTypeFormattingRegistrationOptions extends TextDocumentReg
    */
   private List<String> moreTriggerCharacter;
   
+  public DocumentOnTypeFormattingRegistrationOptions() {
+  }
+  
+  public DocumentOnTypeFormattingRegistrationOptions(final String firstTriggerCharacter, final List<String> moreTriggerCharacter) {
+    this.firstTriggerCharacter = firstTriggerCharacter;
+    this.moreTriggerCharacter = moreTriggerCharacter;
+  }
+  
   /**
    * A character on which formatting should be triggered, like `}`.
    */
@@ -44,15 +52,6 @@ public class DocumentOnTypeFormattingRegistrationOptions extends TextDocumentReg
    * More trigger characters.
    */
   public void setMoreTriggerCharacter(final List<String> moreTriggerCharacter) {
-    this.moreTriggerCharacter = moreTriggerCharacter;
-  }
-  
-  public DocumentOnTypeFormattingRegistrationOptions() {
-    
-  }
-  
-  public DocumentOnTypeFormattingRegistrationOptions(final String firstTriggerCharacter, final List<String> moreTriggerCharacter) {
-    this.firstTriggerCharacter = firstTriggerCharacter;
     this.moreTriggerCharacter = moreTriggerCharacter;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentRangeFormattingParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentRangeFormattingParams.java
@@ -17,6 +17,13 @@ public class DocumentRangeFormattingParams extends DocumentFormattingParams {
   @NonNull
   private Range range;
   
+  public DocumentRangeFormattingParams() {
+  }
+  
+  public DocumentRangeFormattingParams(final Range range) {
+    this.range = range;
+  }
+  
   /**
    * The range to format
    */
@@ -30,14 +37,6 @@ public class DocumentRangeFormattingParams extends DocumentFormattingParams {
    * The range to format
    */
   public void setRange(@NonNull final Range range) {
-    this.range = range;
-  }
-  
-  public DocumentRangeFormattingParams() {
-    
-  }
-  
-  public DocumentRangeFormattingParams(final Range range) {
     this.range = range;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentSymbolParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentSymbolParams.java
@@ -16,6 +16,13 @@ public class DocumentSymbolParams {
   @NonNull
   private TextDocumentIdentifier textDocument;
   
+  public DocumentSymbolParams() {
+  }
+  
+  public DocumentSymbolParams(final TextDocumentIdentifier textDocument) {
+    this.textDocument = textDocument;
+  }
+  
   /**
    * The text document.
    */
@@ -29,14 +36,6 @@ public class DocumentSymbolParams {
    * The text document.
    */
   public void setTextDocument(@NonNull final TextDocumentIdentifier textDocument) {
-    this.textDocument = textDocument;
-  }
-  
-  public DocumentSymbolParams() {
-    
-  }
-  
-  public DocumentSymbolParams(final TextDocumentIdentifier textDocument) {
     this.textDocument = textDocument;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DynamicRegistrationCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DynamicRegistrationCapabilities.java
@@ -10,6 +10,13 @@ public class DynamicRegistrationCapabilities {
    */
   private Boolean dynamicRegistration;
   
+  public DynamicRegistrationCapabilities() {
+  }
+  
+  public DynamicRegistrationCapabilities(final Boolean dynamicRegistration) {
+    this.dynamicRegistration = dynamicRegistration;
+  }
+  
   /**
    * Supports dynamic registration.
    */
@@ -22,14 +29,6 @@ public class DynamicRegistrationCapabilities {
    * Supports dynamic registration.
    */
   public void setDynamicRegistration(final Boolean dynamicRegistration) {
-    this.dynamicRegistration = dynamicRegistration;
-  }
-  
-  public DynamicRegistrationCapabilities() {
-    
-  }
-  
-  public DynamicRegistrationCapabilities(final Boolean dynamicRegistration) {
     this.dynamicRegistration = dynamicRegistration;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ExecuteCommandOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ExecuteCommandOptions.java
@@ -1,8 +1,8 @@
 package org.eclipse.lsp4j;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
-import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -15,7 +15,16 @@ public class ExecuteCommandOptions {
    * The commands to be executed on the server
    */
   @NonNull
-  private List<String> commands = CollectionLiterals.<String>newArrayList();
+  private List<String> commands;
+  
+  public ExecuteCommandOptions() {
+    ArrayList<String> _arrayList = new ArrayList<String>();
+    this.commands = _arrayList;
+  }
+  
+  public ExecuteCommandOptions(final List<String> commands) {
+    this.commands = commands;
+  }
   
   /**
    * The commands to be executed on the server
@@ -30,14 +39,6 @@ public class ExecuteCommandOptions {
    * The commands to be executed on the server
    */
   public void setCommands(@NonNull final List<String> commands) {
-    this.commands = commands;
-  }
-  
-  public ExecuteCommandOptions() {
-    
-  }
-  
-  public ExecuteCommandOptions(final List<String> commands) {
     this.commands = commands;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ExecuteCommandParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ExecuteCommandParams.java
@@ -20,6 +20,14 @@ public class ExecuteCommandParams {
    */
   private List<Object> arguments;
   
+  public ExecuteCommandParams() {
+  }
+  
+  public ExecuteCommandParams(final String command, final List<Object> arguments) {
+    this.command = command;
+    this.arguments = arguments;
+  }
+  
   /**
    * The identifier of the actual command handler.
    */
@@ -52,15 +60,6 @@ public class ExecuteCommandParams {
    * Example requests that return a command are textDocument/codeAction or textDocument/codeLens.
    */
   public void setArguments(final List<Object> arguments) {
-    this.arguments = arguments;
-  }
-  
-  public ExecuteCommandParams() {
-    
-  }
-  
-  public ExecuteCommandParams(final String command, final List<Object> arguments) {
-    this.command = command;
     this.arguments = arguments;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ExecuteCommandRegistrationOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ExecuteCommandRegistrationOptions.java
@@ -14,6 +14,13 @@ public class ExecuteCommandRegistrationOptions {
    */
   private List<String> commands;
   
+  public ExecuteCommandRegistrationOptions() {
+  }
+  
+  public ExecuteCommandRegistrationOptions(final List<String> commands) {
+    this.commands = commands;
+  }
+  
   /**
    * The commands to be executed on the server
    */
@@ -26,14 +33,6 @@ public class ExecuteCommandRegistrationOptions {
    * The commands to be executed on the server
    */
   public void setCommands(final List<String> commands) {
-    this.commands = commands;
-  }
-  
-  public ExecuteCommandRegistrationOptions() {
-    
-  }
-  
-  public ExecuteCommandRegistrationOptions(final List<String> commands) {
     this.commands = commands;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/FileEvent.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/FileEvent.java
@@ -22,6 +22,14 @@ public class FileEvent {
   @NonNull
   private FileChangeType type;
   
+  public FileEvent() {
+  }
+  
+  public FileEvent(final String uri, final FileChangeType type) {
+    this.uri = uri;
+    this.type = type;
+  }
+  
   /**
    * The file's uri.
    */
@@ -51,15 +59,6 @@ public class FileEvent {
    * The change type.
    */
   public void setType(@NonNull final FileChangeType type) {
-    this.type = type;
-  }
-  
-  public FileEvent() {
-    
-  }
-  
-  public FileEvent(final String uri, final FileChangeType type) {
-    this.uri = uri;
     this.type = type;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/FormattingOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/FormattingOptions.java
@@ -24,6 +24,15 @@ public class FormattingOptions {
    */
   private Map<String, String> properties;
   
+  public FormattingOptions() {
+  }
+  
+  public FormattingOptions(final int tabSize, final boolean insertSpaces, final Map<String, String> properties) {
+    this.tabSize = tabSize;
+    this.insertSpaces = insertSpaces;
+    this.properties = properties;
+  }
+  
   /**
    * Size of a tab in spaces.
    */
@@ -66,16 +75,6 @@ public class FormattingOptions {
    * Signature for further properties.
    */
   public void setProperties(final Map<String, String> properties) {
-    this.properties = properties;
-  }
-  
-  public FormattingOptions() {
-    
-  }
-  
-  public FormattingOptions(final int tabSize, final boolean insertSpaces, final Map<String, String> properties) {
-    this.tabSize = tabSize;
-    this.insertSpaces = insertSpaces;
     this.properties = properties;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Hover.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Hover.java
@@ -24,6 +24,14 @@ public class Hover {
    */
   private Range range;
   
+  public Hover() {
+  }
+  
+  public Hover(final List<Either<String, MarkedString>> contents, final Range range) {
+    this.contents = contents;
+    this.range = range;
+  }
+  
   /**
    * The hover's content as markdown
    */
@@ -52,15 +60,6 @@ public class Hover {
    * An optional range
    */
   public void setRange(final Range range) {
-    this.range = range;
-  }
-  
-  public Hover() {
-    
-  }
-  
-  public Hover(final List<Either<String, MarkedString>> contents, final Range range) {
-    this.contents = contents;
     this.range = range;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/InitializeError.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/InitializeError.java
@@ -11,6 +11,13 @@ public class InitializeError {
    */
   private boolean retry;
   
+  public InitializeError() {
+  }
+  
+  public InitializeError(final boolean retry) {
+    this.retry = retry;
+  }
+  
   /**
    * Indicates whether the client should retry to send the initialize request after showing the message provided
    * in the ResponseError.
@@ -25,14 +32,6 @@ public class InitializeError {
    * in the ResponseError.
    */
   public void setRetry(final boolean retry) {
-    this.retry = retry;
-  }
-  
-  public InitializeError() {
-    
-  }
-  
-  public InitializeError(final boolean retry) {
     this.retry = retry;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/InitializeParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/InitializeParams.java
@@ -173,10 +173,6 @@ public class InitializeParams {
     this.trace = trace;
   }
   
-  public InitializeParams() {
-    
-  }
-  
   @Override
   @Pure
   public String toString() {

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/InitializeResult.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/InitializeResult.java
@@ -13,6 +13,13 @@ public class InitializeResult {
   @NonNull
   private ServerCapabilities capabilities;
   
+  public InitializeResult() {
+  }
+  
+  public InitializeResult(final ServerCapabilities capabilities) {
+    this.capabilities = capabilities;
+  }
+  
   /**
    * The capabilities the language server provides.
    */
@@ -26,14 +33,6 @@ public class InitializeResult {
    * The capabilities the language server provides.
    */
   public void setCapabilities(@NonNull final ServerCapabilities capabilities) {
-    this.capabilities = capabilities;
-  }
-  
-  public InitializeResult() {
-    
-  }
-  
-  public InitializeResult(final ServerCapabilities capabilities) {
     this.capabilities = capabilities;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Location.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Location.java
@@ -16,6 +16,14 @@ public class Location {
   @NonNull
   private Range range;
   
+  public Location() {
+  }
+  
+  public Location(final String uri, final Range range) {
+    this.uri = uri;
+    this.range = range;
+  }
+  
   @Pure
   @NonNull
   public String getUri() {
@@ -33,15 +41,6 @@ public class Location {
   }
   
   public void setRange(@NonNull final Range range) {
-    this.range = range;
-  }
-  
-  public Location() {
-    
-  }
-  
-  public Location(final String uri, final Range range) {
-    this.uri = uri;
     this.range = range;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/MarkedString.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/MarkedString.java
@@ -25,6 +25,14 @@ public class MarkedString {
   @NonNull
   private String value;
   
+  public MarkedString() {
+  }
+  
+  public MarkedString(final String language, final String value) {
+    this.language = language;
+    this.value = value;
+  }
+  
   @Pure
   @NonNull
   public String getLanguage() {
@@ -42,15 +50,6 @@ public class MarkedString {
   }
   
   public void setValue(@NonNull final String value) {
-    this.value = value;
-  }
-  
-  public MarkedString() {
-    
-  }
-  
-  public MarkedString(final String language, final String value) {
-    this.language = language;
     this.value = value;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/MessageActionItem.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/MessageActionItem.java
@@ -17,6 +17,13 @@ public class MessageActionItem {
   @NonNull
   private String title;
   
+  public MessageActionItem() {
+  }
+  
+  public MessageActionItem(final String title) {
+    this.title = title;
+  }
+  
   /**
    * A short title like 'Retry', 'Open Log' etc.
    */
@@ -30,14 +37,6 @@ public class MessageActionItem {
    * A short title like 'Retry', 'Open Log' etc.
    */
   public void setTitle(@NonNull final String title) {
-    this.title = title;
-  }
-  
-  public MessageActionItem() {
-    
-  }
-  
-  public MessageActionItem(final String title) {
     this.title = title;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/MessageParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/MessageParams.java
@@ -25,6 +25,14 @@ public class MessageParams {
   @NonNull
   private String message;
   
+  public MessageParams() {
+  }
+  
+  public MessageParams(final MessageType type, final String message) {
+    this.type = type;
+    this.message = message;
+  }
+  
   /**
    * The message type.
    */
@@ -54,15 +62,6 @@ public class MessageParams {
    * The actual message.
    */
   public void setMessage(@NonNull final String message) {
-    this.message = message;
-  }
-  
-  public MessageParams() {
-    
-  }
-  
-  public MessageParams(final MessageType type, final String message) {
-    this.type = type;
     this.message = message;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ParameterInformation.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ParameterInformation.java
@@ -20,6 +20,14 @@ public class ParameterInformation {
    */
   private String documentation;
   
+  public ParameterInformation() {
+  }
+  
+  public ParameterInformation(final String label, final String documentation) {
+    this.label = label;
+    this.documentation = documentation;
+  }
+  
   /**
    * The label of this signature. Will be shown in the UI.
    */
@@ -48,15 +56,6 @@ public class ParameterInformation {
    * The human-readable doc-comment of this signature. Will be shown in the UI but can be omitted.
    */
   public void setDocumentation(final String documentation) {
-    this.documentation = documentation;
-  }
-  
-  public ParameterInformation() {
-    
-  }
-  
-  public ParameterInformation(final String label, final String documentation) {
-    this.label = label;
     this.documentation = documentation;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Position.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Position.java
@@ -18,6 +18,14 @@ public class Position {
    */
   private int character;
   
+  public Position() {
+  }
+  
+  public Position(final int line, final int character) {
+    this.line = line;
+    this.character = character;
+  }
+  
   /**
    * Line position in a document (zero-based).
    */
@@ -45,15 +53,6 @@ public class Position {
    * Character offset on a line in a document (zero-based).
    */
   public void setCharacter(final int character) {
-    this.character = character;
-  }
-  
-  public Position() {
-    
-  }
-  
-  public Position(final int line, final int character) {
-    this.line = line;
     this.character = character;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/PublishDiagnosticsParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/PublishDiagnosticsParams.java
@@ -22,7 +22,17 @@ public class PublishDiagnosticsParams {
    * An array of diagnostic information items.
    */
   @NonNull
-  private List<Diagnostic> diagnostics = new ArrayList<Diagnostic>();
+  private List<Diagnostic> diagnostics;
+  
+  public PublishDiagnosticsParams() {
+    ArrayList<Diagnostic> _arrayList = new ArrayList<Diagnostic>();
+    this.diagnostics = _arrayList;
+  }
+  
+  public PublishDiagnosticsParams(final String uri, final List<Diagnostic> diagnostics) {
+    this.uri = uri;
+    this.diagnostics = diagnostics;
+  }
   
   /**
    * The URI for which diagnostic information is reported.
@@ -53,15 +63,6 @@ public class PublishDiagnosticsParams {
    * An array of diagnostic information items.
    */
   public void setDiagnostics(@NonNull final List<Diagnostic> diagnostics) {
-    this.diagnostics = diagnostics;
-  }
-  
-  public PublishDiagnosticsParams() {
-    
-  }
-  
-  public PublishDiagnosticsParams(final String uri, final List<Diagnostic> diagnostics) {
-    this.uri = uri;
     this.diagnostics = diagnostics;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Range.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Range.java
@@ -22,6 +22,14 @@ public class Range {
   @NonNull
   private Position end;
   
+  public Range() {
+  }
+  
+  public Range(final Position start, final Position end) {
+    this.start = start;
+    this.end = end;
+  }
+  
   /**
    * The range's start position
    */
@@ -51,15 +59,6 @@ public class Range {
    * The range's end position
    */
   public void setEnd(@NonNull final Position end) {
-    this.end = end;
-  }
-  
-  public Range() {
-    
-  }
-  
-  public Range(final Position start, final Position end) {
-    this.start = start;
     this.end = end;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ReferenceContext.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ReferenceContext.java
@@ -14,6 +14,13 @@ public class ReferenceContext {
    */
   private boolean includeDeclaration;
   
+  public ReferenceContext() {
+  }
+  
+  public ReferenceContext(final boolean includeDeclaration) {
+    this.includeDeclaration = includeDeclaration;
+  }
+  
   /**
    * Include the declaration of the current symbol.
    */
@@ -26,14 +33,6 @@ public class ReferenceContext {
    * Include the declaration of the current symbol.
    */
   public void setIncludeDeclaration(final boolean includeDeclaration) {
-    this.includeDeclaration = includeDeclaration;
-  }
-  
-  public ReferenceContext() {
-    
-  }
-  
-  public ReferenceContext(final boolean includeDeclaration) {
     this.includeDeclaration = includeDeclaration;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ReferenceParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ReferenceParams.java
@@ -15,6 +15,13 @@ public class ReferenceParams extends TextDocumentPositionParams {
   @NonNull
   private ReferenceContext context;
   
+  public ReferenceParams() {
+  }
+  
+  public ReferenceParams(final ReferenceContext context) {
+    this.context = context;
+  }
+  
   @Pure
   @NonNull
   public ReferenceContext getContext() {
@@ -22,14 +29,6 @@ public class ReferenceParams extends TextDocumentPositionParams {
   }
   
   public void setContext(@NonNull final ReferenceContext context) {
-    this.context = context;
-  }
-  
-  public ReferenceParams() {
-    
-  }
-  
-  public ReferenceParams(final ReferenceContext context) {
     this.context = context;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Registration.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Registration.java
@@ -27,6 +27,15 @@ public class Registration {
    */
   private Object registerOptions;
   
+  public Registration() {
+  }
+  
+  public Registration(final String id, final String method, final Object registerOptions) {
+    this.id = id;
+    this.method = method;
+    this.registerOptions = registerOptions;
+  }
+  
   /**
    * The id used to register the request. The id can be used to deregister
    * the request again.
@@ -73,16 +82,6 @@ public class Registration {
    * Options necessary for the registration.
    */
   public void setRegisterOptions(final Object registerOptions) {
-    this.registerOptions = registerOptions;
-  }
-  
-  public Registration() {
-    
-  }
-  
-  public Registration(final String id, final String method, final Object registerOptions) {
-    this.id = id;
-    this.method = method;
     this.registerOptions = registerOptions;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/RegistrationParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/RegistrationParams.java
@@ -1,16 +1,25 @@
 package org.eclipse.lsp4j;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.lsp4j.Registration;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
-import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 @SuppressWarnings("all")
 public class RegistrationParams {
   @NonNull
-  private List<Registration> registrations = CollectionLiterals.<Registration>newArrayList();
+  private List<Registration> registrations;
+  
+  public RegistrationParams() {
+    ArrayList<Registration> _arrayList = new ArrayList<Registration>();
+    this.registrations = _arrayList;
+  }
+  
+  public RegistrationParams(final List<Registration> registrations) {
+    this.registrations = registrations;
+  }
   
   @Pure
   @NonNull
@@ -19,14 +28,6 @@ public class RegistrationParams {
   }
   
   public void setRegistrations(@NonNull final List<Registration> registrations) {
-    this.registrations = registrations;
-  }
-  
-  public RegistrationParams() {
-    
-  }
-  
-  public RegistrationParams(final List<Registration> registrations) {
     this.registrations = registrations;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/RenameParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/RenameParams.java
@@ -30,6 +30,15 @@ public class RenameParams {
   @NonNull
   private String newName;
   
+  public RenameParams() {
+  }
+  
+  public RenameParams(final TextDocumentIdentifier textDocument, final Position position, final String newName) {
+    this.textDocument = textDocument;
+    this.position = position;
+    this.newName = newName;
+  }
+  
   /**
    * The document in which to find the symbol.
    */
@@ -77,16 +86,6 @@ public class RenameParams {
    * ResponseError with an appropriate message set.
    */
   public void setNewName(@NonNull final String newName) {
-    this.newName = newName;
-  }
-  
-  public RenameParams() {
-    
-  }
-  
-  public RenameParams(final TextDocumentIdentifier textDocument, final Position position, final String newName) {
-    this.textDocument = textDocument;
-    this.position = position;
     this.newName = newName;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SaveOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SaveOptions.java
@@ -13,6 +13,13 @@ public class SaveOptions {
    */
   private Boolean includeText;
   
+  public SaveOptions() {
+  }
+  
+  public SaveOptions(final Boolean includeText) {
+    this.includeText = includeText;
+  }
+  
   /**
    * The client is supposed to include the content on save.
    */
@@ -25,14 +32,6 @@ public class SaveOptions {
    * The client is supposed to include the content on save.
    */
   public void setIncludeText(final Boolean includeText) {
-    this.includeText = includeText;
-  }
-  
-  public SaveOptions() {
-    
-  }
-  
-  public SaveOptions(final Boolean includeText) {
     this.includeText = includeText;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ServerCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ServerCapabilities.java
@@ -385,10 +385,6 @@ public class ServerCapabilities {
     this.experimental = experimental;
   }
   
-  public ServerCapabilities() {
-    
-  }
-  
   @Override
   @Pure
   public String toString() {

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ShowMessageRequestParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ShowMessageRequestParams.java
@@ -18,6 +18,13 @@ public class ShowMessageRequestParams extends MessageParams {
    */
   private List<MessageActionItem> actions;
   
+  public ShowMessageRequestParams() {
+  }
+  
+  public ShowMessageRequestParams(final List<MessageActionItem> actions) {
+    this.actions = actions;
+  }
+  
   /**
    * The message action items to present.
    */
@@ -30,14 +37,6 @@ public class ShowMessageRequestParams extends MessageParams {
    * The message action items to present.
    */
   public void setActions(final List<MessageActionItem> actions) {
-    this.actions = actions;
-  }
-  
-  public ShowMessageRequestParams() {
-    
-  }
-  
-  public ShowMessageRequestParams(final List<MessageActionItem> actions) {
     this.actions = actions;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureHelp.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureHelp.java
@@ -17,7 +17,7 @@ public class SignatureHelp {
    * One or more signatures.
    */
   @NonNull
-  private List<SignatureInformation> signatures = new ArrayList<SignatureInformation>();
+  private List<SignatureInformation> signatures;
   
   /**
    * The active signature.
@@ -28,6 +28,17 @@ public class SignatureHelp {
    * The active parameter of the active signature.
    */
   private Integer activeParameter;
+  
+  public SignatureHelp() {
+    ArrayList<SignatureInformation> _arrayList = new ArrayList<SignatureInformation>();
+    this.signatures = _arrayList;
+  }
+  
+  public SignatureHelp(final List<SignatureInformation> signatures, final Integer activeSignature, final Integer activeParameter) {
+    this.signatures = signatures;
+    this.activeSignature = activeSignature;
+    this.activeParameter = activeParameter;
+  }
   
   /**
    * One or more signatures.
@@ -72,16 +83,6 @@ public class SignatureHelp {
    * The active parameter of the active signature.
    */
   public void setActiveParameter(final Integer activeParameter) {
-    this.activeParameter = activeParameter;
-  }
-  
-  public SignatureHelp() {
-    
-  }
-  
-  public SignatureHelp(final List<SignatureInformation> signatures, final Integer activeSignature, final Integer activeParameter) {
-    this.signatures = signatures;
-    this.activeSignature = activeSignature;
     this.activeParameter = activeParameter;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureHelpOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureHelpOptions.java
@@ -14,6 +14,13 @@ public class SignatureHelpOptions {
    */
   private List<String> triggerCharacters;
   
+  public SignatureHelpOptions() {
+  }
+  
+  public SignatureHelpOptions(final List<String> triggerCharacters) {
+    this.triggerCharacters = triggerCharacters;
+  }
+  
   /**
    * The characters that trigger signature help automatically.
    */
@@ -26,14 +33,6 @@ public class SignatureHelpOptions {
    * The characters that trigger signature help automatically.
    */
   public void setTriggerCharacters(final List<String> triggerCharacters) {
-    this.triggerCharacters = triggerCharacters;
-  }
-  
-  public SignatureHelpOptions() {
-    
-  }
-  
-  public SignatureHelpOptions(final List<String> triggerCharacters) {
     this.triggerCharacters = triggerCharacters;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureHelpRegistrationOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureHelpRegistrationOptions.java
@@ -12,6 +12,13 @@ public class SignatureHelpRegistrationOptions extends TextDocumentRegistrationOp
    */
   private List<String> triggerCharacters;
   
+  public SignatureHelpRegistrationOptions() {
+  }
+  
+  public SignatureHelpRegistrationOptions(final List<String> triggerCharacters) {
+    this.triggerCharacters = triggerCharacters;
+  }
+  
   /**
    * The characters that trigger signature help automatically.
    */
@@ -24,14 +31,6 @@ public class SignatureHelpRegistrationOptions extends TextDocumentRegistrationOp
    * The characters that trigger signature help automatically.
    */
   public void setTriggerCharacters(final List<String> triggerCharacters) {
-    this.triggerCharacters = triggerCharacters;
-  }
-  
-  public SignatureHelpRegistrationOptions() {
-    
-  }
-  
-  public SignatureHelpRegistrationOptions(final List<String> triggerCharacters) {
     this.triggerCharacters = triggerCharacters;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureInformation.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureInformation.java
@@ -28,6 +28,15 @@ public class SignatureInformation {
    */
   private List<ParameterInformation> parameters;
   
+  public SignatureInformation() {
+  }
+  
+  public SignatureInformation(final String label, final String documentation, final List<ParameterInformation> parameters) {
+    this.label = label;
+    this.documentation = documentation;
+    this.parameters = parameters;
+  }
+  
   /**
    * The label of this signature. Will be shown in the UI.
    */
@@ -71,16 +80,6 @@ public class SignatureInformation {
    * The parameters of this signature.
    */
   public void setParameters(final List<ParameterInformation> parameters) {
-    this.parameters = parameters;
-  }
-  
-  public SignatureInformation() {
-    
-  }
-  
-  public SignatureInformation(final String label, final String documentation, final List<ParameterInformation> parameters) {
-    this.label = label;
-    this.documentation = documentation;
     this.parameters = parameters;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SymbolInformation.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SymbolInformation.java
@@ -97,10 +97,6 @@ public class SymbolInformation {
     this.containerName = containerName;
   }
   
-  public SymbolInformation() {
-    
-  }
-  
   @Override
   @Pure
   public String toString() {

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SynchronizationCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SynchronizationCapabilities.java
@@ -23,6 +23,15 @@ public class SynchronizationCapabilities extends DynamicRegistrationCapabilities
    */
   private Boolean didSave;
   
+  public SynchronizationCapabilities() {
+  }
+  
+  public SynchronizationCapabilities(final Boolean willSave, final Boolean willSaveWaitUntil, final Boolean didSave) {
+    this.willSave = willSave;
+    this.willSaveWaitUntil = willSaveWaitUntil;
+    this.didSave = didSave;
+  }
+  
   /**
    * The client supports sending will save notifications.
    */
@@ -69,16 +78,6 @@ public class SynchronizationCapabilities extends DynamicRegistrationCapabilities
    * The client supports did save notifications.
    */
   public void setDidSave(final Boolean didSave) {
-    this.didSave = didSave;
-  }
-  
-  public SynchronizationCapabilities() {
-    
-  }
-  
-  public SynchronizationCapabilities(final Boolean willSave, final Boolean willSaveWaitUntil, final Boolean didSave) {
-    this.willSave = willSave;
-    this.willSaveWaitUntil = willSaveWaitUntil;
     this.didSave = didSave;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentChangeRegistrationOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentChangeRegistrationOptions.java
@@ -18,6 +18,13 @@ public class TextDocumentChangeRegistrationOptions extends TextDocumentRegistrat
   @NonNull
   private TextDocumentSyncKind syncKind;
   
+  public TextDocumentChangeRegistrationOptions() {
+  }
+  
+  public TextDocumentChangeRegistrationOptions(final TextDocumentSyncKind syncKind) {
+    this.syncKind = syncKind;
+  }
+  
   /**
    * How documents are synced to the server. See TextDocumentSyncKind.Full
    * and TextDocumentSyncKind.Incremental.
@@ -33,14 +40,6 @@ public class TextDocumentChangeRegistrationOptions extends TextDocumentRegistrat
    * and TextDocumentSyncKind.Incremental.
    */
   public void setSyncKind(@NonNull final TextDocumentSyncKind syncKind) {
-    this.syncKind = syncKind;
-  }
-  
-  public TextDocumentChangeRegistrationOptions() {
-    
-  }
-  
-  public TextDocumentChangeRegistrationOptions(final TextDocumentSyncKind syncKind) {
     this.syncKind = syncKind;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentClientCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentClientCapabilities.java
@@ -314,10 +314,6 @@ public class TextDocumentClientCapabilities {
     this.rename = rename;
   }
   
-  public TextDocumentClientCapabilities() {
-    
-  }
-  
   @Override
   @Pure
   public String toString() {

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentContentChangeEvent.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentContentChangeEvent.java
@@ -27,6 +27,15 @@ public class TextDocumentContentChangeEvent {
   @NonNull
   private String text;
   
+  public TextDocumentContentChangeEvent() {
+  }
+  
+  public TextDocumentContentChangeEvent(final Range range, final Integer rangeLength, final String text) {
+    this.range = range;
+    this.rangeLength = rangeLength;
+    this.text = text;
+  }
+  
   /**
    * The range of the document that changed.
    */
@@ -70,16 +79,6 @@ public class TextDocumentContentChangeEvent {
    * The new text of the document.
    */
   public void setText(@NonNull final String text) {
-    this.text = text;
-  }
-  
-  public TextDocumentContentChangeEvent() {
-    
-  }
-  
-  public TextDocumentContentChangeEvent(final Range range, final Integer rangeLength, final String text) {
-    this.range = range;
-    this.rangeLength = rangeLength;
     this.text = text;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentEdit.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentEdit.java
@@ -26,6 +26,14 @@ public class TextDocumentEdit {
   @NonNull
   private List<TextEdit> edits;
   
+  public TextDocumentEdit() {
+  }
+  
+  public TextDocumentEdit(final VersionedTextDocumentIdentifier textDocument, final List<TextEdit> edits) {
+    this.textDocument = textDocument;
+    this.edits = edits;
+  }
+  
   /**
    * The text document to change.
    */
@@ -55,15 +63,6 @@ public class TextDocumentEdit {
    * The edits to be applied
    */
   public void setEdits(@NonNull final List<TextEdit> edits) {
-    this.edits = edits;
-  }
-  
-  public TextDocumentEdit() {
-    
-  }
-  
-  public TextDocumentEdit(final VersionedTextDocumentIdentifier textDocument, final List<TextEdit> edits) {
-    this.textDocument = textDocument;
     this.edits = edits;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentIdentifier.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentIdentifier.java
@@ -15,6 +15,13 @@ public class TextDocumentIdentifier {
   @NonNull
   private String uri;
   
+  public TextDocumentIdentifier() {
+  }
+  
+  public TextDocumentIdentifier(final String uri) {
+    this.uri = uri;
+  }
+  
   /**
    * The text document's uri.
    */
@@ -28,14 +35,6 @@ public class TextDocumentIdentifier {
    * The text document's uri.
    */
   public void setUri(@NonNull final String uri) {
-    this.uri = uri;
-  }
-  
-  public TextDocumentIdentifier() {
-    
-  }
-  
-  public TextDocumentIdentifier(final String uri) {
     this.uri = uri;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentItem.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentItem.java
@@ -95,10 +95,6 @@ public class TextDocumentItem {
     this.text = text;
   }
   
-  public TextDocumentItem() {
-    
-  }
-  
   @Override
   @Pure
   public String toString() {

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentPositionParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentPositionParams.java
@@ -29,6 +29,15 @@ public class TextDocumentPositionParams {
   @NonNull
   private Position position;
   
+  public TextDocumentPositionParams() {
+  }
+  
+  public TextDocumentPositionParams(final TextDocumentIdentifier textDocument, final String uri, final Position position) {
+    this.textDocument = textDocument;
+    this.uri = uri;
+    this.position = position;
+  }
+  
   /**
    * The text document.
    */
@@ -75,16 +84,6 @@ public class TextDocumentPositionParams {
    * The position inside the text document.
    */
   public void setPosition(@NonNull final Position position) {
-    this.position = position;
-  }
-  
-  public TextDocumentPositionParams() {
-    
-  }
-  
-  public TextDocumentPositionParams(final TextDocumentIdentifier textDocument, final String uri, final Position position) {
-    this.textDocument = textDocument;
-    this.uri = uri;
     this.position = position;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentRegistrationOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentRegistrationOptions.java
@@ -15,6 +15,13 @@ public class TextDocumentRegistrationOptions {
    */
   private DocumentSelector documentSelector;
   
+  public TextDocumentRegistrationOptions() {
+  }
+  
+  public TextDocumentRegistrationOptions(final DocumentSelector documentSelector) {
+    this.documentSelector = documentSelector;
+  }
+  
   /**
    * A document selector to identify the scope of the registration. If set to null
    * the document selector provided on the client side will be used.
@@ -29,14 +36,6 @@ public class TextDocumentRegistrationOptions {
    * the document selector provided on the client side will be used.
    */
   public void setDocumentSelector(final DocumentSelector documentSelector) {
-    this.documentSelector = documentSelector;
-  }
-  
-  public TextDocumentRegistrationOptions() {
-    
-  }
-  
-  public TextDocumentRegistrationOptions(final DocumentSelector documentSelector) {
     this.documentSelector = documentSelector;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentSaveRegistrationOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentSaveRegistrationOptions.java
@@ -11,6 +11,13 @@ public class TextDocumentSaveRegistrationOptions extends TextDocumentRegistratio
    */
   private Boolean includeText;
   
+  public TextDocumentSaveRegistrationOptions() {
+  }
+  
+  public TextDocumentSaveRegistrationOptions(final Boolean includeText) {
+    this.includeText = includeText;
+  }
+  
   /**
    * The client is supposed to include the content on save.
    */
@@ -23,14 +30,6 @@ public class TextDocumentSaveRegistrationOptions extends TextDocumentRegistratio
    * The client is supposed to include the content on save.
    */
   public void setIncludeText(final Boolean includeText) {
-    this.includeText = includeText;
-  }
-  
-  public TextDocumentSaveRegistrationOptions() {
-    
-  }
-  
-  public TextDocumentSaveRegistrationOptions(final Boolean includeText) {
     this.includeText = includeText;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentSyncOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentSyncOptions.java
@@ -110,10 +110,6 @@ public class TextDocumentSyncOptions {
     this.save = save;
   }
   
-  public TextDocumentSyncOptions() {
-    
-  }
-  
   @Override
   @Pure
   public String toString() {

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextEdit.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextEdit.java
@@ -22,6 +22,14 @@ public class TextEdit {
   @NonNull
   private String newText;
   
+  public TextEdit() {
+  }
+  
+  public TextEdit(final Range range, final String newText) {
+    this.range = range;
+    this.newText = newText;
+  }
+  
   /**
    * The range of the text document to be manipulated. To insert text into a document create a range where start === end.
    */
@@ -51,15 +59,6 @@ public class TextEdit {
    * The string to be inserted. For delete operations use an empty string.
    */
   public void setNewText(@NonNull final String newText) {
-    this.newText = newText;
-  }
-  
-  public TextEdit() {
-    
-  }
-  
-  public TextEdit(final Range range, final String newText) {
-    this.range = range;
     this.newText = newText;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Unregistration.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Unregistration.java
@@ -22,6 +22,14 @@ public class Unregistration {
   @NonNull
   private String method;
   
+  public Unregistration() {
+  }
+  
+  public Unregistration(final String id, final String method) {
+    this.id = id;
+    this.method = method;
+  }
+  
   /**
    * The id used to unregister the request or notification. Usually an id
    * provided during the register request.
@@ -53,15 +61,6 @@ public class Unregistration {
    * The method / capability to unregister for.
    */
   public void setMethod(@NonNull final String method) {
-    this.method = method;
-  }
-  
-  public Unregistration() {
-    
-  }
-  
-  public Unregistration(final String id, final String method) {
-    this.id = id;
     this.method = method;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/UnregistrationParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/UnregistrationParams.java
@@ -1,16 +1,25 @@
 package org.eclipse.lsp4j;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.lsp4j.Unregistration;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
-import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 @SuppressWarnings("all")
 public class UnregistrationParams {
   @NonNull
-  private List<Unregistration> unregisterations = CollectionLiterals.<Unregistration>newArrayList();
+  private List<Unregistration> unregisterations;
+  
+  public UnregistrationParams() {
+    ArrayList<Unregistration> _arrayList = new ArrayList<Unregistration>();
+    this.unregisterations = _arrayList;
+  }
+  
+  public UnregistrationParams(final List<Unregistration> unregisterations) {
+    this.unregisterations = unregisterations;
+  }
   
   @Pure
   @NonNull
@@ -19,14 +28,6 @@ public class UnregistrationParams {
   }
   
   public void setUnregisterations(@NonNull final List<Unregistration> unregisterations) {
-    this.unregisterations = unregisterations;
-  }
-  
-  public UnregistrationParams() {
-    
-  }
-  
-  public UnregistrationParams(final List<Unregistration> unregisterations) {
     this.unregisterations = unregisterations;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/VersionedTextDocumentIdentifier.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/VersionedTextDocumentIdentifier.java
@@ -14,6 +14,13 @@ public class VersionedTextDocumentIdentifier extends TextDocumentIdentifier {
    */
   private int version;
   
+  public VersionedTextDocumentIdentifier() {
+  }
+  
+  public VersionedTextDocumentIdentifier(final int version) {
+    this.version = version;
+  }
+  
   /**
    * The version number of this document.
    */
@@ -26,14 +33,6 @@ public class VersionedTextDocumentIdentifier extends TextDocumentIdentifier {
    * The version number of this document.
    */
   public void setVersion(final int version) {
-    this.version = version;
-  }
-  
-  public VersionedTextDocumentIdentifier() {
-    
-  }
-  
-  public VersionedTextDocumentIdentifier(final int version) {
     this.version = version;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/WillSaveTextDocumentParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/WillSaveTextDocumentParams.java
@@ -20,6 +20,14 @@ public class WillSaveTextDocumentParams {
   @NonNull
   private TextDocumentSaveReason reason;
   
+  public WillSaveTextDocumentParams() {
+  }
+  
+  public WillSaveTextDocumentParams(final TextDocumentIdentifier textDocument, final TextDocumentSaveReason reason) {
+    this.textDocument = textDocument;
+    this.reason = reason;
+  }
+  
   /**
    * The document that will be saved.
    */
@@ -49,15 +57,6 @@ public class WillSaveTextDocumentParams {
    * A reason why a text document is saved.
    */
   public void setReason(@NonNull final TextDocumentSaveReason reason) {
-    this.reason = reason;
-  }
-  
-  public WillSaveTextDocumentParams() {
-    
-  }
-  
-  public WillSaveTextDocumentParams(final TextDocumentIdentifier textDocument, final TextDocumentSaveReason reason) {
-    this.textDocument = textDocument;
     this.reason = reason;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/WorkspaceClientCapabilites.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/WorkspaceClientCapabilites.java
@@ -136,10 +136,6 @@ public class WorkspaceClientCapabilites {
     this.executeCommand = executeCommand;
   }
   
-  public WorkspaceClientCapabilites() {
-    
-  }
-  
   @Override
   @Pure
   public String toString() {

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/WorkspaceEdit.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/WorkspaceEdit.java
@@ -19,7 +19,7 @@ public class WorkspaceEdit {
   /**
    * Holds changes to existing resources.
    */
-  private Map<String, List<TextEdit>> changes = new LinkedHashMap<String, List<TextEdit>>();
+  private Map<String, List<TextEdit>> changes;
   
   /**
    * An array of `TextDocumentEdit`s to express changes to specific a specific
@@ -27,6 +27,16 @@ public class WorkspaceEdit {
    * edits is expressed via `WorkspaceClientCapabilites.versionedWorkspaceEdit`.
    */
   private List<TextDocumentEdit> documentChanges;
+  
+  public WorkspaceEdit() {
+    LinkedHashMap<String, List<TextEdit>> _linkedHashMap = new LinkedHashMap<String, List<TextEdit>>();
+    this.changes = _linkedHashMap;
+  }
+  
+  public WorkspaceEdit(final Map<String, List<TextEdit>> changes, final List<TextDocumentEdit> documentChanges) {
+    this.changes = changes;
+    this.documentChanges = documentChanges;
+  }
   
   /**
    * Holds changes to existing resources.
@@ -59,15 +69,6 @@ public class WorkspaceEdit {
    * edits is expressed via `WorkspaceClientCapabilites.versionedWorkspaceEdit`.
    */
   public void setDocumentChanges(final List<TextDocumentEdit> documentChanges) {
-    this.documentChanges = documentChanges;
-  }
-  
-  public WorkspaceEdit() {
-    
-  }
-  
-  public WorkspaceEdit(final Map<String, List<TextEdit>> changes, final List<TextDocumentEdit> documentChanges) {
-    this.changes = changes;
     this.documentChanges = documentChanges;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/WorkspaceEditCapabilites.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/WorkspaceEditCapabilites.java
@@ -10,6 +10,13 @@ public class WorkspaceEditCapabilites {
    */
   private Boolean documentChanges;
   
+  public WorkspaceEditCapabilites() {
+  }
+  
+  public WorkspaceEditCapabilites(final Boolean documentChanges) {
+    this.documentChanges = documentChanges;
+  }
+  
   /**
    * The client supports versioned document changes in `WorkspaceEdit`s
    */
@@ -22,14 +29,6 @@ public class WorkspaceEditCapabilites {
    * The client supports versioned document changes in `WorkspaceEdit`s
    */
   public void setDocumentChanges(final Boolean documentChanges) {
-    this.documentChanges = documentChanges;
-  }
-  
-  public WorkspaceEditCapabilites() {
-    
-  }
-  
-  public WorkspaceEditCapabilites(final Boolean documentChanges) {
     this.documentChanges = documentChanges;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/WorkspaceSymbolParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/WorkspaceSymbolParams.java
@@ -15,6 +15,13 @@ public class WorkspaceSymbolParams {
   @NonNull
   private String query;
   
+  public WorkspaceSymbolParams() {
+  }
+  
+  public WorkspaceSymbolParams(final String query) {
+    this.query = query;
+  }
+  
   /**
    * A non-empty query string
    */
@@ -28,14 +35,6 @@ public class WorkspaceSymbolParams {
    * A non-empty query string
    */
   public void setQuery(@NonNull final String query) {
-    this.query = query;
-  }
-  
-  public WorkspaceSymbolParams() {
-    
-  }
-  
-  public WorkspaceSymbolParams(final String query) {
     this.query = query;
   }
   


### PR DESCRIPTION
As a first step for improving the situation described in #82, I removed the automatic generation of constructors and wrote explicit constructors instead. These are the same as before so we don't break the API.