### PR TITLE
Added Either3 type

### DIFF
--- a/org.eclipse.lsp4j.generator/src/main/xtend-gen/org/eclipse/lsp4j/generator/JsonRpcDataTransformationContext.java
+++ b/org.eclipse.lsp4j.generator/src/main/xtend-gen/org/eclipse/lsp4j/generator/JsonRpcDataTransformationContext.java
@@ -160,108 +160,76 @@ public class JsonRpcDataTransformationContext implements TransformationContext {
     throw new IllegalStateException(("Unexpected type reference: " + type));
   }
   
-  public boolean isSource(final Element arg0) {
-    return this.delegate.isSource(arg0);
+  public Element getPrimaryGeneratedJavaElement(final Element source) {
+    return this.delegate.getPrimaryGeneratedJavaElement(source);
   }
   
-  public boolean isGenerated(final Element arg0) {
-    return this.delegate.isGenerated(arg0);
+  public Element getPrimarySourceElement(final Element target) {
+    return this.delegate.getPrimarySourceElement(target);
   }
   
-  public boolean isExternal(final Element arg0) {
-    return this.delegate.isExternal(arg0);
+  public boolean isExternal(final Element element) {
+    return this.delegate.isExternal(element);
   }
   
-  public Element getPrimaryGeneratedJavaElement(final Element arg0) {
-    return this.delegate.getPrimaryGeneratedJavaElement(arg0);
+  public boolean isGenerated(final Element element) {
+    return this.delegate.isGenerated(element);
   }
   
-  public boolean isThePrimaryGeneratedJavaElement(final Element arg0) {
-    return this.delegate.isThePrimaryGeneratedJavaElement(arg0);
+  public boolean isSource(final Element element) {
+    return this.delegate.isSource(element);
   }
   
-  public Element getPrimarySourceElement(final Element arg0) {
-    return this.delegate.getPrimarySourceElement(arg0);
+  public boolean isThePrimaryGeneratedJavaElement(final Element target) {
+    return this.delegate.isThePrimaryGeneratedJavaElement(target);
   }
   
-  public List<? extends Problem> getProblems(final Element arg0) {
-    return this.delegate.getProblems(arg0);
+  public void addError(final Element element, final String message) {
+    this.delegate.addError(element, message);
   }
   
-  public void addError(final Element arg0, final String arg1) {
-    this.delegate.addError(arg0, arg1);
+  public void addWarning(final Element element, final String message) {
+    this.delegate.addWarning(element, message);
   }
   
-  public void addWarning(final Element arg0, final String arg1) {
-    this.delegate.addWarning(arg0, arg1);
+  public List<? extends Problem> getProblems(final Element element) {
+    return this.delegate.getProblems(element);
   }
   
-  public void validateLater(final Procedure0 arg0) {
-    this.delegate.validateLater(arg0);
-  }
-  
-  public TypeReference newArrayTypeReference(final TypeReference arg0) {
-    return this.delegate.newArrayTypeReference(arg0);
-  }
-  
-  public TypeReference newTypeReference(final String arg0, final TypeReference... arg1) {
-    return this.delegate.newTypeReference(arg0, arg1);
-  }
-  
-  public TypeReference newTypeReference(final Type arg0, final TypeReference... arg1) {
-    return this.delegate.newTypeReference(arg0, arg1);
-  }
-  
-  public TypeReference newSelfTypeReference(final Type arg0) {
-    return this.delegate.newSelfTypeReference(arg0);
-  }
-  
-  public TypeReference newTypeReference(final Class<?> arg0, final TypeReference... arg1) {
-    return this.delegate.newTypeReference(arg0, arg1);
-  }
-  
-  public TypeReference newWildcardTypeReference() {
-    return this.delegate.newWildcardTypeReference();
-  }
-  
-  public TypeReference newWildcardTypeReference(final TypeReference arg0) {
-    return this.delegate.newWildcardTypeReference(arg0);
-  }
-  
-  public TypeReference newWildcardTypeReferenceWithLowerBound(final TypeReference arg0) {
-    return this.delegate.newWildcardTypeReferenceWithLowerBound(arg0);
-  }
-  
-  public TypeReference getObject() {
-    return this.delegate.getObject();
-  }
-  
-  public TypeReference getString() {
-    return this.delegate.getString();
-  }
-  
-  public TypeReference getList(final TypeReference arg0) {
-    return this.delegate.getList(arg0);
-  }
-  
-  public TypeReference getSet(final TypeReference arg0) {
-    return this.delegate.getSet(arg0);
+  public void validateLater(final Procedure0 validationCallback) {
+    this.delegate.validateLater(validationCallback);
   }
   
   public TypeReference getAnyType() {
     return this.delegate.getAnyType();
   }
   
-  public TypeReference getPrimitiveVoid() {
-    return this.delegate.getPrimitiveVoid();
+  public TypeReference getList(final TypeReference param) {
+    return this.delegate.getList(param);
+  }
+  
+  public TypeReference getObject() {
+    return this.delegate.getObject();
   }
   
   public TypeReference getPrimitiveBoolean() {
     return this.delegate.getPrimitiveBoolean();
   }
   
-  public TypeReference getPrimitiveShort() {
-    return this.delegate.getPrimitiveShort();
+  public TypeReference getPrimitiveByte() {
+    return this.delegate.getPrimitiveByte();
+  }
+  
+  public TypeReference getPrimitiveChar() {
+    return this.delegate.getPrimitiveChar();
+  }
+  
+  public TypeReference getPrimitiveDouble() {
+    return this.delegate.getPrimitiveDouble();
+  }
+  
+  public TypeReference getPrimitiveFloat() {
+    return this.delegate.getPrimitiveFloat();
   }
   
   public TypeReference getPrimitiveInt() {
@@ -272,132 +240,164 @@ public class JsonRpcDataTransformationContext implements TransformationContext {
     return this.delegate.getPrimitiveLong();
   }
   
-  public TypeReference getPrimitiveFloat() {
-    return this.delegate.getPrimitiveFloat();
+  public TypeReference getPrimitiveShort() {
+    return this.delegate.getPrimitiveShort();
   }
   
-  public TypeReference getPrimitiveDouble() {
-    return this.delegate.getPrimitiveDouble();
+  public TypeReference getPrimitiveVoid() {
+    return this.delegate.getPrimitiveVoid();
   }
   
-  public TypeReference getPrimitiveChar() {
-    return this.delegate.getPrimitiveChar();
+  public TypeReference getSet(final TypeReference param) {
+    return this.delegate.getSet(param);
   }
   
-  public TypeReference getPrimitiveByte() {
-    return this.delegate.getPrimitiveByte();
+  public TypeReference getString() {
+    return this.delegate.getString();
   }
   
-  public MutableClassDeclaration findClass(final String arg0) {
-    return this.delegate.findClass(arg0);
+  public TypeReference newArrayTypeReference(final TypeReference componentType) {
+    return this.delegate.newArrayTypeReference(componentType);
   }
   
-  public MutableInterfaceDeclaration findInterface(final String arg0) {
-    return this.delegate.findInterface(arg0);
+  public TypeReference newSelfTypeReference(final Type typeDeclaration) {
+    return this.delegate.newSelfTypeReference(typeDeclaration);
   }
   
-  public MutableEnumerationTypeDeclaration findEnumerationType(final String arg0) {
-    return this.delegate.findEnumerationType(arg0);
+  public TypeReference newTypeReference(final String typeName, final TypeReference... typeArguments) {
+    return this.delegate.newTypeReference(typeName, typeArguments);
   }
   
-  public MutableAnnotationTypeDeclaration findAnnotationType(final String arg0) {
-    return this.delegate.findAnnotationType(arg0);
+  public TypeReference newTypeReference(final Type typeDeclaration, final TypeReference... typeArguments) {
+    return this.delegate.newTypeReference(typeDeclaration, typeArguments);
   }
   
-  public Type findTypeGlobally(final Class<?> arg0) {
-    return this.delegate.findTypeGlobally(arg0);
+  public TypeReference newTypeReference(final Class<?> clazz, final TypeReference... typeArguments) {
+    return this.delegate.newTypeReference(clazz, typeArguments);
   }
   
-  public Type findTypeGlobally(final String arg0) {
-    return this.delegate.findTypeGlobally(arg0);
+  public TypeReference newWildcardTypeReference() {
+    return this.delegate.newWildcardTypeReference();
   }
   
-  public Iterable<? extends Path> getChildren(final Path arg0) {
-    return this.delegate.getChildren(arg0);
+  public TypeReference newWildcardTypeReference(final TypeReference upperBound) {
+    return this.delegate.newWildcardTypeReference(upperBound);
   }
   
-  public boolean exists(final Path arg0) {
-    return this.delegate.exists(arg0);
+  public TypeReference newWildcardTypeReferenceWithLowerBound(final TypeReference lowerBound) {
+    return this.delegate.newWildcardTypeReferenceWithLowerBound(lowerBound);
   }
   
-  public boolean isFolder(final Path arg0) {
-    return this.delegate.isFolder(arg0);
+  public MutableAnnotationTypeDeclaration findAnnotationType(final String qualifiedName) {
+    return this.delegate.findAnnotationType(qualifiedName);
   }
   
-  public boolean isFile(final Path arg0) {
-    return this.delegate.isFile(arg0);
+  public MutableClassDeclaration findClass(final String qualifiedName) {
+    return this.delegate.findClass(qualifiedName);
   }
   
-  public long getLastModification(final Path arg0) {
-    return this.delegate.getLastModification(arg0);
+  public MutableEnumerationTypeDeclaration findEnumerationType(final String qualifiedName) {
+    return this.delegate.findEnumerationType(qualifiedName);
   }
   
-  public String getCharset(final Path arg0) {
-    return this.delegate.getCharset(arg0);
+  public MutableInterfaceDeclaration findInterface(final String qualifiedName) {
+    return this.delegate.findInterface(qualifiedName);
   }
   
-  public CharSequence getContents(final Path arg0) {
-    return this.delegate.getContents(arg0);
+  public Type findTypeGlobally(final Class<?> clazz) {
+    return this.delegate.findTypeGlobally(clazz);
   }
   
-  public InputStream getContentsAsStream(final Path arg0) {
-    return this.delegate.getContentsAsStream(arg0);
+  public Type findTypeGlobally(final String typeName) {
+    return this.delegate.findTypeGlobally(typeName);
   }
   
-  public URI toURI(final Path arg0) {
-    return this.delegate.toURI(arg0);
+  public boolean exists(final Path path) {
+    return this.delegate.exists(path);
   }
   
-  public Path getSourceFolder(final Path arg0) {
-    return this.delegate.getSourceFolder(arg0);
+  public String getCharset(final Path path) {
+    return this.delegate.getCharset(path);
   }
   
-  public Path getTargetFolder(final Path arg0) {
-    return this.delegate.getTargetFolder(arg0);
+  public Iterable<? extends Path> getChildren(final Path path) {
+    return this.delegate.getChildren(path);
   }
   
-  public Path getProjectFolder(final Path arg0) {
-    return this.delegate.getProjectFolder(arg0);
+  public CharSequence getContents(final Path path) {
+    return this.delegate.getContents(path);
   }
   
-  public Set<Path> getProjectSourceFolders(final Path arg0) {
-    return this.delegate.getProjectSourceFolders(arg0);
+  public InputStream getContentsAsStream(final Path path) {
+    return this.delegate.getContentsAsStream(path);
   }
   
-  public AnnotationReference newAnnotationReference(final String arg0) {
-    return this.delegate.newAnnotationReference(arg0);
+  public long getLastModification(final Path path) {
+    return this.delegate.getLastModification(path);
   }
   
-  public AnnotationReference newAnnotationReference(final Type arg0) {
-    return this.delegate.newAnnotationReference(arg0);
+  public boolean isFile(final Path path) {
+    return this.delegate.isFile(path);
   }
   
-  public AnnotationReference newAnnotationReference(final Class<?> arg0) {
-    return this.delegate.newAnnotationReference(arg0);
+  public boolean isFolder(final Path path) {
+    return this.delegate.isFolder(path);
   }
   
-  public AnnotationReference newAnnotationReference(final AnnotationReference arg0) {
-    return this.delegate.newAnnotationReference(arg0);
+  public URI toURI(final Path path) {
+    return this.delegate.toURI(path);
   }
   
-  public AnnotationReference newAnnotationReference(final String arg0, final Procedure1<AnnotationReferenceBuildContext> arg1) {
-    return this.delegate.newAnnotationReference(arg0, arg1);
+  public Path getProjectFolder(final Path path) {
+    return this.delegate.getProjectFolder(path);
   }
   
-  public AnnotationReference newAnnotationReference(final Type arg0, final Procedure1<AnnotationReferenceBuildContext> arg1) {
-    return this.delegate.newAnnotationReference(arg0, arg1);
+  public Set<Path> getProjectSourceFolders(final Path path) {
+    return this.delegate.getProjectSourceFolders(path);
   }
   
-  public AnnotationReference newAnnotationReference(final Class<?> arg0, final Procedure1<AnnotationReferenceBuildContext> arg1) {
-    return this.delegate.newAnnotationReference(arg0, arg1);
+  public Path getSourceFolder(final Path path) {
+    return this.delegate.getSourceFolder(path);
   }
   
-  public AnnotationReference newAnnotationReference(final AnnotationReference arg0, final Procedure1<AnnotationReferenceBuildContext> arg1) {
-    return this.delegate.newAnnotationReference(arg0, arg1);
+  public Path getTargetFolder(final Path sourceFolder) {
+    return this.delegate.getTargetFolder(sourceFolder);
   }
   
-  public void setPrimarySourceElement(final MutableElement arg0, final Element arg1) {
-    this.delegate.setPrimarySourceElement(arg0, arg1);
+  public AnnotationReference newAnnotationReference(final String annotationTypeName) {
+    return this.delegate.newAnnotationReference(annotationTypeName);
+  }
+  
+  public AnnotationReference newAnnotationReference(final Type annotationTypeDelcaration) {
+    return this.delegate.newAnnotationReference(annotationTypeDelcaration);
+  }
+  
+  public AnnotationReference newAnnotationReference(final Class<?> annotationClass) {
+    return this.delegate.newAnnotationReference(annotationClass);
+  }
+  
+  public AnnotationReference newAnnotationReference(final AnnotationReference annotationReference) {
+    return this.delegate.newAnnotationReference(annotationReference);
+  }
+  
+  public AnnotationReference newAnnotationReference(final String annotationTypeName, final Procedure1<AnnotationReferenceBuildContext> initializer) {
+    return this.delegate.newAnnotationReference(annotationTypeName, initializer);
+  }
+  
+  public AnnotationReference newAnnotationReference(final Type annotationTypeDelcaration, final Procedure1<AnnotationReferenceBuildContext> initializer) {
+    return this.delegate.newAnnotationReference(annotationTypeDelcaration, initializer);
+  }
+  
+  public AnnotationReference newAnnotationReference(final Class<?> annotationClass, final Procedure1<AnnotationReferenceBuildContext> initializer) {
+    return this.delegate.newAnnotationReference(annotationClass, initializer);
+  }
+  
+  public AnnotationReference newAnnotationReference(final AnnotationReference annotationReference, final Procedure1<AnnotationReferenceBuildContext> initializer) {
+    return this.delegate.newAnnotationReference(annotationReference, initializer);
+  }
+  
+  public void setPrimarySourceElement(final MutableElement javaElement, final Element sourceElement) {
+    this.delegate.setPrimarySourceElement(javaElement, sourceElement);
   }
   
   @Pure

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/MessageJsonHandler.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/MessageJsonHandler.java
@@ -99,12 +99,9 @@ public class MessageJsonHandler {
 	 */
 	public static String toString(Object object) {
 		if (toStringInstance == null) {
-			toStringInstance = new MessageJsonHandler(Collections.emptyMap()) {
-				@Override
-				public GsonBuilder getDefaultGsonBuilder() {
-					return super.getDefaultGsonBuilder().setPrettyPrinting();
-				}
-			};
+			toStringInstance = new MessageJsonHandler(Collections.emptyMap(), gsonBuilder -> {
+				gsonBuilder.setPrettyPrinting();
+			});
 		}
 		return toStringInstance.gson.toJson(object);
 	}

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/adapters/TypeUtils.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/adapters/TypeUtils.java
@@ -1,0 +1,179 @@
+/*******************************************************************************
+ * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.lsp4j.jsonrpc.json.adapters;
+
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.lang.reflect.TypeVariable;
+import java.lang.reflect.WildcardType;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.gson.reflect.TypeToken;
+
+/**
+ * Utilities for handling types in the JSON parser / serializer.
+ */
+public class TypeUtils {
+	
+	private TypeUtils() {}
+	
+	/**
+	 * Determine the actual type arguments of the given type token with regard to the given target type.
+	 */
+	public static Type[] getElementTypes(TypeToken<?> typeToken, Class<?> targetType) {
+		return getElementTypes(typeToken.getType(), typeToken.getRawType(), targetType);
+	}
+	
+	private static Type[] getElementTypes(Type type, Class<?> rawType, Class<?> targetType) {
+		if (targetType.equals(rawType) && type instanceof ParameterizedType) {
+			Type mappedType;
+			if (type instanceof ParameterizedTypeImpl)
+				mappedType = type;
+			else
+				// Transform wildcards in the actual type arguments
+				mappedType = getMappedType(type, Collections.emptyMap());
+			return ((ParameterizedType) mappedType).getActualTypeArguments();
+		}
+		// Map the parameters of the raw type to the actual type arguments
+		Map<String, Type> varMapping = createVariableMapping(type, rawType);
+		if (targetType.isInterface()) {
+			// Look for superinterfaces that extend the target interface
+			Class<?>[] interfaces = rawType.getInterfaces();
+			for (int i = 0; i < interfaces.length; i++) {
+				if (Collection.class.isAssignableFrom(interfaces[i])) {
+					Type genericInterface = rawType.getGenericInterfaces()[i];
+					Type mappedInterface = getMappedType(genericInterface, varMapping);
+					return getElementTypes(mappedInterface, interfaces[i], targetType);
+				}
+			}
+		}
+		if (!rawType.isInterface()) {
+			// Visit the superclass if it extends the target class / implements the target interface
+			Class<?> rawSupertype = rawType.getSuperclass();
+			if (targetType.isAssignableFrom(rawSupertype)) {
+				Type genericSuperclass = rawType.getGenericSuperclass();
+				Type mappedSuperclass = getMappedType(genericSuperclass, varMapping);
+				return getElementTypes(mappedSuperclass, rawSupertype, targetType);
+			}
+		}
+		// No luck, return an array of Object types
+		Type[] result = new Type[targetType.getTypeParameters().length];
+		Arrays.fill(result, Object.class);
+		return result;
+	}
+	
+	private static <T> Map<String, Type> createVariableMapping(Type type, Class<T> rawType) {
+		if (type instanceof ParameterizedType) {
+			TypeVariable<Class<T>>[] vars = rawType.getTypeParameters();
+			Type[] args = ((ParameterizedType) type).getActualTypeArguments();
+			Map<String, Type> newVarMapping = new HashMap<>(capacity(vars.length));
+			for (int i = 0; i < vars.length; i++) {
+				Type actualType = Object.class;
+				if (i < args.length) {
+					actualType = args[i];
+					if (actualType instanceof WildcardType)
+						actualType = ((WildcardType) actualType).getUpperBounds()[0];
+				}
+				newVarMapping.put(vars[i].getName(), actualType);
+			}
+			return newVarMapping;
+		}
+		return Collections.emptyMap();
+	}
+	
+	private static int capacity(int expectedSize) {
+		if (expectedSize < 3)
+			return expectedSize + 1;
+		else
+			return expectedSize + expectedSize / 3;
+	}
+	
+	private static Type getMappedType(Type type, Map<String, Type> varMapping) {
+		if (type instanceof TypeVariable) {
+			String name = ((TypeVariable<?>) type).getName();
+			if (varMapping.containsKey(name))
+				return varMapping.get(name);
+		}
+		if (type instanceof WildcardType) {
+			return getMappedType(((WildcardType) type).getUpperBounds()[0], varMapping);
+		}
+		if (type instanceof ParameterizedType) {
+			ParameterizedType pt = (ParameterizedType) type;
+			Type[] origArgs = pt.getActualTypeArguments();
+			Type[] mappedArgs = new Type[origArgs.length];
+			for (int i = 0; i < origArgs.length; i++) {
+				mappedArgs[i] = getMappedType(origArgs[i], varMapping);
+			}
+			return new ParameterizedTypeImpl(pt, mappedArgs);
+		}
+		return type;
+	}
+
+	private static class ParameterizedTypeImpl implements ParameterizedType {
+		
+		private final Type ownerType;
+		private final Type rawType;
+		private final Type[] actualTypeArguments;
+		
+		ParameterizedTypeImpl(ParameterizedType original, Type[] typeArguments) {
+			this(original.getOwnerType(), original.getRawType(), typeArguments);
+		}
+		
+		ParameterizedTypeImpl(Type ownerType, Type rawType, Type[] typeArguments) {
+			this.ownerType = ownerType;
+			this.rawType = rawType;
+			this.actualTypeArguments = typeArguments;
+		}
+		
+		@Override
+		public Type getOwnerType() {
+			return ownerType;
+		}
+		
+		@Override
+		public Type getRawType() {
+			return rawType;
+		}
+
+		@Override
+		public Type[] getActualTypeArguments() {
+			return actualTypeArguments;
+		}
+		
+		@Override
+		public String toString() {
+			StringBuilder result = new StringBuilder();
+			if (ownerType != null) {
+				result.append(toString(ownerType));
+				result.append('$');
+			}
+			result.append(toString(rawType));
+			result.append('<');
+			for (int i = 0; i < actualTypeArguments.length; i++) {
+				if (i > 0)
+					result.append(", ");
+				result.append(toString(actualTypeArguments[i]));
+			}
+			result.append('>');
+			return result.toString();
+		}
+		
+		private String toString(Type type) {
+			if (type instanceof Class<?>)
+				return ((Class<?>) type).getName();
+			else
+				return String.valueOf(type);
+		}
+		
+	}
+
+}

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/Either.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/Either.java
@@ -15,11 +15,7 @@ import java.util.Collection;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 
 /**
- * 
  * An either type maps union types in protocol specifications.
- *
- * @param <L>
- * @param <R>
  */
 public class Either<L, R> {
 
@@ -55,6 +51,25 @@ public class Either<L, R> {
 	public boolean isRight() {
 		return right != null;
 	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (obj instanceof Either<?, ?>) {
+			Either<?, ?> other = (Either<?, ?>) obj;
+			return this.left != null && other.left != null && this.left.equals(other.left)
+					|| this.right != null && other.right != null && this.right.equals(other.right);
+		}
+		return false;
+	}
+	
+	@Override
+	public int hashCode() {
+		if (this.left != null)
+			return this.left.hashCode();
+		if (this.right != null)
+			return this.right.hashCode();
+		return 0;
+	}
 
 	public String toString() {
 		StringBuilder builder = new StringBuilder("Either [").append(System.lineSeparator());
@@ -65,7 +80,10 @@ public class Either<L, R> {
 
 	/**
 	 * Return a left disjoint type if the given type is either.
+	 * 
+	 * @deprecated Use {@link org.eclipse.lsp4j.jsonrpc.json.adapters.TypeUtils#getElementTypes(Type, Class, Class)} instead
 	 */
+	@Deprecated
 	public static Type getLeftDisjointType(Type type) {
 		if (isEither(type)) {
 			if (type instanceof ParameterizedType) {
@@ -82,7 +100,10 @@ public class Either<L, R> {
 
 	/**
 	 * Return a right disjoint type if the given type is either.
+	 * 
+	 * @deprecated Use {@link org.eclipse.lsp4j.jsonrpc.json.adapters.TypeUtils#getElementTypes(Type, Class, Class)} instead
 	 */
+	@Deprecated
 	public static Type getRightDisjointType(Type type) {
 		if (isEither(type)) {
 			if (type instanceof ParameterizedType) {
@@ -96,7 +117,7 @@ public class Either<L, R> {
 		}
 		return null;
 	}
-
+	
 	/**
 	 * Return all disjoint types.
 	 */

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/Either3.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/Either3.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.lsp4j.jsonrpc.messages;
+
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+
+/**
+ * Union type for three types.
+ */
+public class Either3<T1, T2, T3> extends Either<T1, Either<T2, T3>> {
+	
+	public static <T1, T2, T3> Either3<T1, T2, T3> forFirst(@NonNull T1 first) {
+		return new Either3<T1, T2, T3>(first, null);
+	}
+
+	public static <T1, T2, T3> Either3<T1, T2, T3> forSecond(@NonNull T2 second) {
+		return new Either3<T1, T2, T3>(null, new Either<T2, T3>(second, null));
+	}
+	
+	public static <T1, T2, T3> Either3<T1, T2, T3> forThird(@NonNull T3 third) {
+		return new Either3<T1, T2, T3>(null, new Either<T2, T3>(null, third));
+	}
+	
+	public static <T1, T2, T3> Either3<T1, T2, T3> forLeft3(@NonNull T1 first) {
+		return new Either3<T1, T2, T3>(first, null);
+	}
+	
+	public static <T1, T2, T3> Either3<T1, T2, T3> forRight3(@NonNull Either<T2, T3> right) {
+		return new Either3<T1, T2, T3>(null, right);
+	}
+
+	protected Either3(T1 left, Either<T2, T3> right) {
+		super(left, right);
+	}
+	
+	public T1 getFirst() {
+		return getLeft();
+	}
+	
+	public T2 getSecond() {
+		Either<T2, T3> right = getRight();
+		if (right == null)
+			return null;
+		else
+			return right.getLeft();
+	}
+	
+	public T3 getThird() {
+		Either<T2, T3> right = getRight();
+		if (right == null)
+			return null;
+		else
+			return right.getRight();
+	}
+	
+	public boolean isFirst() {
+		return isLeft();
+	}
+	
+	public boolean isSecond() {
+		return isRight() && getRight().isLeft();
+	}
+	
+	public boolean isThird() {
+		return isRight() && getRight().isRight();
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder builder = new StringBuilder("Either3 [").append(System.lineSeparator());
+		builder.append("  first = ").append(getFirst()).append(System.lineSeparator());
+		builder.append("  second = ").append(getSecond()).append(System.lineSeparator());
+		builder.append("  third = ").append(getThird()).append(System.lineSeparator());
+		return builder.append("]").toString();
+	}
+
+}

--- a/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/LauncherTest.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/LauncherTest.java
@@ -1,3 +1,10 @@
+/*******************************************************************************
+ * Copyright (c) 2016 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
 package org.eclipse.lsp4j.jsonrpc.test;
 
 import java.io.ByteArrayInputStream;

--- a/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/json/EitherTest.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/json/EitherTest.java
@@ -1,0 +1,108 @@
+/*******************************************************************************
+ * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.lsp4j.jsonrpc.test.json;
+
+import org.eclipse.lsp4j.jsonrpc.json.adapters.EitherTypeAdapterFactory;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4j.jsonrpc.messages.Either3;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+
+public class EitherTest {
+	
+	protected Gson createGson() {
+		return new GsonBuilder().registerTypeAdapterFactory(new EitherTypeAdapterFactory()).create();
+	}
+	
+	protected void assertSerialize(Object object, String expected) {
+		Gson gson = createGson();
+		String actual = gson.toJson(object);
+		Assert.assertEquals(expected, actual);
+	}
+	
+	protected void assertParse(Object expected, String string) {
+		Gson gson = createGson();
+		Object actual = gson.fromJson(string, expected.getClass());
+		Assert.assertEquals(expected, actual);
+	}
+	
+	@Test
+	public void testSerializeEither() {
+		MyObjectA object = new MyObjectA();
+		object.myProperty = Either.forRight(7);
+		assertSerialize(object, "{\"myProperty\":7}");
+	}
+	
+	@Test
+	public void testParseEither() {
+		MyObjectA object = new MyObjectA();
+		object.myProperty = Either.forRight(7);
+		assertParse(object, "{\"myProperty\":7}");
+	}
+	
+	protected static class MyObjectA {
+		public Either<String, Integer> myProperty;
+		
+		@Override
+		public boolean equals(Object obj) {
+			if (obj instanceof MyObjectA) {
+				MyObjectA other = (MyObjectA) obj;
+				return this.myProperty == null && other.myProperty == null
+						|| this.myProperty != null && this.myProperty.equals(other.myProperty);
+			}
+			return false;
+		}
+		
+		@Override
+		public int hashCode() {
+			if (myProperty != null)
+				return myProperty.hashCode();
+			return 0;
+		}
+	}
+	
+	@Test
+	public void testSerializeEither3() {
+		MyObjectB object = new MyObjectB();
+		object.myProperty = Either3.forSecond(7);
+		assertSerialize(object, "{\"myProperty\":7}");
+	}
+	
+	@Test
+	public void testParseEither3() {
+		MyObjectB object = new MyObjectB();
+		object.myProperty = Either3.forSecond(7);
+		assertParse(object, "{\"myProperty\":7}");
+	}
+	
+	protected static class MyObjectB {
+		public Either3<String, Integer, Boolean> myProperty;
+		
+		@Override
+		public boolean equals(Object obj) {
+			if (obj instanceof MyObjectB) {
+				MyObjectB other = (MyObjectB) obj;
+				return this.myProperty == null && other.myProperty == null
+						|| this.myProperty != null && this.myProperty.equals(other.myProperty);
+			}
+			return false;
+		}
+		
+		@Override
+		public int hashCode() {
+			if (myProperty != null)
+				return myProperty.hashCode();
+			return 0;
+		}
+	}
+
+}

--- a/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/json/MessageJsonHandlerTest.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/json/MessageJsonHandlerTest.java
@@ -1,3 +1,10 @@
+/*******************************************************************************
+ * Copyright (c) 2016 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
 package org.eclipse.lsp4j.jsonrpc.test.json;
 
 import java.util.LinkedHashMap;

--- a/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/json/MyClass.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/json/MyClass.java
@@ -1,3 +1,10 @@
+/*******************************************************************************
+ * Copyright (c) 2016 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
 package org.eclipse.lsp4j.jsonrpc.test.json;
 
 public class MyClass {

--- a/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/json/MyClassList.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/json/MyClassList.java
@@ -1,3 +1,10 @@
+/*******************************************************************************
+ * Copyright (c) 2016 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
 package org.eclipse.lsp4j.jsonrpc.test.json;
 
 import java.util.ArrayList;

--- a/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/json/MyEnum.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/json/MyEnum.java
@@ -1,3 +1,10 @@
+/*******************************************************************************
+ * Copyright (c) 2016 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
 package org.eclipse.lsp4j.jsonrpc.test.json;
 
 public enum MyEnum {

--- a/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/json/TypeUtilsTest.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/json/TypeUtilsTest.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+package org.eclipse.lsp4j.jsonrpc.test.json;
+
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+
+import org.eclipse.lsp4j.jsonrpc.json.adapters.TypeUtils;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4j.jsonrpc.messages.Either3;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.gson.reflect.TypeToken;
+
+public class TypeUtilsTest {
+	
+	protected void assertElementTypes(TypeToken<?> typeToken, Class<?> targetType, Type... expectedElementTypes) {
+		Type[] actualElementTypes = TypeUtils.getElementTypes(typeToken, targetType);
+		Assert.assertArrayEquals(expectedElementTypes, actualElementTypes);
+	}
+	
+	@Test
+	public void testCollectionElement1() {
+		TypeToken<?> token = new TypeToken<List<String>>() {};
+		assertElementTypes(token, Collection.class, String.class);
+	}
+	
+	@Test
+	public void testCollectionElement2() {
+		TypeToken<?> token = new TypeToken<List<? extends Number>>() {};
+		assertElementTypes(token, Collection.class, Number.class);
+	}
+	
+	private static interface MyCollection extends Collection<String> {
+	}
+	
+	@Test
+	public void testCollectionElement3() {
+		TypeToken<?> token = new TypeToken<MyCollection>() {};
+		assertElementTypes(token, Collection.class, String.class);
+	}
+	
+	private static class MyLinkedList extends LinkedList<String> {
+		private static final long serialVersionUID = 1L;
+	}
+	
+	@Test
+	public void testCollectionElement4() {
+		TypeToken<?> token = new TypeToken<MyLinkedList>() {};
+		assertElementTypes(token, Collection.class, String.class);
+	}
+	
+	@Test
+	public void testCollectionElement5() {
+		TypeToken<?> token = new TypeToken<List<Either<List<String>, String>>>() {};
+		assertElementTypes(token, Collection.class, new TypeToken<Either<List<String>, String>>() {}.getType());
+	}
+	
+	@Test
+	public void testEitherElements1() {
+		TypeToken<?> token = new TypeToken<Either<String, Number>>() {};
+		assertElementTypes(token, Either.class, String.class, Number.class);
+	}
+	
+	@Test
+	public void testEitherElements2() {
+		TypeToken<?> token = new TypeToken<Either<String, ? extends Number>>() {};
+		assertElementTypes(token, Either.class, String.class, Number.class);
+	}
+	
+	private static class MyEitherA extends Either<String, Number> {
+		protected MyEitherA(String left, Number right) {
+			super(left, right);
+		}
+	}
+	
+	@Test
+	public void testEitherElements3() {
+		TypeToken<?> token = new TypeToken<MyEitherA>() {};
+		assertElementTypes(token, Either.class, String.class, Number.class);
+	}
+	
+	private static class MyEitherB<T> extends Either<String, T> {
+		protected MyEitherB(String left, T right) {
+			super(left, right);
+		}
+	}
+	
+	@Test
+	public void testEitherElements4() {
+		TypeToken<?> token = new TypeToken<MyEitherB<Number>>() {};
+		assertElementTypes(token, Either.class, String.class, Number.class);
+	}
+	
+	@Test
+	public void testEitherElements5() {
+		TypeToken<?> token = new TypeToken<Either3<String, Number, Boolean>>() {};
+		assertElementTypes(token, Either.class, String.class, new TypeToken<Either<Number, Boolean>>() {}.getType());
+	}
+	
+	@Test
+	public void testEitherElements6() {
+		TypeToken<?> token = new TypeToken<Either3<String, Number, Boolean>>() {};
+		assertElementTypes(token, Either3.class, String.class, Number.class, Boolean.class);
+	}
+	
+	private static class MyEitherC extends Either3<String, Number, Boolean> {
+		protected MyEitherC(String left, Either<Number, Boolean> right) {
+			super(left, right);
+		}
+	}
+	
+	@Test
+	public void testEitherElements7() {
+		TypeToken<?> token = new TypeToken<MyEitherC>() {};
+		assertElementTypes(token, Either.class, String.class, new TypeToken<Either<Number, Boolean>>() {}.getType());
+	}
+
+}

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -1290,7 +1290,7 @@ class FileEvent {
 /**
  * Value-object describing what options formatting should use.
  */
-class FormattingOptions extends LinkedHashMap<String, Either3<String, Integer, Boolean>> {
+class FormattingOptions extends LinkedHashMap<String, Either3<String, Number, Boolean>> {
 
 	static val TAB_SIZE = 'tabSize'
 	static val INSERT_SPACES = 'insertSpaces'
@@ -1320,11 +1320,11 @@ class FormattingOptions extends LinkedHashMap<String, Either3<String, Integer, B
     	put(key, Either3.forFirst(value))
     }
     
-    def Integer getInteger(String key) {
+    def Number getNumber(String key) {
     	get(key)?.getSecond
     }
     
-    def void putInteger(String key, Integer value) {
+    def void putNumber(String key, Number value) {
     	put(key, Either3.forSecond(value))
     }
     
@@ -1340,7 +1340,7 @@ class FormattingOptions extends LinkedHashMap<String, Either3<String, Integer, B
 	 * Size of a tab in spaces.
 	 */
     def int getTabSize() {
-    	val value = getInteger(TAB_SIZE)
+    	val value = getNumber(TAB_SIZE)
     	if (value !== null)
     		return value.intValue
     	else
@@ -1348,7 +1348,7 @@ class FormattingOptions extends LinkedHashMap<String, Either3<String, Integer, B
     }
     
     def void setTabSize(int tabSize) {
-    	putInteger(TAB_SIZE, tabSize)
+    	putNumber(TAB_SIZE, tabSize)
     }
     
  	/**

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -6,6 +6,7 @@ import java.util.List
 import java.util.Map
 import org.eclipse.lsp4j.generator.JsonRpcData
 import org.eclipse.lsp4j.jsonrpc.messages.Either
+import org.eclipse.lsp4j.jsonrpc.messages.Either3
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull
 
 @JsonRpcData
@@ -1289,7 +1290,7 @@ class FileEvent {
 /**
  * Value-object describing what options formatting should use.
  */
-class FormattingOptions extends LinkedHashMap<String, Either<String, Either<Integer, Boolean>>> {
+class FormattingOptions extends LinkedHashMap<String, Either3<String, Integer, Boolean>> {
 
 	static val TAB_SIZE = 'tabSize'
 	static val INSERT_SPACES = 'insertSpaces'
@@ -1312,27 +1313,27 @@ class FormattingOptions extends LinkedHashMap<String, Either<String, Either<Inte
     }
     
     def String getString(String key) {
-    	get(key)?.getLeft
+    	get(key)?.getFirst
     }
     
     def void putString(String key, String value) {
-    	put(key, Either.forLeft(value))
+    	put(key, Either3.forFirst(value))
     }
     
     def Integer getInteger(String key) {
-    	get(key)?.getRight?.getLeft
+    	get(key)?.getSecond
     }
     
     def void putInteger(String key, Integer value) {
-    	put(key, Either.forRight(Either.forLeft(value)))
+    	put(key, Either3.forSecond(value))
     }
     
     def Boolean getBoolean(String key) {
-    	get(key)?.getRight?.getRight
+    	get(key)?.getThird
     }
     
     def void putBoolean(String key, Boolean value) {
-    	put(key, Either.forRight(Either.forRight(value)))
+    	put(key, Either3.forThird(value))
     }
     
 	/**
@@ -1372,13 +1373,11 @@ class FormattingOptions extends LinkedHashMap<String, Either<String, Either<Inte
     def Map<String, String> getProperties() {
     	val properties = newLinkedHashMap
     	for (entry : entrySet) {
-    		val value =
-    			if (entry.value.isLeft)
-    				entry.value.getLeft
-    			else if (entry.value.isRight && entry.value.getRight.isLeft)
-    				entry.value.getRight.getLeft
-    			else if (entry.value.isRight && entry.value.getRight.isRight)
-    				entry.value.getRight.getRight
+    		val value = switch it: entry.value {
+    			case isFirst: getFirst
+    			case isSecond: getSecond
+    			case isThird: getThird
+    		}
     		if (value !== null)
     			properties.put(entry.key, value.toString)
     	}

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/FormattingOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/FormattingOptions.java
@@ -4,14 +4,14 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4j.jsonrpc.messages.Either3;
 import org.eclipse.xtext.xbase.lib.CollectionLiterals;
 
 /**
  * Value-object describing what options formatting should use.
  */
 @SuppressWarnings("all")
-public class FormattingOptions extends LinkedHashMap<String, Either<String, Either<Integer, Boolean>>> {
+public class FormattingOptions extends LinkedHashMap<String, Either3<String, Integer, Boolean>> {
   private final static String TAB_SIZE = "tabSize";
   
   private final static String INSERT_SPACES = "insertSpaces";
@@ -34,50 +34,42 @@ public class FormattingOptions extends LinkedHashMap<String, Either<String, Eith
   }
   
   public String getString(final String key) {
-    Either<String, Either<Integer, Boolean>> _get = this.get(key);
-    String _left = null;
+    Either3<String, Integer, Boolean> _get = this.get(key);
+    String _first = null;
     if (_get!=null) {
-      _left=_get.getLeft();
+      _first=_get.getFirst();
     }
-    return _left;
+    return _first;
   }
   
   public void putString(final String key, final String value) {
-    this.put(key, Either.<String, Either<Integer, Boolean>>forLeft(value));
+    this.put(key, Either3.<String, Integer, Boolean>forFirst(value));
   }
   
   public Integer getInteger(final String key) {
-    Either<String, Either<Integer, Boolean>> _get = this.get(key);
-    Either<Integer, Boolean> _right = null;
+    Either3<String, Integer, Boolean> _get = this.get(key);
+    Integer _second = null;
     if (_get!=null) {
-      _right=_get.getRight();
+      _second=_get.getSecond();
     }
-    Integer _left = null;
-    if (_right!=null) {
-      _left=_right.getLeft();
-    }
-    return _left;
+    return _second;
   }
   
   public void putInteger(final String key, final Integer value) {
-    this.put(key, Either.<String, Either<Integer, Boolean>>forRight(Either.<Integer, Boolean>forLeft(value)));
+    this.put(key, Either3.<String, Integer, Boolean>forSecond(value));
   }
   
   public Boolean getBoolean(final String key) {
-    Either<String, Either<Integer, Boolean>> _get = this.get(key);
-    Either<Integer, Boolean> _right = null;
+    Either3<String, Integer, Boolean> _get = this.get(key);
+    Boolean _third = null;
     if (_get!=null) {
-      _right=_get.getRight();
+      _third=_get.getThird();
     }
-    Boolean _right_1 = null;
-    if (_right!=null) {
-      _right_1=_right.getRight();
-    }
-    return _right_1;
+    return _third;
   }
   
   public void putBoolean(final String key, final Boolean value) {
-    this.put(key, Either.<String, Either<Integer, Boolean>>forRight(Either.<Integer, Boolean>forRight(value)));
+    this.put(key, Either3.<String, Integer, Boolean>forThird(value));
   }
   
   /**
@@ -118,27 +110,33 @@ public class FormattingOptions extends LinkedHashMap<String, Either<String, Eith
   @Deprecated
   public Map<String, String> getProperties() {
     final LinkedHashMap<String, String> properties = CollectionLiterals.<String, String>newLinkedHashMap();
-    Set<Map.Entry<String, Either<String, Either<Integer, Boolean>>>> _entrySet = this.entrySet();
-    for (final Map.Entry<String, Either<String, Either<Integer, Boolean>>> entry : _entrySet) {
+    Set<Map.Entry<String, Either3<String, Integer, Boolean>>> _entrySet = this.entrySet();
+    for (final Map.Entry<String, Either3<String, Integer, Boolean>> entry : _entrySet) {
       {
-        Object _xifexpression = null;
-        boolean _isLeft = entry.getValue().isLeft();
-        if (_isLeft) {
-          _xifexpression = entry.getValue().getLeft();
-        } else {
-          Object _xifexpression_1 = null;
-          if ((entry.getValue().isRight() && entry.getValue().getRight().isLeft())) {
-            _xifexpression_1 = entry.getValue().getRight().getLeft();
-          } else {
-            Boolean _xifexpression_2 = null;
-            if ((entry.getValue().isRight() && entry.getValue().getRight().isRight())) {
-              _xifexpression_2 = entry.getValue().getRight().getRight();
-            }
-            _xifexpression_1 = _xifexpression_2;
-          }
-          _xifexpression = ((Object)_xifexpression_1);
+        Object _switchResult = null;
+        Either3<String, Integer, Boolean> _value = entry.getValue();
+        final Either3<String, Integer, Boolean> it = _value;
+        boolean _matched = false;
+        boolean _isFirst = it.isFirst();
+        if (_isFirst) {
+          _matched=true;
+          _switchResult = it.getFirst();
         }
-        final Object value = ((Object)_xifexpression);
+        if (!_matched) {
+          boolean _isSecond = it.isSecond();
+          if (_isSecond) {
+            _matched=true;
+            _switchResult = it.getSecond();
+          }
+        }
+        if (!_matched) {
+          boolean _isThird = it.isThird();
+          if (_isThird) {
+            _matched=true;
+            _switchResult = it.getThird();
+          }
+        }
+        final Object value = ((Object)_switchResult);
         if ((value != null)) {
           properties.put(entry.getKey(), value.toString());
         }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/FormattingOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/FormattingOptions.java
@@ -1,5 +1,6 @@
 package org.eclipse.lsp4j;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -11,7 +12,7 @@ import org.eclipse.xtext.xbase.lib.CollectionLiterals;
  * Value-object describing what options formatting should use.
  */
 @SuppressWarnings("all")
-public class FormattingOptions extends LinkedHashMap<String, Either3<String, Integer, Boolean>> {
+public class FormattingOptions extends LinkedHashMap<String, Either3<String, Number, Boolean>> {
   private final static String TAB_SIZE = "tabSize";
   
   private final static String INSERT_SPACES = "insertSpaces";
@@ -34,7 +35,7 @@ public class FormattingOptions extends LinkedHashMap<String, Either3<String, Int
   }
   
   public String getString(final String key) {
-    Either3<String, Integer, Boolean> _get = this.get(key);
+    Either3<String, Number, Boolean> _get = this.get(key);
     String _first = null;
     if (_get!=null) {
       _first=_get.getFirst();
@@ -43,24 +44,24 @@ public class FormattingOptions extends LinkedHashMap<String, Either3<String, Int
   }
   
   public void putString(final String key, final String value) {
-    this.put(key, Either3.<String, Integer, Boolean>forFirst(value));
+    this.put(key, Either3.<String, Number, Boolean>forFirst(value));
   }
   
-  public Integer getInteger(final String key) {
-    Either3<String, Integer, Boolean> _get = this.get(key);
-    Integer _second = null;
+  public Number getNumber(final String key) {
+    Either3<String, Number, Boolean> _get = this.get(key);
+    Number _second = null;
     if (_get!=null) {
       _second=_get.getSecond();
     }
     return _second;
   }
   
-  public void putInteger(final String key, final Integer value) {
-    this.put(key, Either3.<String, Integer, Boolean>forSecond(value));
+  public void putNumber(final String key, final Number value) {
+    this.put(key, Either3.<String, Number, Boolean>forSecond(value));
   }
   
   public Boolean getBoolean(final String key) {
-    Either3<String, Integer, Boolean> _get = this.get(key);
+    Either3<String, Number, Boolean> _get = this.get(key);
     Boolean _third = null;
     if (_get!=null) {
       _third=_get.getThird();
@@ -69,14 +70,14 @@ public class FormattingOptions extends LinkedHashMap<String, Either3<String, Int
   }
   
   public void putBoolean(final String key, final Boolean value) {
-    this.put(key, Either3.<String, Integer, Boolean>forThird(value));
+    this.put(key, Either3.<String, Number, Boolean>forThird(value));
   }
   
   /**
    * Size of a tab in spaces.
    */
   public int getTabSize() {
-    final Integer value = this.getInteger(FormattingOptions.TAB_SIZE);
+    final Number value = this.getNumber(FormattingOptions.TAB_SIZE);
     if ((value != null)) {
       return value.intValue();
     } else {
@@ -85,7 +86,7 @@ public class FormattingOptions extends LinkedHashMap<String, Either3<String, Int
   }
   
   public void setTabSize(final int tabSize) {
-    this.putInteger(FormattingOptions.TAB_SIZE, Integer.valueOf(tabSize));
+    this.putNumber(FormattingOptions.TAB_SIZE, Integer.valueOf(tabSize));
   }
   
   /**
@@ -110,12 +111,12 @@ public class FormattingOptions extends LinkedHashMap<String, Either3<String, Int
   @Deprecated
   public Map<String, String> getProperties() {
     final LinkedHashMap<String, String> properties = CollectionLiterals.<String, String>newLinkedHashMap();
-    Set<Map.Entry<String, Either3<String, Integer, Boolean>>> _entrySet = this.entrySet();
-    for (final Map.Entry<String, Either3<String, Integer, Boolean>> entry : _entrySet) {
+    Set<Map.Entry<String, Either3<String, Number, Boolean>>> _entrySet = this.entrySet();
+    for (final Map.Entry<String, Either3<String, Number, Boolean>> entry : _entrySet) {
       {
-        Object _switchResult = null;
-        Either3<String, Integer, Boolean> _value = entry.getValue();
-        final Either3<String, Integer, Boolean> it = _value;
+        Serializable _switchResult = null;
+        Either3<String, Number, Boolean> _value = entry.getValue();
+        final Either3<String, Number, Boolean> it = _value;
         boolean _matched = false;
         boolean _isFirst = it.isFirst();
         if (_isFirst) {
@@ -136,7 +137,7 @@ public class FormattingOptions extends LinkedHashMap<String, Either3<String, Int
             _switchResult = it.getThird();
           }
         }
-        final Object value = ((Object)_switchResult);
+        final Serializable value = _switchResult;
         if ((value != null)) {
           properties.put(entry.getKey(), value.toString());
         }

--- a/org.eclipse.lsp4j/src/test/java/org/eclipse/lsp4j/test/services/JsonParseTest.xtend
+++ b/org.eclipse.lsp4j/src/test/java/org/eclipse/lsp4j/test/services/JsonParseTest.xtend
@@ -357,7 +357,8 @@ class JsonParseTest {
 			    },
 			    "options": {
 			      "tabSize": 4,
-			      "insertSpaces": false
+			      "insertSpaces": false,
+			      "customProperty": -7
 			    }
 			  }
 			}
@@ -371,6 +372,7 @@ class JsonParseTest {
 					tabSize = 4
 					insertSpaces = false
 				]
+				options.putInteger('customProperty', -7)
 			]
 		])
 	}

--- a/org.eclipse.lsp4j/src/test/java/org/eclipse/lsp4j/test/services/JsonParseTest.xtend
+++ b/org.eclipse.lsp4j/src/test/java/org/eclipse/lsp4j/test/services/JsonParseTest.xtend
@@ -372,7 +372,7 @@ class JsonParseTest {
 					tabSize = 4
 					insertSpaces = false
 				]
-				options.putInteger('customProperty', -7)
+				options.putNumber('customProperty', -7)
 			]
 		])
 	}

--- a/org.eclipse.lsp4j/src/test/java/org/eclipse/lsp4j/test/services/JsonSerializeTest.xtend
+++ b/org.eclipse.lsp4j/src/test/java/org/eclipse/lsp4j/test/services/JsonSerializeTest.xtend
@@ -212,7 +212,7 @@ class JsonSerializeTest {
 	}
 	
     @Test
-    def void testRename() {
+    def void testRenameResponse() {
         val message = new ResponseMessage => [
             jsonrpc = "2.0"
             id = "12"
@@ -340,7 +340,7 @@ class JsonSerializeTest {
     }
         
 	@Test
-	def void testBuildCompletionList() {
+	def void testCompletionResponse() {
 		val message = new ResponseMessage => [
 			jsonrpc = "2.0"
 			id = "12"
@@ -370,7 +370,7 @@ class JsonSerializeTest {
 	}
 	
 	@Test
-	def void testBuildDocumentFormattingParams() {
+	def void testDocumentFormatting() {
 		val message = new RequestMessage => [
 			jsonrpc = "2.0"
 			id = "12"
@@ -381,6 +381,7 @@ class JsonSerializeTest {
 					tabSize = 4
 					insertSpaces = false
 				]
+				options.putInteger('customProperty', -7)
 			]
 		]
 		message.assertSerialize('''
@@ -394,7 +395,8 @@ class JsonSerializeTest {
 			    },
 			    "options": {
 			      "tabSize": 4,
-			      "insertSpaces": false
+			      "insertSpaces": false,
+			      "customProperty": -7
 			    }
 			  }
 			}

--- a/org.eclipse.lsp4j/src/test/java/org/eclipse/lsp4j/test/services/JsonSerializeTest.xtend
+++ b/org.eclipse.lsp4j/src/test/java/org/eclipse/lsp4j/test/services/JsonSerializeTest.xtend
@@ -381,7 +381,7 @@ class JsonSerializeTest {
 					tabSize = 4
 					insertSpaces = false
 				]
-				options.putInteger('customProperty', -7)
+				options.putNumber('customProperty', -7)
 			]
 		]
 		message.assertSerialize('''

--- a/org.eclipse.lsp4j/src/test/xtend-gen/org/eclipse/lsp4j/test/services/JsonParseTest.java
+++ b/org.eclipse.lsp4j/src/test/xtend-gen/org/eclipse/lsp4j/test/services/JsonParseTest.java
@@ -754,7 +754,10 @@ public class JsonParseTest {
     _builder.append("\"tabSize\": 4,");
     _builder.newLine();
     _builder.append("      ");
-    _builder.append("\"insertSpaces\": false");
+    _builder.append("\"insertSpaces\": false,");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("\"customProperty\": -7");
     _builder.newLine();
     _builder.append("    ");
     _builder.append("}");
@@ -780,6 +783,7 @@ public class JsonParseTest {
         };
         FormattingOptions _doubleArrow = ObjectExtensions.<FormattingOptions>operator_doubleArrow(_formattingOptions, _function_2);
         it_1.setOptions(_doubleArrow);
+        it_1.getOptions().putInteger("customProperty", Integer.valueOf((-7)));
       };
       DocumentFormattingParams _doubleArrow = ObjectExtensions.<DocumentFormattingParams>operator_doubleArrow(_documentFormattingParams, _function_1);
       it.setParams(_doubleArrow);

--- a/org.eclipse.lsp4j/src/test/xtend-gen/org/eclipse/lsp4j/test/services/JsonParseTest.java
+++ b/org.eclipse.lsp4j/src/test/xtend-gen/org/eclipse/lsp4j/test/services/JsonParseTest.java
@@ -783,7 +783,7 @@ public class JsonParseTest {
         };
         FormattingOptions _doubleArrow = ObjectExtensions.<FormattingOptions>operator_doubleArrow(_formattingOptions, _function_2);
         it_1.setOptions(_doubleArrow);
-        it_1.getOptions().putInteger("customProperty", Integer.valueOf((-7)));
+        it_1.getOptions().putNumber("customProperty", Integer.valueOf((-7)));
       };
       DocumentFormattingParams _doubleArrow = ObjectExtensions.<DocumentFormattingParams>operator_doubleArrow(_documentFormattingParams, _function_1);
       it.setParams(_doubleArrow);

--- a/org.eclipse.lsp4j/src/test/xtend-gen/org/eclipse/lsp4j/test/services/JsonSerializeTest.java
+++ b/org.eclipse.lsp4j/src/test/xtend-gen/org/eclipse/lsp4j/test/services/JsonSerializeTest.java
@@ -770,7 +770,7 @@ public class JsonSerializeTest {
         };
         FormattingOptions _doubleArrow = ObjectExtensions.<FormattingOptions>operator_doubleArrow(_formattingOptions, _function_2);
         it_1.setOptions(_doubleArrow);
-        it_1.getOptions().putInteger("customProperty", Integer.valueOf((-7)));
+        it_1.getOptions().putNumber("customProperty", Integer.valueOf((-7)));
       };
       DocumentFormattingParams _doubleArrow = ObjectExtensions.<DocumentFormattingParams>operator_doubleArrow(_documentFormattingParams, _function_1);
       it.setParams(_doubleArrow);

--- a/org.eclipse.lsp4j/src/test/xtend-gen/org/eclipse/lsp4j/test/services/JsonSerializeTest.java
+++ b/org.eclipse.lsp4j/src/test/xtend-gen/org/eclipse/lsp4j/test/services/JsonSerializeTest.java
@@ -410,7 +410,7 @@ public class JsonSerializeTest {
   }
   
   @Test
-  public void testRename() {
+  public void testRenameResponse() {
     ResponseMessage _responseMessage = new ResponseMessage();
     final Procedure1<ResponseMessage> _function = (ResponseMessage it) -> {
       it.setJsonrpc("2.0");
@@ -695,7 +695,7 @@ public class JsonSerializeTest {
   }
   
   @Test
-  public void testBuildCompletionList() {
+  public void testCompletionResponse() {
     ResponseMessage _responseMessage = new ResponseMessage();
     final Procedure1<ResponseMessage> _function = (ResponseMessage it) -> {
       it.setJsonrpc("2.0");
@@ -753,7 +753,7 @@ public class JsonSerializeTest {
   }
   
   @Test
-  public void testBuildDocumentFormattingParams() {
+  public void testDocumentFormatting() {
     RequestMessage _requestMessage = new RequestMessage();
     final Procedure1<RequestMessage> _function = (RequestMessage it) -> {
       it.setJsonrpc("2.0");
@@ -770,6 +770,7 @@ public class JsonSerializeTest {
         };
         FormattingOptions _doubleArrow = ObjectExtensions.<FormattingOptions>operator_doubleArrow(_formattingOptions, _function_2);
         it_1.setOptions(_doubleArrow);
+        it_1.getOptions().putInteger("customProperty", Integer.valueOf((-7)));
       };
       DocumentFormattingParams _doubleArrow = ObjectExtensions.<DocumentFormattingParams>operator_doubleArrow(_documentFormattingParams, _function_1);
       it.setParams(_doubleArrow);
@@ -806,7 +807,10 @@ public class JsonSerializeTest {
     _builder.append("\"tabSize\": 4,");
     _builder.newLine();
     _builder.append("      ");
-    _builder.append("\"insertSpaces\": false");
+    _builder.append("\"insertSpaces\": false,");
+    _builder.newLine();
+    _builder.append("      ");
+    _builder.append("\"customProperty\": -7");
     _builder.newLine();
     _builder.append("    ");
     _builder.append("}");


### PR DESCRIPTION
 * Added a type `Either3<T1, T2, T3> extends Either<T1, Either<T2, T3>>`
 * FormattingOptions use Either3 as map values (see #110)
 * Added `TypeUtils` to extract common code from Gson type adapter factories
 * Corrected handling of generic types for Collection and Either (both type adapters were wrong in some cases)