### PR TITLE
EndpointProxy: Fixed 'equals'

### DIFF
--- a/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/annotations/EndpointsTest.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/annotations/EndpointsTest.java
@@ -18,6 +18,7 @@ import java.util.function.Consumer;
 
 import org.eclipse.lsp4j.jsonrpc.Endpoint;
 import org.eclipse.lsp4j.jsonrpc.json.JsonRpcMethod;
+import org.eclipse.lsp4j.jsonrpc.services.GenericEndpoint;
 import org.eclipse.lsp4j.jsonrpc.services.JsonDelegate;
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
@@ -176,6 +177,11 @@ public class EndpointsTest {
 		@JsonNotification
 		@Override
 		void accept(String message);
+	}
+	
+	@Test public void testIssue106() {
+		Foo foo = ServiceEndpoints.toServiceObject(new GenericEndpoint(new Object()), Foo.class);
+		assertEquals(foo, foo);
 	}
 	
 	@Test public void testIssue107() {


### PR DESCRIPTION
Fixes #106. The problem was that the proxy was calling `equals` on the delegate, which always returns false if the argument is the proxy. According to the contract of `equals`, we should return `true`.