### PR TITLE
Additional properties of Formatting options must not be wrapped in a 'properties' property

### DIFF
--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -1289,31 +1289,109 @@ class FileEvent {
 /**
  * Value-object describing what options formatting should use.
  */
-@JsonRpcData
-class FormattingOptions {
-	/**
-	 * Size of a tab in spaces.
-	 */
-	int tabSize
+class FormattingOptions extends LinkedHashMap<String, Object> {
 
-	/**
-	 * Prefer spaces over tabs.
-	 */
-	boolean insertSpaces
+	static val TAB_SIZE = 'tabSize'
+	static val INSERT_SPACES = 'insertSpaces'
 
-	/**
-	 * Signature for further properties.
-	 */
-	Map<String, String> properties
-    
     new() {
     }
     
-    new(int tabSize, boolean insertSpaces, Map<String, String> properties) {
+    new(int tabSize, boolean insertSpaces) {
     	this.tabSize = tabSize
     	this.insertSpaces = insertSpaces
-    	this.properties = properties
     }
+    
+    /**
+     * @deprecated See https://github.com/eclipse/lsp4j/issues/99
+     */
+    @Deprecated
+    new(int tabSize, boolean insertSpaces, Map<String, String> properties) {
+    	this(tabSize, insertSpaces)
+    	putAll(properties)
+    }
+    
+    /**
+     * Only {@code boolean | number | string} are accepted by formatting options.
+     */
+	override put(String key, Object value) {
+		switch key {
+			case TAB_SIZE: {
+				if (value instanceof Integer)
+		    		return super.put(key, value)
+		    	else if (value instanceof Number)
+		    		return super.put(key, value.intValue)
+		    	else if (value instanceof String)
+		    		try {
+		    			return super.put(key, Integer.valueOf(value))
+					} catch (NumberFormatException e) {}
+			}
+			case INSERT_SPACES: {
+				if (value instanceof Boolean)
+		    		return super.put(key, value)
+		    	else if (value instanceof String)
+		    		return super.put(key, Boolean.valueOf(value))
+			}
+			default: {
+				if (value instanceof Boolean || value instanceof Number || value instanceof String)
+					return super.put(key, value)
+				else
+					return super.put(key, value.toString)
+			}
+		}
+		return null
+	}
+    
+	/**
+	 * Size of a tab in spaces.
+	 */
+    def int getTabSize() {
+    	val value = get(TAB_SIZE)
+    	if (value instanceof Number)
+    		return value.intValue
+    	else
+    		throw new AssertionError("Property '" + TAB_SIZE + "' must be a number")
+    }
+    
+    def void setTabSize(int tabSize) {
+    	put(TAB_SIZE, tabSize)
+    }
+    
+ 	/**
+	 * Prefer spaces over tabs.
+	 */
+    def boolean isInsertSpaces() {
+       	val value = get(INSERT_SPACES)
+    	if (value instanceof Boolean)
+    		return value
+    	else
+    		throw new AssertionError("Property '" + INSERT_SPACES + "' must be a Boolean")
+    }
+    
+    def void setInsertSpaces(boolean insertSpaces) {
+    	put(INSERT_SPACES, insertSpaces)
+    }
+    
+    /**
+     * @deprecated See https://github.com/eclipse/lsp4j/issues/99
+     */
+    @Deprecated
+    def Map<String, String> getProperties() {
+    	val result = newLinkedHashMap
+    	for (entry : entrySet) {
+    		result.put(entry.key, entry.value.toString)
+    	}
+    	return result
+    }
+    
+    /**
+     * @deprecated See https://github.com/eclipse/lsp4j/issues/99
+     */
+    @Deprecated
+    def void setProperties(Map<String, String> properties) {
+    	putAll(properties)
+    }
+    
 }
 
 /**

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -1335,7 +1335,7 @@ class FormattingOptions extends LinkedHashMap<String, Object> {
 			default: {
 				if (value instanceof Boolean || value instanceof Number || value instanceof String)
 					return super.put(key, value)
-				else
+				else if (value !== null)
 					return super.put(key, value.toString)
 			}
 		}
@@ -1349,6 +1349,8 @@ class FormattingOptions extends LinkedHashMap<String, Object> {
     	val value = get(TAB_SIZE)
     	if (value instanceof Number)
     		return value.intValue
+    	else if (value === null)
+    		return 0
     	else
     		throw new AssertionError("Property '" + TAB_SIZE + "' must be a number")
     }
@@ -1364,6 +1366,8 @@ class FormattingOptions extends LinkedHashMap<String, Object> {
        	val value = get(INSERT_SPACES)
     	if (value instanceof Boolean)
     		return value
+    	else if (value === null)
+    		return false
     	else
     		throw new AssertionError("Property '" + INSERT_SPACES + "' must be a Boolean")
     }
@@ -1377,11 +1381,7 @@ class FormattingOptions extends LinkedHashMap<String, Object> {
      */
     @Deprecated
     def Map<String, String> getProperties() {
-    	val result = newLinkedHashMap
-    	for (entry : entrySet) {
-    		result.put(entry.key, entry.value.toString)
-    	}
-    	return result
+    	mapValues[toString]
     }
     
     /**

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -1289,7 +1289,7 @@ class FileEvent {
 /**
  * Value-object describing what options formatting should use.
  */
-class FormattingOptions extends LinkedHashMap<String, Either<String, Either<Number, Boolean>>> {
+class FormattingOptions extends LinkedHashMap<String, Either<String, Either<Integer, Boolean>>> {
 
 	static val TAB_SIZE = 'tabSize'
 	static val INSERT_SPACES = 'insertSpaces'
@@ -1312,23 +1312,23 @@ class FormattingOptions extends LinkedHashMap<String, Either<String, Either<Numb
     }
     
     def String getString(String key) {
-    	get(key).getLeft
+    	get(key)?.getLeft
     }
     
     def void putString(String key, String value) {
     	put(key, Either.forLeft(value))
     }
     
-    def Number getNumber(String key) {
-    	get(key).getRight?.getLeft
+    def Integer getInteger(String key) {
+    	get(key)?.getRight?.getLeft
     }
     
-    def void putNumber(String key, Number value) {
+    def void putInteger(String key, Integer value) {
     	put(key, Either.forRight(Either.forLeft(value)))
     }
     
     def Boolean getBoolean(String key) {
-    	get(key).getRight?.getRight
+    	get(key)?.getRight?.getRight
     }
     
     def void putBoolean(String key, Boolean value) {
@@ -1339,7 +1339,7 @@ class FormattingOptions extends LinkedHashMap<String, Either<String, Either<Numb
 	 * Size of a tab in spaces.
 	 */
     def int getTabSize() {
-    	val value = getNumber(TAB_SIZE)
+    	val value = getInteger(TAB_SIZE)
     	if (value !== null)
     		return value.intValue
     	else
@@ -1347,7 +1347,7 @@ class FormattingOptions extends LinkedHashMap<String, Either<String, Either<Numb
     }
     
     def void setTabSize(int tabSize) {
-    	putNumber(TAB_SIZE, tabSize)
+    	putInteger(TAB_SIZE, tabSize)
     }
     
  	/**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/FormattingOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/FormattingOptions.java
@@ -2,9 +2,9 @@ package org.eclipse.lsp4j;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.Set;
-import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 import org.eclipse.xtext.xbase.lib.Exceptions;
+import org.eclipse.xtext.xbase.lib.Functions.Function1;
+import org.eclipse.xtext.xbase.lib.MapExtensions;
 
 /**
  * Value-object describing what options formatting should use.
@@ -73,14 +73,19 @@ public class FormattingOptions extends LinkedHashMap<String, Object> {
           if ((((value instanceof Boolean) || (value instanceof Number)) || (value instanceof String))) {
             return super.put(key, value);
           } else {
-            return super.put(key, value.toString());
+            if ((value != null)) {
+              return super.put(key, value.toString());
+            }
           }
+          break;
       }
     } else {
       if ((((value instanceof Boolean) || (value instanceof Number)) || (value instanceof String))) {
         return super.put(key, value);
       } else {
-        return super.put(key, value.toString());
+        if ((value != null)) {
+          return super.put(key, value.toString());
+        }
       }
     }
     return null;
@@ -94,7 +99,11 @@ public class FormattingOptions extends LinkedHashMap<String, Object> {
     if ((value instanceof Number)) {
       return ((Number)value).intValue();
     } else {
-      throw new AssertionError((("Property \'" + FormattingOptions.TAB_SIZE) + "\' must be a number"));
+      if ((value == null)) {
+        return 0;
+      } else {
+        throw new AssertionError((("Property \'" + FormattingOptions.TAB_SIZE) + "\' must be a number"));
+      }
     }
   }
   
@@ -110,7 +119,11 @@ public class FormattingOptions extends LinkedHashMap<String, Object> {
     if ((value instanceof Boolean)) {
       return ((Boolean) value).booleanValue();
     } else {
-      throw new AssertionError((("Property \'" + FormattingOptions.INSERT_SPACES) + "\' must be a Boolean"));
+      if ((value == null)) {
+        return false;
+      } else {
+        throw new AssertionError((("Property \'" + FormattingOptions.INSERT_SPACES) + "\' must be a Boolean"));
+      }
     }
   }
   
@@ -123,12 +136,10 @@ public class FormattingOptions extends LinkedHashMap<String, Object> {
    */
   @Deprecated
   public Map<String, String> getProperties() {
-    final LinkedHashMap<String, String> result = CollectionLiterals.<String, String>newLinkedHashMap();
-    Set<Map.Entry<String, Object>> _entrySet = this.entrySet();
-    for (final Map.Entry<String, Object> entry : _entrySet) {
-      result.put(entry.getKey(), entry.getValue().toString());
-    }
-    return result;
+    final Function1<Object, String> _function = (Object it) -> {
+      return it.toString();
+    };
+    return MapExtensions.<String, Object, String>mapValues(this, _function);
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/FormattingOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/FormattingOptions.java
@@ -1,123 +1,141 @@
 package org.eclipse.lsp4j;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
-import org.eclipse.xtext.xbase.lib.Pure;
-import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+import java.util.Set;
+import org.eclipse.xtext.xbase.lib.CollectionLiterals;
+import org.eclipse.xtext.xbase.lib.Exceptions;
 
 /**
  * Value-object describing what options formatting should use.
  */
 @SuppressWarnings("all")
-public class FormattingOptions {
-  /**
-   * Size of a tab in spaces.
-   */
-  private int tabSize;
+public class FormattingOptions extends LinkedHashMap<String, Object> {
+  private final static String TAB_SIZE = "tabSize";
   
-  /**
-   * Prefer spaces over tabs.
-   */
-  private boolean insertSpaces;
-  
-  /**
-   * Signature for further properties.
-   */
-  private Map<String, String> properties;
+  private final static String INSERT_SPACES = "insertSpaces";
   
   public FormattingOptions() {
   }
   
+  public FormattingOptions(final int tabSize, final boolean insertSpaces) {
+    this.setTabSize(tabSize);
+    this.setInsertSpaces(insertSpaces);
+  }
+  
+  /**
+   * @deprecated See https://github.com/eclipse/lsp4j/issues/99
+   */
+  @Deprecated
   public FormattingOptions(final int tabSize, final boolean insertSpaces, final Map<String, String> properties) {
-    this.tabSize = tabSize;
-    this.insertSpaces = insertSpaces;
-    this.properties = properties;
+    this(tabSize, insertSpaces);
+    this.putAll(properties);
+  }
+  
+  /**
+   * Only {@code boolean | number | string} are accepted by formatting options.
+   */
+  @Override
+  public Object put(final String key, final Object value) {
+    if (key != null) {
+      switch (key) {
+        case FormattingOptions.TAB_SIZE:
+          if ((value instanceof Integer)) {
+            return super.put(key, value);
+          } else {
+            if ((value instanceof Number)) {
+              return super.put(key, Integer.valueOf(((Number)value).intValue()));
+            } else {
+              if ((value instanceof String)) {
+                try {
+                  return super.put(key, Integer.valueOf(((String)value)));
+                } catch (final Throwable _t) {
+                  if (_t instanceof NumberFormatException) {
+                    final NumberFormatException e = (NumberFormatException)_t;
+                  } else {
+                    throw Exceptions.sneakyThrow(_t);
+                  }
+                }
+              }
+            }
+          }
+          break;
+        case FormattingOptions.INSERT_SPACES:
+          if ((value instanceof Boolean)) {
+            return super.put(key, value);
+          } else {
+            if ((value instanceof String)) {
+              return super.put(key, Boolean.valueOf(((String)value)));
+            }
+          }
+          break;
+        default:
+          if ((((value instanceof Boolean) || (value instanceof Number)) || (value instanceof String))) {
+            return super.put(key, value);
+          } else {
+            return super.put(key, value.toString());
+          }
+      }
+    } else {
+      if ((((value instanceof Boolean) || (value instanceof Number)) || (value instanceof String))) {
+        return super.put(key, value);
+      } else {
+        return super.put(key, value.toString());
+      }
+    }
+    return null;
   }
   
   /**
    * Size of a tab in spaces.
    */
-  @Pure
   public int getTabSize() {
-    return this.tabSize;
+    final Object value = this.get(FormattingOptions.TAB_SIZE);
+    if ((value instanceof Number)) {
+      return ((Number)value).intValue();
+    } else {
+      throw new AssertionError((("Property \'" + FormattingOptions.TAB_SIZE) + "\' must be a number"));
+    }
   }
   
-  /**
-   * Size of a tab in spaces.
-   */
   public void setTabSize(final int tabSize) {
-    this.tabSize = tabSize;
+    this.put(FormattingOptions.TAB_SIZE, Integer.valueOf(tabSize));
   }
   
   /**
    * Prefer spaces over tabs.
    */
-  @Pure
   public boolean isInsertSpaces() {
-    return this.insertSpaces;
+    final Object value = this.get(FormattingOptions.INSERT_SPACES);
+    if ((value instanceof Boolean)) {
+      return ((Boolean) value).booleanValue();
+    } else {
+      throw new AssertionError((("Property \'" + FormattingOptions.INSERT_SPACES) + "\' must be a Boolean"));
+    }
   }
   
-  /**
-   * Prefer spaces over tabs.
-   */
   public void setInsertSpaces(final boolean insertSpaces) {
-    this.insertSpaces = insertSpaces;
+    this.put(FormattingOptions.INSERT_SPACES, Boolean.valueOf(insertSpaces));
   }
   
   /**
-   * Signature for further properties.
+   * @deprecated See https://github.com/eclipse/lsp4j/issues/99
    */
-  @Pure
+  @Deprecated
   public Map<String, String> getProperties() {
-    return this.properties;
+    final LinkedHashMap<String, String> result = CollectionLiterals.<String, String>newLinkedHashMap();
+    Set<Map.Entry<String, Object>> _entrySet = this.entrySet();
+    for (final Map.Entry<String, Object> entry : _entrySet) {
+      result.put(entry.getKey(), entry.getValue().toString());
+    }
+    return result;
   }
   
   /**
-   * Signature for further properties.
+   * @deprecated See https://github.com/eclipse/lsp4j/issues/99
    */
+  @Deprecated
   public void setProperties(final Map<String, String> properties) {
-    this.properties = properties;
-  }
-  
-  @Override
-  @Pure
-  public String toString() {
-    ToStringBuilder b = new ToStringBuilder(this);
-    b.add("tabSize", this.tabSize);
-    b.add("insertSpaces", this.insertSpaces);
-    b.add("properties", this.properties);
-    return b.toString();
-  }
-  
-  @Override
-  @Pure
-  public boolean equals(final Object obj) {
-    if (this == obj)
-      return true;
-    if (obj == null)
-      return false;
-    if (getClass() != obj.getClass())
-      return false;
-    FormattingOptions other = (FormattingOptions) obj;
-    if (other.tabSize != this.tabSize)
-      return false;
-    if (other.insertSpaces != this.insertSpaces)
-      return false;
-    if (this.properties == null) {
-      if (other.properties != null)
-        return false;
-    } else if (!this.properties.equals(other.properties))
-      return false;
-    return true;
-  }
-  
-  @Override
-  @Pure
-  public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + this.tabSize;
-    result = prime * result + (this.insertSpaces ? 1231 : 1237);
-    result = prime * result + ((this.properties== null) ? 0 : this.properties.hashCode());
-    return result;
+    this.putAll(properties);
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/FormattingOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/FormattingOptions.java
@@ -1,6 +1,5 @@
 package org.eclipse.lsp4j;
 
-import java.io.Serializable;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -12,7 +11,7 @@ import org.eclipse.xtext.xbase.lib.CollectionLiterals;
  * Value-object describing what options formatting should use.
  */
 @SuppressWarnings("all")
-public class FormattingOptions extends LinkedHashMap<String, Either<String, Either<Number, Boolean>>> {
+public class FormattingOptions extends LinkedHashMap<String, Either<String, Either<Integer, Boolean>>> {
   private final static String TAB_SIZE = "tabSize";
   
   private final static String INSERT_SPACES = "insertSpaces";
@@ -35,28 +34,41 @@ public class FormattingOptions extends LinkedHashMap<String, Either<String, Eith
   }
   
   public String getString(final String key) {
-    return this.get(key).getLeft();
+    Either<String, Either<Integer, Boolean>> _get = this.get(key);
+    String _left = null;
+    if (_get!=null) {
+      _left=_get.getLeft();
+    }
+    return _left;
   }
   
   public void putString(final String key, final String value) {
-    this.put(key, Either.<String, Either<Number, Boolean>>forLeft(value));
+    this.put(key, Either.<String, Either<Integer, Boolean>>forLeft(value));
   }
   
-  public Number getNumber(final String key) {
-    Either<Number, Boolean> _right = this.get(key).getRight();
-    Number _left = null;
+  public Integer getInteger(final String key) {
+    Either<String, Either<Integer, Boolean>> _get = this.get(key);
+    Either<Integer, Boolean> _right = null;
+    if (_get!=null) {
+      _right=_get.getRight();
+    }
+    Integer _left = null;
     if (_right!=null) {
       _left=_right.getLeft();
     }
     return _left;
   }
   
-  public void putNumber(final String key, final Number value) {
-    this.put(key, Either.<String, Either<Number, Boolean>>forRight(Either.<Number, Boolean>forLeft(value)));
+  public void putInteger(final String key, final Integer value) {
+    this.put(key, Either.<String, Either<Integer, Boolean>>forRight(Either.<Integer, Boolean>forLeft(value)));
   }
   
   public Boolean getBoolean(final String key) {
-    Either<Number, Boolean> _right = this.get(key).getRight();
+    Either<String, Either<Integer, Boolean>> _get = this.get(key);
+    Either<Integer, Boolean> _right = null;
+    if (_get!=null) {
+      _right=_get.getRight();
+    }
     Boolean _right_1 = null;
     if (_right!=null) {
       _right_1=_right.getRight();
@@ -65,14 +77,14 @@ public class FormattingOptions extends LinkedHashMap<String, Either<String, Eith
   }
   
   public void putBoolean(final String key, final Boolean value) {
-    this.put(key, Either.<String, Either<Number, Boolean>>forRight(Either.<Number, Boolean>forRight(value)));
+    this.put(key, Either.<String, Either<Integer, Boolean>>forRight(Either.<Integer, Boolean>forRight(value)));
   }
   
   /**
    * Size of a tab in spaces.
    */
   public int getTabSize() {
-    final Number value = this.getNumber(FormattingOptions.TAB_SIZE);
+    final Integer value = this.getInteger(FormattingOptions.TAB_SIZE);
     if ((value != null)) {
       return value.intValue();
     } else {
@@ -81,7 +93,7 @@ public class FormattingOptions extends LinkedHashMap<String, Either<String, Eith
   }
   
   public void setTabSize(final int tabSize) {
-    this.putNumber(FormattingOptions.TAB_SIZE, Integer.valueOf(tabSize));
+    this.putInteger(FormattingOptions.TAB_SIZE, Integer.valueOf(tabSize));
   }
   
   /**
@@ -106,15 +118,15 @@ public class FormattingOptions extends LinkedHashMap<String, Either<String, Eith
   @Deprecated
   public Map<String, String> getProperties() {
     final LinkedHashMap<String, String> properties = CollectionLiterals.<String, String>newLinkedHashMap();
-    Set<Map.Entry<String, Either<String, Either<Number, Boolean>>>> _entrySet = this.entrySet();
-    for (final Map.Entry<String, Either<String, Either<Number, Boolean>>> entry : _entrySet) {
+    Set<Map.Entry<String, Either<String, Either<Integer, Boolean>>>> _entrySet = this.entrySet();
+    for (final Map.Entry<String, Either<String, Either<Integer, Boolean>>> entry : _entrySet) {
       {
-        Serializable _xifexpression = null;
+        Object _xifexpression = null;
         boolean _isLeft = entry.getValue().isLeft();
         if (_isLeft) {
           _xifexpression = entry.getValue().getLeft();
         } else {
-          Serializable _xifexpression_1 = null;
+          Object _xifexpression_1 = null;
           if ((entry.getValue().isRight() && entry.getValue().getRight().isLeft())) {
             _xifexpression_1 = entry.getValue().getRight().getLeft();
           } else {
@@ -124,9 +136,9 @@ public class FormattingOptions extends LinkedHashMap<String, Either<String, Eith
             }
             _xifexpression_1 = _xifexpression_2;
           }
-          _xifexpression = _xifexpression_1;
+          _xifexpression = ((Object)_xifexpression_1);
         }
-        final Serializable value = _xifexpression;
+        final Object value = ((Object)_xifexpression);
         if ((value != null)) {
           properties.put(entry.getKey(), value.toString());
         }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/FormattingOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/FormattingOptions.java
@@ -1,16 +1,18 @@
 package org.eclipse.lsp4j;
 
+import java.io.Serializable;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import org.eclipse.xtext.xbase.lib.Exceptions;
-import org.eclipse.xtext.xbase.lib.Functions.Function1;
-import org.eclipse.xtext.xbase.lib.MapExtensions;
+import java.util.Set;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 
 /**
  * Value-object describing what options formatting should use.
  */
 @SuppressWarnings("all")
-public class FormattingOptions extends LinkedHashMap<String, Object> {
+public class FormattingOptions extends LinkedHashMap<String, Either<String, Either<Number, Boolean>>> {
   private final static String TAB_SIZE = "tabSize";
   
   private final static String INSERT_SPACES = "insertSpaces";
@@ -29,106 +31,73 @@ public class FormattingOptions extends LinkedHashMap<String, Object> {
   @Deprecated
   public FormattingOptions(final int tabSize, final boolean insertSpaces, final Map<String, String> properties) {
     this(tabSize, insertSpaces);
-    this.putAll(properties);
+    this.setProperties(properties);
   }
   
-  /**
-   * Only {@code boolean | number | string} are accepted by formatting options.
-   */
-  @Override
-  public Object put(final String key, final Object value) {
-    if (key != null) {
-      switch (key) {
-        case FormattingOptions.TAB_SIZE:
-          if ((value instanceof Integer)) {
-            return super.put(key, value);
-          } else {
-            if ((value instanceof Number)) {
-              return super.put(key, Integer.valueOf(((Number)value).intValue()));
-            } else {
-              if ((value instanceof String)) {
-                try {
-                  return super.put(key, Integer.valueOf(((String)value)));
-                } catch (final Throwable _t) {
-                  if (_t instanceof NumberFormatException) {
-                    final NumberFormatException e = (NumberFormatException)_t;
-                  } else {
-                    throw Exceptions.sneakyThrow(_t);
-                  }
-                }
-              }
-            }
-          }
-          break;
-        case FormattingOptions.INSERT_SPACES:
-          if ((value instanceof Boolean)) {
-            return super.put(key, value);
-          } else {
-            if ((value instanceof String)) {
-              return super.put(key, Boolean.valueOf(((String)value)));
-            }
-          }
-          break;
-        default:
-          if ((((value instanceof Boolean) || (value instanceof Number)) || (value instanceof String))) {
-            return super.put(key, value);
-          } else {
-            if ((value != null)) {
-              return super.put(key, value.toString());
-            }
-          }
-          break;
-      }
-    } else {
-      if ((((value instanceof Boolean) || (value instanceof Number)) || (value instanceof String))) {
-        return super.put(key, value);
-      } else {
-        if ((value != null)) {
-          return super.put(key, value.toString());
-        }
-      }
+  public String getString(final String key) {
+    return this.get(key).getLeft();
+  }
+  
+  public void putString(final String key, final String value) {
+    this.put(key, Either.<String, Either<Number, Boolean>>forLeft(value));
+  }
+  
+  public Number getNumber(final String key) {
+    Either<Number, Boolean> _right = this.get(key).getRight();
+    Number _left = null;
+    if (_right!=null) {
+      _left=_right.getLeft();
     }
-    return null;
+    return _left;
+  }
+  
+  public void putNumber(final String key, final Number value) {
+    this.put(key, Either.<String, Either<Number, Boolean>>forRight(Either.<Number, Boolean>forLeft(value)));
+  }
+  
+  public Boolean getBoolean(final String key) {
+    Either<Number, Boolean> _right = this.get(key).getRight();
+    Boolean _right_1 = null;
+    if (_right!=null) {
+      _right_1=_right.getRight();
+    }
+    return _right_1;
+  }
+  
+  public void putBoolean(final String key, final Boolean value) {
+    this.put(key, Either.<String, Either<Number, Boolean>>forRight(Either.<Number, Boolean>forRight(value)));
   }
   
   /**
    * Size of a tab in spaces.
    */
   public int getTabSize() {
-    final Object value = this.get(FormattingOptions.TAB_SIZE);
-    if ((value instanceof Number)) {
-      return ((Number)value).intValue();
+    final Number value = this.getNumber(FormattingOptions.TAB_SIZE);
+    if ((value != null)) {
+      return value.intValue();
     } else {
-      if ((value == null)) {
-        return 0;
-      } else {
-        throw new AssertionError((("Property \'" + FormattingOptions.TAB_SIZE) + "\' must be a number"));
-      }
+      return 0;
     }
   }
   
   public void setTabSize(final int tabSize) {
-    this.put(FormattingOptions.TAB_SIZE, Integer.valueOf(tabSize));
+    this.putNumber(FormattingOptions.TAB_SIZE, Integer.valueOf(tabSize));
   }
   
   /**
    * Prefer spaces over tabs.
    */
   public boolean isInsertSpaces() {
-    final Object value = this.get(FormattingOptions.INSERT_SPACES);
-    if ((value instanceof Boolean)) {
-      return ((Boolean) value).booleanValue();
+    final Boolean value = this.getBoolean(FormattingOptions.INSERT_SPACES);
+    if ((value != null)) {
+      return (value).booleanValue();
     } else {
-      if ((value == null)) {
-        return false;
-      } else {
-        throw new AssertionError((("Property \'" + FormattingOptions.INSERT_SPACES) + "\' must be a Boolean"));
-      }
+      return false;
     }
   }
   
   public void setInsertSpaces(final boolean insertSpaces) {
-    this.put(FormattingOptions.INSERT_SPACES, Boolean.valueOf(insertSpaces));
+    this.putBoolean(FormattingOptions.INSERT_SPACES, Boolean.valueOf(insertSpaces));
   }
   
   /**
@@ -136,10 +105,34 @@ public class FormattingOptions extends LinkedHashMap<String, Object> {
    */
   @Deprecated
   public Map<String, String> getProperties() {
-    final Function1<Object, String> _function = (Object it) -> {
-      return it.toString();
-    };
-    return MapExtensions.<String, Object, String>mapValues(this, _function);
+    final LinkedHashMap<String, String> properties = CollectionLiterals.<String, String>newLinkedHashMap();
+    Set<Map.Entry<String, Either<String, Either<Number, Boolean>>>> _entrySet = this.entrySet();
+    for (final Map.Entry<String, Either<String, Either<Number, Boolean>>> entry : _entrySet) {
+      {
+        Serializable _xifexpression = null;
+        boolean _isLeft = entry.getValue().isLeft();
+        if (_isLeft) {
+          _xifexpression = entry.getValue().getLeft();
+        } else {
+          Serializable _xifexpression_1 = null;
+          if ((entry.getValue().isRight() && entry.getValue().getRight().isLeft())) {
+            _xifexpression_1 = entry.getValue().getRight().getLeft();
+          } else {
+            Boolean _xifexpression_2 = null;
+            if ((entry.getValue().isRight() && entry.getValue().getRight().isRight())) {
+              _xifexpression_2 = entry.getValue().getRight().getRight();
+            }
+            _xifexpression_1 = _xifexpression_2;
+          }
+          _xifexpression = _xifexpression_1;
+        }
+        final Serializable value = _xifexpression;
+        if ((value != null)) {
+          properties.put(entry.getKey(), value.toString());
+        }
+      }
+    }
+    return Collections.<String, String>unmodifiableMap(properties);
   }
   
   /**
@@ -147,6 +140,9 @@ public class FormattingOptions extends LinkedHashMap<String, Object> {
    */
   @Deprecated
   public void setProperties(final Map<String, String> properties) {
-    this.putAll(properties);
+    Set<Map.Entry<String, String>> _entrySet = properties.entrySet();
+    for (final Map.Entry<String, String> entry : _entrySet) {
+      this.putString(entry.getKey(), entry.getValue());
+    }
   }
 }

--- a/org.eclipse.lsp4j/src/test/java/org/eclipse/lsp4j/test/services/JsonParseTest.xtend
+++ b/org.eclipse.lsp4j/src/test/java/org/eclipse/lsp4j/test/services/JsonParseTest.xtend
@@ -12,6 +12,8 @@ import java.util.HashMap
 import org.eclipse.lsp4j.Diagnostic
 import org.eclipse.lsp4j.DiagnosticSeverity
 import org.eclipse.lsp4j.DidChangeTextDocumentParams
+import org.eclipse.lsp4j.DocumentFormattingParams
+import org.eclipse.lsp4j.FormattingOptions
 import org.eclipse.lsp4j.Hover
 import org.eclipse.lsp4j.Position
 import org.eclipse.lsp4j.PublishDiagnosticsParams
@@ -23,6 +25,7 @@ import org.eclipse.lsp4j.TextEdit
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier
 import org.eclipse.lsp4j.WorkspaceEdit
 import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler
+import org.eclipse.lsp4j.jsonrpc.messages.Either
 import org.eclipse.lsp4j.jsonrpc.messages.Message
 import org.eclipse.lsp4j.jsonrpc.messages.NotificationMessage
 import org.eclipse.lsp4j.jsonrpc.messages.RequestMessage
@@ -36,7 +39,6 @@ import org.junit.Before
 import org.junit.Test
 
 import static org.junit.Assert.*
-import org.eclipse.lsp4j.jsonrpc.messages.Either
 
 class JsonParseTest {
 	
@@ -341,5 +343,36 @@ class JsonParseTest {
             ]
         ])
     }
+    
+	@Test
+	def void testDocumentFormatting() {
+		'''
+			{
+			  "jsonrpc": "2.0",
+			  "id": "12",
+			  "method": "textDocument/formatting",
+			  "params": {
+			    "textDocument": {
+			      "uri": "file:///tmp/foo"
+			    },
+			    "options": {
+			      "tabSize": 4,
+			      "insertSpaces": false
+			    }
+			  }
+			}
+		'''.assertParse(new RequestMessage => [
+			jsonrpc = "2.0"
+			id = "12"
+			method = MessageMethods.DOC_FORMATTING
+			params = new DocumentFormattingParams => [
+				textDocument = new TextDocumentIdentifier("file:///tmp/foo")
+				options = new FormattingOptions => [
+					tabSize = 4
+					insertSpaces = false
+				]
+			]
+		])
+	}
     
 }

--- a/org.eclipse.lsp4j/src/test/xtend-gen/org/eclipse/lsp4j/test/services/JsonParseTest.java
+++ b/org.eclipse.lsp4j/src/test/xtend-gen/org/eclipse/lsp4j/test/services/JsonParseTest.java
@@ -14,6 +14,8 @@ import java.util.Map;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.DidChangeTextDocumentParams;
+import org.eclipse.lsp4j.DocumentFormattingParams;
+import org.eclipse.lsp4j.FormattingOptions;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.MarkedString;
 import org.eclipse.lsp4j.Position;
@@ -716,6 +718,73 @@ public class JsonParseTest {
       it.setResult(_doubleArrow);
     };
     ResponseMessage _doubleArrow = ObjectExtensions.<ResponseMessage>operator_doubleArrow(_responseMessage, _function_1);
+    this.assertParse(_builder, _doubleArrow);
+  }
+  
+  @Test
+  public void testDocumentFormatting() {
+    StringConcatenation _builder = new StringConcatenation();
+    _builder.append("{");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("\"jsonrpc\": \"2.0\",");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("\"id\": \"12\",");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("\"method\": \"textDocument/formatting\",");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("\"params\": {");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("\"textDocument\": {");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("\"uri\": \"file:///tmp/foo\"");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("},");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("\"options\": {");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("\"tabSize\": 4,");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("\"insertSpaces\": false");
+    _builder.newLine();
+    _builder.append("    ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("  ");
+    _builder.append("}");
+    _builder.newLine();
+    _builder.append("}");
+    _builder.newLine();
+    RequestMessage _requestMessage = new RequestMessage();
+    final Procedure1<RequestMessage> _function = (RequestMessage it) -> {
+      it.setJsonrpc("2.0");
+      it.setId("12");
+      it.setMethod(MessageMethods.DOC_FORMATTING);
+      DocumentFormattingParams _documentFormattingParams = new DocumentFormattingParams();
+      final Procedure1<DocumentFormattingParams> _function_1 = (DocumentFormattingParams it_1) -> {
+        TextDocumentIdentifier _textDocumentIdentifier = new TextDocumentIdentifier("file:///tmp/foo");
+        it_1.setTextDocument(_textDocumentIdentifier);
+        FormattingOptions _formattingOptions = new FormattingOptions();
+        final Procedure1<FormattingOptions> _function_2 = (FormattingOptions it_2) -> {
+          it_2.setTabSize(4);
+          it_2.setInsertSpaces(false);
+        };
+        FormattingOptions _doubleArrow = ObjectExtensions.<FormattingOptions>operator_doubleArrow(_formattingOptions, _function_2);
+        it_1.setOptions(_doubleArrow);
+      };
+      DocumentFormattingParams _doubleArrow = ObjectExtensions.<DocumentFormattingParams>operator_doubleArrow(_documentFormattingParams, _function_1);
+      it.setParams(_doubleArrow);
+    };
+    RequestMessage _doubleArrow = ObjectExtensions.<RequestMessage>operator_doubleArrow(_requestMessage, _function);
     this.assertParse(_builder, _doubleArrow);
   }
 }


### PR DESCRIPTION
Fixes #99. I tried to keep the protocol API as compatible as possible with the previous state.