### PR TITLE
Added equals and hashCode implementations to message types

### DIFF
--- a/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/messages/DebugNotificationMessage.java
+++ b/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/messages/DebugNotificationMessage.java
@@ -32,4 +32,31 @@ public class DebugNotificationMessage extends NotificationMessage {
 		this.id = id;
 	}
 
+	@Override
+	public boolean equals(final Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		if (!super.equals(obj))
+			return false;
+		DebugNotificationMessage other = (DebugNotificationMessage) obj;
+		if (this.id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!this.id.equals(other.id))
+			return false;
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + ((this.id == null) ? 0 : this.id.hashCode());
+		return result;
+	}
+
 }

--- a/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/messages/DebugResponseMessage.java
+++ b/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/messages/DebugResponseMessage.java
@@ -48,4 +48,37 @@ public class DebugResponseMessage extends ResponseMessage {
 		this.method = method;
 	}
 
+	@Override
+	public boolean equals(final Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		if (!super.equals(obj))
+			return false;
+		DebugResponseMessage other = (DebugResponseMessage) obj;
+		if (this.responseId == null) {
+			if (other.responseId != null)
+				return false;
+		} else if (!this.responseId.equals(other.responseId))
+			return false;
+		if (this.method == null) {
+			if (other.method != null)
+				return false;
+		} else if (!this.method.equals(other.method))
+			return false;
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + ((this.responseId == null) ? 0 : this.responseId.hashCode());
+		result = prime * result + ((this.method == null) ? 0 : this.method.hashCode());
+		return result;
+	}
+
 }

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/CancelParams.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/CancelParams.java
@@ -33,5 +33,30 @@ public class CancelParams {
 	public String toString() {
 		return MessageJsonHandler.toString(this);
 	}
-	
+
+	@Override
+	public boolean equals(final Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		CancelParams other = (CancelParams) obj;
+		if (this.id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!this.id.equals(other.id))
+			return false;
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((this.id == null) ? 0 : this.id.hashCode());
+		return result;
+	}
+
 }

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/Message.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/Message.java
@@ -16,7 +16,7 @@ import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
  * uses "2.0" as the jsonrpc version.
  */
 public abstract class Message {
-	
+
 	@NonNull
 	private String jsonrpc = MessageConstants.JSONRPC_VERSION;
 
@@ -27,10 +27,35 @@ public abstract class Message {
 	public void setJsonrpc(String jsonrpc) {
 		this.jsonrpc = jsonrpc;
 	}
-	
+
 	@Override
 	public String toString() {
 		return MessageJsonHandler.toString(this);
 	}
-	
+
+	@Override
+	public boolean equals(final Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		Message other = (Message) obj;
+		if (this.jsonrpc == null) {
+			if (other.jsonrpc != null)
+				return false;
+		} else if (!this.jsonrpc.equals(other.jsonrpc))
+			return false;
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((this.jsonrpc == null) ? 0 : this.jsonrpc.hashCode());
+		return result;
+	}
+
 }

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/NotificationMessage.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/NotificationMessage.java
@@ -41,5 +41,38 @@ public class NotificationMessage extends Message {
 	public void setParams(Object params) {
 		this.params = params;
 	}
-	
+
+	@Override
+	public boolean equals(final Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		if (!super.equals(obj))
+			return false;
+		NotificationMessage other = (NotificationMessage) obj;
+		if (this.method == null) {
+			if (other.method != null)
+				return false;
+		} else if (!this.method.equals(other.method))
+			return false;
+		if (this.params == null) {
+			if (other.params != null)
+				return false;
+		} else if (!this.params.equals(other.params))
+			return false;
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + ((this.method == null) ? 0 : this.method.hashCode());
+		result = prime * result + ((this.params == null) ? 0 : this.params.hashCode());
+		return result;
+	}
+
 }

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/RequestMessage.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/RequestMessage.java
@@ -56,5 +56,44 @@ public class RequestMessage extends Message {
 	public void setParams(Object params) {
 		this.params = params;
 	}
-	
+
+	@Override
+	public boolean equals(final Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		if (!super.equals(obj))
+			return false;
+		RequestMessage other = (RequestMessage) obj;
+		if (this.id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!this.id.equals(other.id))
+			return false;
+		if (this.method == null) {
+			if (other.method != null)
+				return false;
+		} else if (!this.method.equals(other.method))
+			return false;
+		if (this.params == null) {
+			if (other.params != null)
+				return false;
+		} else if (!this.params.equals(other.params))
+			return false;
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + ((this.id == null) ? 0 : this.id.hashCode());
+		result = prime * result + ((this.method == null) ? 0 : this.method.hashCode());
+		result = prime * result + ((this.params == null) ? 0 : this.params.hashCode());
+		return result;
+	}
+
 }

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/ResponseError.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/ResponseError.java
@@ -11,7 +11,7 @@ import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 
 public class ResponseError {
-	
+
 	/**
 	 * A number indicating the error type that occured.
 	 */
@@ -60,20 +60,54 @@ public class ResponseError {
 
 	public ResponseError() {
 	}
-	
+
 	public ResponseError(ResponseErrorCode code, String message, Object data) {
 		this(code.getValue(), message, data);
 	}
-	
+
 	public ResponseError(int code, String message, Object data) {
 		this.code = code;
 		this.message = message;
 		this.data = data;
 	}
-	
+
 	@Override
 	public String toString() {
 		return MessageJsonHandler.toString(this);
 	}
-	
+
+	@Override
+	public boolean equals(final Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		ResponseError other = (ResponseError) obj;
+		if (other.code != this.code)
+			return false;
+		if (this.message == null) {
+			if (other.message != null)
+				return false;
+		} else if (!this.message.equals(other.message))
+			return false;
+		if (this.data == null) {
+			if (other.data != null)
+				return false;
+		} else if (!this.data.equals(other.data))
+			return false;
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + this.code;
+		result = prime * result + ((this.message == null) ? 0 : this.message.hashCode());
+		result = prime * result + ((this.data == null) ? 0 : this.data.hashCode());
+		return result;
+	}
+
 }

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/ResponseMessage.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/ResponseMessage.java
@@ -57,5 +57,44 @@ public class ResponseMessage extends Message {
 	public void setError(ResponseError error) {
 		this.error = error;
 	}
-	
+
+	@Override
+	public boolean equals(final Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		if (!super.equals(obj))
+			return false;
+		ResponseMessage other = (ResponseMessage) obj;
+		if (this.id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!this.id.equals(other.id))
+			return false;
+		if (this.result == null) {
+			if (other.result != null)
+				return false;
+		} else if (!this.result.equals(other.result))
+			return false;
+		if (this.error == null) {
+			if (other.error != null)
+				return false;
+		} else if (!this.error.equals(other.error))
+			return false;
+		return true;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = super.hashCode();
+		result = prime * result + ((this.id == null) ? 0 : this.id.hashCode());
+		result = prime * result + ((this.result == null) ? 0 : this.result.hashCode());
+		result = prime * result + ((this.error == null) ? 0 : this.error.hashCode());
+		return result;
+	}
+
 }


### PR DESCRIPTION
For parameter and result types, we already generate such implementations with the `JsonRpcDataProcessor`.

Fixes #123.