### PR TITLE
Moved some methods from Either to TypeUtils

### DIFF
--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/adapters/EitherTypeAdapterFactory.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/adapters/EitherTypeAdapterFactory.java
@@ -9,8 +9,8 @@ package org.eclipse.lsp4j.jsonrpc.json.adapters;
 
 import java.io.IOException;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.jsonrpc.messages.Either3;
@@ -31,7 +31,7 @@ public class EitherTypeAdapterFactory implements TypeAdapterFactory {
 	@SuppressWarnings({ "rawtypes", "unchecked" })
 	@Override
 	public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> typeToken) {
-		if (!Either.isEither(typeToken.getType())) {
+		if (!TypeUtils.isEither(typeToken.getType())) {
 			return null;
 		}
 		return new Adapter(gson, typeToken);
@@ -102,9 +102,9 @@ public class EitherTypeAdapterFactory implements TypeAdapterFactory {
 		public EitherTypeArgument(Gson gson, Type type) {
 			this.token = (TypeToken<T>) TypeToken.get(type);
 			this.adapter = gson.getAdapter(this.token);
-			this.expectedTokens = new ArrayList<>();
-			for (Type disjoinType : Either.getAllDisjoinTypes(type)) {
-				Class<?> rawType = TypeToken.get(disjoinType).getRawType();
+			this.expectedTokens = new HashSet<>();
+			for (Type expectedType : TypeUtils.getExpectedTypes(type)) {
+				Class<?> rawType = TypeToken.get(expectedType).getRawType();
 				JsonToken expectedToken = getExpectedToken(rawType);
 				expectedTokens.add(expectedToken);
 			}

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/Either.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/Either.java
@@ -120,11 +120,15 @@ public class Either<L, R> {
 	
 	/**
 	 * Return all disjoint types.
+	 * 
+	 * @deprecated Use {@link org.eclipse.lsp4j.jsonrpc.json.adapters.TypeUtils#getExpectedTypes(Type)} instead
 	 */
+	@Deprecated
 	public static Collection<Type> getAllDisjoinTypes(Type type) {
 		return collectDisjoinTypes(type, new ArrayList<>());
 	}
 
+	@Deprecated
 	protected static Collection<Type> collectDisjoinTypes(Type type, Collection<Type> types) {
 		if (isEither(type)) {
 			if (type instanceof ParameterizedType) {
@@ -138,6 +142,7 @@ public class Either<L, R> {
 		return types;
 	}
 
+	@Deprecated
 	protected static Collection<Type> collectDisjoinTypes(ParameterizedType type, Collection<Type> types) {
 		for (Type typeArgument : type.getActualTypeArguments()) {
 			collectDisjoinTypes(typeArgument, types);
@@ -145,6 +150,7 @@ public class Either<L, R> {
 		return types;
 	}
 
+	@Deprecated
 	protected static Collection<Type> collectDisjoinTypes(Class<?> type, Collection<Type> types) {
 		for (Type typeParameter : type.getTypeParameters()) {
 			collectDisjoinTypes(typeParameter, types);
@@ -154,7 +160,10 @@ public class Either<L, R> {
 
 	/**
 	 * Test whether the given type is Either.
+	 * 
+	 * @deprecated Use {@link org.eclipse.lsp4j.jsonrpc.json.adapters.TypeUtils#isEither(Type)} instead
 	 */
+	@Deprecated
 	public static boolean isEither(Type type) {
 		if (type instanceof ParameterizedType) {
 			return isEither((ParameterizedType) type);
@@ -167,14 +176,20 @@ public class Either<L, R> {
 
 	/**
 	 * Test whether the given type is Either.
+	 * 
+	 * @deprecated Use {@link org.eclipse.lsp4j.jsonrpc.json.adapters.TypeUtils#isEither(Type)} instead
 	 */
+	@Deprecated
 	public static boolean isEither(ParameterizedType type) {
 		return isEither(type.getRawType());
 	}
 
 	/**
 	 * Test whether the given class is Either.
+	 * 
+	 * @deprecated Use {@link org.eclipse.lsp4j.jsonrpc.json.adapters.TypeUtils#isEither(Type)} instead
 	 */
+	@Deprecated
 	public static boolean isEither(Class<?> cls) {
 		return Either.class.isAssignableFrom(cls);
 	}


### PR DESCRIPTION
`Either` contains some methods that are used only in its type adapter. They should be moved there to separate the data structure from its parsing / serialization code.