### PR TITLE
Changed type of 'id' fields to Either<String, Number>

### DIFF
--- a/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/DebugRemoteEndpoint.java
+++ b/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/DebugRemoteEndpoint.java
@@ -34,7 +34,7 @@ public class DebugRemoteEndpoint extends RemoteEndpoint {
 	@Override
 	protected DebugRequestMessage createRequestMessage(String method, Object parameter) {
 		DebugRequestMessage requestMessage = new DebugRequestMessage();
-		requestMessage.setId(String.valueOf(nextSeqId.incrementAndGet()));
+		requestMessage.setId(nextSeqId.incrementAndGet());
 		requestMessage.setMethod(method);
 		requestMessage.setParams(parameter);
 		return requestMessage;
@@ -43,8 +43,8 @@ public class DebugRemoteEndpoint extends RemoteEndpoint {
 	@Override
 	protected DebugResponseMessage createResponseMessage(RequestMessage requestMessage) {
 		DebugResponseMessage responseMessage = new DebugResponseMessage();
-		responseMessage.setResponseId(String.valueOf(nextSeqId.incrementAndGet()));
-		responseMessage.setId(requestMessage.getId());
+		responseMessage.setResponseId(nextSeqId.incrementAndGet());
+		responseMessage.setRawId(requestMessage.getRawId());
 		responseMessage.setMethod(requestMessage.getMethod());
 		return responseMessage;
 	}
@@ -52,7 +52,7 @@ public class DebugRemoteEndpoint extends RemoteEndpoint {
 	@Override
 	protected DebugNotificationMessage createNotificationMessage(String method, Object parameter) {
 		DebugNotificationMessage notificationMessage = new DebugNotificationMessage();
-		notificationMessage.setId(String.valueOf(nextSeqId.incrementAndGet()));
+		notificationMessage.setId(nextSeqId.incrementAndGet());
 		notificationMessage.setMethod(method);
 		notificationMessage.setParams(parameter);
 		return notificationMessage;

--- a/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/adapters/DebugMessageTypeAdapter.java
+++ b/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/adapters/DebugMessageTypeAdapter.java
@@ -428,7 +428,7 @@ public class DebugMessageTypeAdapter extends MessageTypeAdapter {
 		out.endObject();
 	}
 	
-	private void writeIntId(JsonWriter out, Either<String, Integer> id) throws IOException {
+	private void writeIntId(JsonWriter out, Either<String, Number> id) throws IOException {
 		if (id == null)
 			writeNullValue(out);
 		else if (id.isLeft())

--- a/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/messages/DebugNotificationMessage.java
+++ b/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/messages/DebugNotificationMessage.java
@@ -8,6 +8,7 @@
 package org.eclipse.lsp4j.jsonrpc.debug.messages;
 
 import org.eclipse.lsp4j.jsonrpc.debug.adapters.DebugMessageTypeAdapter;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.jsonrpc.messages.NotificationMessage;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 
@@ -22,13 +23,31 @@ public class DebugNotificationMessage extends NotificationMessage {
 	 * The notification id.
 	 */
 	@NonNull
-	private String id;
+	private Either<String, Integer> id;
 
 	public String getId() {
-		return this.id;
+		if (id == null)
+			return null;
+		if (id.isLeft())
+			return id.getLeft();
+		if (id.isRight())
+			return id.getRight().toString();
+		return null;
+	}
+	
+	public Either<String, Integer> getRawId() {
+		return id;
 	}
 
 	public void setId(String id) {
+		this.id = Either.forLeft(id);
+	}
+	
+	public void setId(int id) {
+		this.id = Either.forRight(id);
+	}
+	
+	public void setRawId(Either<String, Integer> id) {
 		this.id = id;
 	}
 

--- a/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/messages/DebugNotificationMessage.java
+++ b/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/messages/DebugNotificationMessage.java
@@ -23,7 +23,7 @@ public class DebugNotificationMessage extends NotificationMessage {
 	 * The notification id.
 	 */
 	@NonNull
-	private Either<String, Integer> id;
+	private Either<String, Number> id;
 
 	public String getId() {
 		if (id == null)
@@ -35,7 +35,7 @@ public class DebugNotificationMessage extends NotificationMessage {
 		return null;
 	}
 	
-	public Either<String, Integer> getRawId() {
+	public Either<String, Number> getRawId() {
 		return id;
 	}
 
@@ -47,7 +47,7 @@ public class DebugNotificationMessage extends NotificationMessage {
 		this.id = Either.forRight(id);
 	}
 	
-	public void setRawId(Either<String, Integer> id) {
+	public void setRawId(Either<String, Number> id) {
 		this.id = id;
 	}
 

--- a/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/messages/DebugResponseMessage.java
+++ b/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/messages/DebugResponseMessage.java
@@ -8,6 +8,7 @@
 package org.eclipse.lsp4j.jsonrpc.debug.messages;
 
 import org.eclipse.lsp4j.jsonrpc.debug.adapters.DebugMessageTypeAdapter;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 
@@ -24,13 +25,31 @@ public class DebugResponseMessage extends ResponseMessage {
 	 * The {@link #getId()} field is the id of the message being replied to.
 	 */
 	@NonNull
-	private String responseId;
+	private Either<String, Integer> responseId;
 
 	public String getResponseId() {
-		return this.responseId;
+		if (responseId == null)
+			return null;
+		if (responseId.isLeft())
+			return responseId.getLeft();
+		if (responseId.isRight())
+			return responseId.getRight().toString();
+		return null;
+	}
+	
+	public Either<String, Integer> getRawResponseId() {
+		return responseId;
 	}
 
 	public void setResponseId(String id) {
+		this.responseId = Either.forLeft(id);
+	}
+	
+	public void setResponseId(int id) {
+		this.responseId = Either.forRight(id);
+	}
+	
+	public void setRawResponseId(Either<String, Integer> id) {
 		this.responseId = id;
 	}
 

--- a/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/messages/DebugResponseMessage.java
+++ b/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/messages/DebugResponseMessage.java
@@ -25,7 +25,7 @@ public class DebugResponseMessage extends ResponseMessage {
 	 * The {@link #getId()} field is the id of the message being replied to.
 	 */
 	@NonNull
-	private Either<String, Integer> responseId;
+	private Either<String, Number> responseId;
 
 	public String getResponseId() {
 		if (responseId == null)
@@ -37,7 +37,7 @@ public class DebugResponseMessage extends ResponseMessage {
 		return null;
 	}
 	
-	public Either<String, Integer> getRawResponseId() {
+	public Either<String, Number> getRawResponseId() {
 		return responseId;
 	}
 
@@ -49,7 +49,7 @@ public class DebugResponseMessage extends ResponseMessage {
 		this.responseId = Either.forRight(id);
 	}
 	
-	public void setRawResponseId(Either<String, Integer> id) {
+	public void setRawResponseId(Either<String, Number> id) {
 		this.responseId = id;
 	}
 

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/RemoteEndpoint.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/RemoteEndpoint.java
@@ -147,7 +147,7 @@ public class RemoteEndpoint implements Endpoint, MessageConsumer, MethodProvider
 		return requestMessage;
 	}
 
-	protected void sendCancelNotification(Either<String, Integer> id) {
+	protected void sendCancelNotification(Either<String, Number> id) {
 		CancelParams cancelParams = new CancelParams();
 		cancelParams.setRawId(id);
 		notify(MessageJsonHandler.CANCEL_METHOD.getMethodName(), cancelParams);

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/adapters/MessageTypeAdapter.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/adapters/MessageTypeAdapter.java
@@ -80,7 +80,7 @@ public class MessageTypeAdapter extends TypeAdapter<Message> {
 		
 		in.beginObject();
 		String jsonrpc = null, method = null;
-		Either<String, Integer> id = null;
+		Either<String, Number> id = null;
 		Object rawParams = null;
 		Object rawResult = null;
 		ResponseError error = null;
@@ -314,7 +314,7 @@ public class MessageTypeAdapter extends TypeAdapter<Message> {
 		return EMPTY_TYPE_ARRAY;
 	}
 	
-	protected Message createMessage(String jsonrpc, Either<String, Integer> id, String method, Object params, Object result, ResponseError error) {
+	protected Message createMessage(String jsonrpc, Either<String, Number> id, String method, Object params, Object result, ResponseError error) {
 		if (id != null && method != null) {
 			RequestMessage message = new RequestMessage();
 			message.setJsonrpc(jsonrpc);
@@ -391,7 +391,7 @@ public class MessageTypeAdapter extends TypeAdapter<Message> {
 		out.endObject();
 	}
 	
-	protected void writeId(JsonWriter out, Either<String, Integer> id) throws IOException {
+	protected void writeId(JsonWriter out, Either<String, Number> id) throws IOException {
 		if (id == null)
 			writeNullValue(out);
 		else if (id.isLeft())

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/CancelParams.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/CancelParams.java
@@ -19,13 +19,31 @@ public class CancelParams {
 	 * The request id to cancel.
 	 */
 	@NonNull
-	private String id;
-	
+	private Either<String, Integer> id;
+
 	public String getId() {
-		return this.id;
+		if (id == null)
+			return null;
+		if (id.isLeft())
+			return id.getLeft();
+		if (id.isRight())
+			return id.getRight().toString();
+		return null;
 	}
 	
+	public Either<String, Integer> getRawId() {
+		return id;
+	}
+
 	public void setId(String id) {
+		this.id = Either.forLeft(id);
+	}
+	
+	public void setId(int id) {
+		this.id = Either.forRight(id);
+	}
+	
+	public void setRawId(Either<String, Integer> id) {
 		this.id = id;
 	}
 	

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/Either.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/Either.java
@@ -43,6 +43,14 @@ public class Either<L, R> {
 	public R getRight() {
 		return right;
 	}
+	
+	public Object get() {
+		if (left != null)
+			return left;
+		if (right != null)
+			return right;
+		return null;
+	}
 
 	public boolean isLeft() {
 		return left != null;

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/Either3.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/Either3.java
@@ -58,6 +58,13 @@ public class Either3<T1, T2, T3> extends Either<T1, Either<T2, T3>> {
 			return right.getRight();
 	}
 	
+	@Override
+	public Object get() {
+		if (isRight())
+			return getRight().get();
+		return super.get();
+	}
+	
 	public boolean isFirst() {
 		return isLeft();
 	}

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/IdentifiableMessage.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/IdentifiableMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 TypeFox GmbH (http://www.typefox.io) and others.
+ * Copyright (c) 2018 TypeFox GmbH (http://www.typefox.io) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -7,16 +7,15 @@
  *******************************************************************************/
 package org.eclipse.lsp4j.jsonrpc.messages;
 
-import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 
 /**
- * To cancel a request a notification message with the following properties is sent.
+ * A message with an {@code id} property.
  */
-public class CancelParams {
+public abstract class IdentifiableMessage extends Message {
 	
 	/**
-	 * The request id to cancel.
+	 * The message identifier.
 	 */
 	@NonNull
 	private Either<String, Number> id;
@@ -46,11 +45,6 @@ public class CancelParams {
 	public void setRawId(Either<String, Number> id) {
 		this.id = id;
 	}
-	
-	@Override
-	public String toString() {
-		return MessageJsonHandler.toString(this);
-	}
 
 	@Override
 	public boolean equals(final Object obj) {
@@ -60,7 +54,9 @@ public class CancelParams {
 			return false;
 		if (getClass() != obj.getClass())
 			return false;
-		CancelParams other = (CancelParams) obj;
+		if (!super.equals(obj))
+			return false;
+		IdentifiableMessage other = (IdentifiableMessage) obj;
 		if (this.id == null) {
 			if (other.id != null)
 				return false;
@@ -72,7 +68,7 @@ public class CancelParams {
 	@Override
 	public int hashCode() {
 		final int prime = 31;
-		int result = 1;
+		int result = super.hashCode();
 		result = prime * result + ((this.id == null) ? 0 : this.id.hashCode());
 		return result;
 	}

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/RequestMessage.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/RequestMessage.java
@@ -14,39 +14,7 @@ import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
  * Every processed request must send a response back to the sender of the
  * request.
  */
-public class RequestMessage extends Message {
-
-	/**
-	 * The request id.
-	 */
-	@NonNull
-	private Either<String, Integer> id;
-
-	public String getId() {
-		if (id == null)
-			return null;
-		if (id.isLeft())
-			return id.getLeft();
-		if (id.isRight())
-			return id.getRight().toString();
-		return null;
-	}
-	
-	public Either<String, Integer> getRawId() {
-		return id;
-	}
-
-	public void setId(String id) {
-		this.id = Either.forLeft(id);
-	}
-	
-	public void setId(int id) {
-		this.id = Either.forRight(id);
-	}
-	
-	public void setRawId(Either<String, Integer> id) {
-		this.id = id;
-	}
+public class RequestMessage extends IdentifiableMessage {
 
 	/**
 	 * The method to be invoked.
@@ -86,11 +54,6 @@ public class RequestMessage extends Message {
 		if (!super.equals(obj))
 			return false;
 		RequestMessage other = (RequestMessage) obj;
-		if (this.id == null) {
-			if (other.id != null)
-				return false;
-		} else if (!this.id.equals(other.id))
-			return false;
 		if (this.method == null) {
 			if (other.method != null)
 				return false;
@@ -108,7 +71,6 @@ public class RequestMessage extends Message {
 	public int hashCode() {
 		final int prime = 31;
 		int result = super.hashCode();
-		result = prime * result + ((this.id == null) ? 0 : this.id.hashCode());
 		result = prime * result + ((this.method == null) ? 0 : this.method.hashCode());
 		result = prime * result + ((this.params == null) ? 0 : this.params.hashCode());
 		return result;

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/RequestMessage.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/RequestMessage.java
@@ -20,13 +20,31 @@ public class RequestMessage extends Message {
 	 * The request id.
 	 */
 	@NonNull
-	private String id;
+	private Either<String, Integer> id;
 
 	public String getId() {
-		return this.id;
+		if (id == null)
+			return null;
+		if (id.isLeft())
+			return id.getLeft();
+		if (id.isRight())
+			return id.getRight().toString();
+		return null;
+	}
+	
+	public Either<String, Integer> getRawId() {
+		return id;
 	}
 
 	public void setId(String id) {
+		this.id = Either.forLeft(id);
+	}
+	
+	public void setId(int id) {
+		this.id = Either.forRight(id);
+	}
+	
+	public void setRawId(Either<String, Integer> id) {
 		this.id = id;
 	}
 

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/ResponseMessage.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/ResponseMessage.java
@@ -14,38 +14,7 @@ package org.eclipse.lsp4j.jsonrpc.messages;
  * ResponseMessage should be set to null in this case to signal a successful
  * request.
  */
-public class ResponseMessage extends Message {
-
-	/**
-	 * The request id.
-	 */
-	private Either<String, Integer> id;
-
-	public String getId() {
-		if (id == null)
-			return null;
-		if (id.isLeft())
-			return id.getLeft();
-		if (id.isRight())
-			return id.getRight().toString();
-		return null;
-	}
-	
-	public Either<String, Integer> getRawId() {
-		return id;
-	}
-
-	public void setId(String id) {
-		this.id = Either.forLeft(id);
-	}
-	
-	public void setId(int id) {
-		this.id = Either.forRight(id);
-	}
-	
-	public void setRawId(Either<String, Integer> id) {
-		this.id = id;
-	}
+public class ResponseMessage extends IdentifiableMessage {
 
 	/**
 	 * The result of a request. This can be omitted in the case of an error.
@@ -84,11 +53,6 @@ public class ResponseMessage extends Message {
 		if (!super.equals(obj))
 			return false;
 		ResponseMessage other = (ResponseMessage) obj;
-		if (this.id == null) {
-			if (other.id != null)
-				return false;
-		} else if (!this.id.equals(other.id))
-			return false;
 		if (this.result == null) {
 			if (other.result != null)
 				return false;
@@ -106,7 +70,6 @@ public class ResponseMessage extends Message {
 	public int hashCode() {
 		final int prime = 31;
 		int result = super.hashCode();
-		result = prime * result + ((this.id == null) ? 0 : this.id.hashCode());
 		result = prime * result + ((this.result == null) ? 0 : this.result.hashCode());
 		result = prime * result + ((this.error == null) ? 0 : this.error.hashCode());
 		return result;

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/ResponseMessage.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/ResponseMessage.java
@@ -7,8 +7,6 @@
  *******************************************************************************/
 package org.eclipse.lsp4j.jsonrpc.messages;
 
-import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
-
 /**
  * Response Message sent as a result of a request. If a request doesn't provide
  * a result value the receiver of a request still needs to return a response
@@ -21,14 +19,31 @@ public class ResponseMessage extends Message {
 	/**
 	 * The request id.
 	 */
-	@NonNull
-	private String id;
+	private Either<String, Integer> id;
 
 	public String getId() {
-		return this.id;
+		if (id == null)
+			return null;
+		if (id.isLeft())
+			return id.getLeft();
+		if (id.isRight())
+			return id.getRight().toString();
+		return null;
+	}
+	
+	public Either<String, Integer> getRawId() {
+		return id;
 	}
 
 	public void setId(String id) {
+		this.id = Either.forLeft(id);
+	}
+	
+	public void setId(int id) {
+		this.id = Either.forRight(id);
+	}
+	
+	public void setRawId(Either<String, Integer> id) {
 		this.id = id;
 	}
 

--- a/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/IntegrationTest.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/IntegrationTest.java
@@ -92,6 +92,60 @@ public class IntegrationTest {
 	}
 
 	@Test
+	public void testResponse1() throws Exception {
+		// create client message
+		String requestMessage = "{\"jsonrpc\":\"2.0\","
+				+ "\"id\":\"42\",\n" 
+				+ "\"method\":\"askServer\",\n" 
+				+ "\"params\": { value: \"bar\" }\n"
+				+ "}";
+		String clientMessage = getHeader(requestMessage.getBytes().length) + requestMessage;
+		
+		// create server side
+		ByteArrayInputStream in = new ByteArrayInputStream(clientMessage.getBytes());
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		MyServer server = new MyServer() {
+			@Override
+			public CompletableFuture<MyParam> askServer(MyParam param) {
+				return CompletableFuture.completedFuture(param);
+			}
+		};
+		Launcher<MyClient> serverSideLauncher = Launcher.createLauncher(server, MyClient.class, in, out);
+		serverSideLauncher.startListening().get(TIMEOUT, TimeUnit.MILLISECONDS);
+		
+		Assert.assertEquals("Content-Length: 52" + CRLF + CRLF
+				+ "{\"jsonrpc\":\"2.0\",\"id\":\"42\",\"result\":{\"value\":\"bar\"}}",
+				out.toString());
+	}
+	
+	@Test
+	public void testResponse2() throws Exception {
+		// create client message
+		String requestMessage = "{\"jsonrpc\":\"2.0\","
+				+ "\"id\":42,\n" 
+				+ "\"method\":\"askServer\",\n" 
+				+ "\"params\": { value: \"bar\" }\n"
+				+ "}";
+		String clientMessage = getHeader(requestMessage.getBytes().length) + requestMessage;
+		
+		// create server side
+		ByteArrayInputStream in = new ByteArrayInputStream(clientMessage.getBytes());
+		ByteArrayOutputStream out = new ByteArrayOutputStream();
+		MyServer server = new MyServer() {
+			@Override
+			public CompletableFuture<MyParam> askServer(MyParam param) {
+				return CompletableFuture.completedFuture(param);
+			}
+		};
+		Launcher<MyClient> serverSideLauncher = Launcher.createLauncher(server, MyClient.class, in, out);
+		serverSideLauncher.startListening().get(TIMEOUT, TimeUnit.MILLISECONDS);
+		
+		Assert.assertEquals("Content-Length: 50" + CRLF + CRLF
+				+ "{\"jsonrpc\":\"2.0\",\"id\":42,\"result\":{\"value\":\"bar\"}}",
+				out.toString());
+	}
+
+	@Test
 	public void testCancellation() throws Exception {
 		// create client side
 		PipedInputStream in = new PipedInputStream();

--- a/org.eclipse.lsp4j/src/test/java/org/eclipse/lsp4j/test/services/JsonParseTest.xtend
+++ b/org.eclipse.lsp4j/src/test/java/org/eclipse/lsp4j/test/services/JsonParseTest.xtend
@@ -77,7 +77,7 @@ class JsonParseTest {
 			}
 		'''.assertParse(new RequestMessage => [
 			jsonrpc = "2.0"
-			id = "1"
+			id = 1
 			method = MessageMethods.DOC_COMPLETION
 			params = new TextDocumentPositionParams => [
 				textDocument = new TextDocumentIdentifier => [

--- a/org.eclipse.lsp4j/src/test/xtend-gen/org/eclipse/lsp4j/test/services/JsonParseTest.java
+++ b/org.eclipse.lsp4j/src/test/xtend-gen/org/eclipse/lsp4j/test/services/JsonParseTest.java
@@ -115,7 +115,7 @@ public class JsonParseTest {
     RequestMessage _requestMessage = new RequestMessage();
     final Procedure1<RequestMessage> _function = (RequestMessage it) -> {
       it.setJsonrpc("2.0");
-      it.setId("1");
+      it.setId(1);
       it.setMethod(MessageMethods.DOC_COMPLETION);
       TextDocumentPositionParams _textDocumentPositionParams = new TextDocumentPositionParams();
       final Procedure1<TextDocumentPositionParams> _function_1 = (TextDocumentPositionParams it_1) -> {


### PR DESCRIPTION
`id` fields in RequestMessage and ResponseMessage now accept both String and int values as demanded by [the specification](http://www.jsonrpc.org/specification). The id of every response is exactly the same value as given by the corresponding request, i.e. a String yields a String and an int yields an int.

Fixes #138.