### PR TITLE
Support multiple local and remote services

### DIFF
--- a/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/DebugLauncher.java
+++ b/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/DebugLauncher.java
@@ -188,16 +188,16 @@ public interface DebugLauncher<T> extends Launcher<T> {
 		}
 
 		MessageJsonHandler jsonHandler = new DebugMessageJsonHandler(supportedMethods, configureGson);
-		MessageConsumer outGoingMessageStream = new StreamMessageConsumer(out, jsonHandler);
-		outGoingMessageStream = wrapper.apply(outGoingMessageStream);
-		RemoteEndpoint serverEndpoint = new DebugRemoteEndpoint(outGoingMessageStream,
+		MessageConsumer outgoingMessageStream = new StreamMessageConsumer(out, jsonHandler);
+		outgoingMessageStream = wrapper.apply(outgoingMessageStream);
+		RemoteEndpoint remoteEndpoint = new DebugRemoteEndpoint(outgoingMessageStream,
 				ServiceEndpoints.toEndpoint(localService));
-		jsonHandler.setMethodProvider(serverEndpoint);
+		jsonHandler.setMethodProvider(remoteEndpoint);
 		// wrap incoming message stream
-		MessageConsumer messageConsumer = wrapper.apply(serverEndpoint);
+		MessageConsumer messageConsumer = wrapper.apply(remoteEndpoint);
 		StreamMessageProducer reader = new StreamMessageProducer(in, jsonHandler);
 
-		T remoteProxy = ServiceEndpoints.toServiceObject(serverEndpoint, remoteInterface);
+		T remoteProxy = ServiceEndpoints.toServiceObject(remoteEndpoint, remoteInterface);
 
 		return new DebugLauncher<T>() {
 
@@ -209,6 +209,11 @@ public interface DebugLauncher<T> extends Launcher<T> {
 			@Override
 			public T getRemoteProxy() {
 				return remoteProxy;
+			}
+
+			@Override
+			public RemoteEndpoint getRemoteEndpoint() {
+				return remoteEndpoint;
 			}
 
 		};

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/Launcher.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/Launcher.java
@@ -10,6 +10,8 @@ package org.eclipse.lsp4j.jsonrpc;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -119,7 +121,7 @@ public interface Launcher<T> {
 	 * The {@code configureGson} function can be used to register additional type adapters in the {@link GsonBuilder}
 	 * in order to support protocol classes that cannot be handled by Gson's reflective capabilities.
 	 * 
-	 * @param localService - an object on which classes RPC methods are looked up
+	 * @param localService - the object that receives method calls from the remote service
 	 * @param remoteInterface - an interface on which RPC methods are looked up
 	 * @param in - inputstream to listen for incoming messages
 	 * @param out - outputstream to send outgoing messages
@@ -129,29 +131,17 @@ public interface Launcher<T> {
 	 */
 	static <T> Launcher<T> createIoLauncher(Object localService, Class<T> remoteInterface, InputStream in, OutputStream out,
 			ExecutorService executorService, Function<MessageConsumer, MessageConsumer> wrapper, Consumer<GsonBuilder> configureGson) {
-		Map<String, JsonRpcMethod> supportedMethods = new LinkedHashMap<String, JsonRpcMethod>();
-		supportedMethods.putAll(ServiceEndpoints.getSupportedMethods(remoteInterface));
+		Collection<Object> localServiceList = Collections.singletonList(localService);
+		Collection<Class<?>> remoteInterfaceList = Collections.singletonList(remoteInterface);
+		MessageJsonHandler jsonHandler = setupJsonHandler(localServiceList, remoteInterfaceList, configureGson);
+		RemoteEndpoint remoteEndpoint = setupRemoteEndpoint(localServiceList, out, jsonHandler, wrapper);
 		
-		if (localService instanceof JsonRpcMethodProvider) {
-			JsonRpcMethodProvider rpcMethodProvider = (JsonRpcMethodProvider) localService;
-			supportedMethods.putAll(rpcMethodProvider.supportedMethods());
-		} else {
-			supportedMethods.putAll(ServiceEndpoints.getSupportedMethods(localService.getClass()));
-		}
-		
-		MessageJsonHandler jsonHandler = new MessageJsonHandler(supportedMethods, configureGson);
-		MessageConsumer outGoingMessageStream = new StreamMessageConsumer(out, jsonHandler);
-		outGoingMessageStream = wrapper.apply(outGoingMessageStream);
-		RemoteEndpoint serverEndpoint = new RemoteEndpoint(outGoingMessageStream, ServiceEndpoints.toEndpoint(localService));
-		jsonHandler.setMethodProvider(serverEndpoint);
-		// wrap incoming message stream
-		MessageConsumer messageConsumer = wrapper.apply(serverEndpoint);
+		MessageConsumer messageConsumer = wrapper.apply(remoteEndpoint);
 		StreamMessageProducer reader = new StreamMessageProducer(in, jsonHandler);
 		
-		T remoteProxy = ServiceEndpoints.toServiceObject(serverEndpoint, remoteInterface);
+		T remoteProxy = ServiceEndpoints.toServiceObject(remoteEndpoint, remoteInterface);
 		
 		return new Launcher<T> () {
-
 			@Override
 			public Future<?> startListening() {
 				return ConcurrentMessageProcessor.startProcessing(reader, messageConsumer, executorService);
@@ -161,12 +151,117 @@ public interface Launcher<T> {
 			public T getRemoteProxy() {
 				return remoteProxy;
 			}
-			
+
+			@Override
+			public RemoteEndpoint getRemoteEndpoint() {
+				return remoteEndpoint;
+			}
 		};
 	}
 	
+	/**
+	 * Create a new Launcher for a collection of local service objects, a collection of remote interfaces and an
+	 * input and output stream. Threads are started with the given executor service. The wrapper function is applied
+	 * to the incoming and outgoing message streams so additional message handling such as validation and tracing
+	 * can be included. The {@code configureGson} function can be used to register additional type adapters in
+	 * the {@link GsonBuilder} in order to support protocol classes that cannot be handled by Gson's reflective
+	 * capabilities.
+	 * 
+	 * @param localServices - the objects that receive method calls from the remote services
+	 * @param remoteInterfaces - interfaces on which RPC methods are looked up
+	 * @param classLoader - a class loader that is able to resolve all given interfaces
+	 * @param in - inputstream to listen for incoming messages
+	 * @param out - outputstream to send outgoing messages
+	 * @param executorService - the executor service used to start threads
+	 * @param wrapper - a function for plugging in additional message consumers
+	 * @param configureGson - a function for Gson configuration
+	 */
+	static Launcher<Object> createIoLauncher(Collection<Object> localServices, Collection<Class<?>> remoteInterfaces, ClassLoader classLoader,
+			InputStream in, OutputStream out, ExecutorService executorService, Function<MessageConsumer, MessageConsumer> wrapper,
+			Consumer<GsonBuilder> configureGson) {
+		MessageJsonHandler jsonHandler = setupJsonHandler(localServices, remoteInterfaces, configureGson);
+		RemoteEndpoint remoteEndpoint = setupRemoteEndpoint(localServices, out, jsonHandler, wrapper);
+		
+		MessageConsumer messageConsumer = wrapper.apply(remoteEndpoint);
+		StreamMessageProducer reader = new StreamMessageProducer(in, jsonHandler);
+		
+		Object remoteProxy = ServiceEndpoints.toServiceObject(remoteEndpoint, remoteInterfaces, classLoader);
+		
+		return new Launcher<Object> () {
+			@Override
+			public Future<?> startListening() {
+				return ConcurrentMessageProcessor.startProcessing(reader, messageConsumer, executorService);
+			}
+			
+			@Override
+			public Object getRemoteProxy() {
+				return remoteProxy;
+			}
+			
+			@Override
+			public RemoteEndpoint getRemoteEndpoint() {
+				return remoteEndpoint;
+			}
+		};
+	}
+	
+	/**
+	 * Set up the JSON handler for messages between the given local and remote services.
+	 */
+	static MessageJsonHandler setupJsonHandler(Collection<Object> localServices, Collection<Class<?>> remoteInterfaces, Consumer<GsonBuilder> configureGson) {
+		Map<String, JsonRpcMethod> supportedMethods = new LinkedHashMap<String, JsonRpcMethod>();
+		// Gather the supported methods of remote interfaces
+		for (Class<?> interface_ : remoteInterfaces) {
+			supportedMethods.putAll(ServiceEndpoints.getSupportedMethods(interface_));
+		}
+		
+		// Gather the supported methods of local services
+		for (Object localService : localServices) {
+			if (localService instanceof JsonRpcMethodProvider) {
+				JsonRpcMethodProvider rpcMethodProvider = (JsonRpcMethodProvider) localService;
+				supportedMethods.putAll(rpcMethodProvider.supportedMethods());
+			} else {
+				supportedMethods.putAll(ServiceEndpoints.getSupportedMethods(localService.getClass()));
+			}
+		}
+		
+		if (configureGson != null)
+			return new MessageJsonHandler(supportedMethods, configureGson);
+		else
+			return new MessageJsonHandler(supportedMethods);
+	}
+	
+	/**
+	 * Set up the remote endpoint that communicates with the local services.
+	 */
+	static RemoteEndpoint setupRemoteEndpoint(Collection<Object> localServices, OutputStream out, MessageJsonHandler jsonHandler,
+			Function<MessageConsumer, MessageConsumer> wrapper) {
+		MessageConsumer outgoingMessageStream = new StreamMessageConsumer(out, jsonHandler);
+		outgoingMessageStream = wrapper.apply(outgoingMessageStream);
+		RemoteEndpoint remoteEndpoint = new RemoteEndpoint(outgoingMessageStream, ServiceEndpoints.toEndpoint(localServices));
+		jsonHandler.setMethodProvider(remoteEndpoint);
+		return remoteEndpoint;
+	}
+	
+	
+	//---------------------------- Interface Methods ----------------------------//
+	
+	/**
+	 * Start a thread that listens to the input stream. The thread terminates when the stream is closed.
+	 * 
+	 * @return a future that returns {@code null} when the listener thread is terminated
+	 */
 	Future<?> startListening();
 	
+	/**
+	 * Returns the proxy instance that implements the remote service interfaces.
+	 */
 	T getRemoteProxy();
+	
+	/**
+	 * Returns the remote endpoint. Use this one to send generic {@code request} or {@code notify} methods
+	 * to the remote services.
+	 */
+	RemoteEndpoint getRemoteEndpoint();
 	
 }

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/services/GenericEndpoint.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/services/GenericEndpoint.java
@@ -9,6 +9,9 @@ package org.eclipse.lsp4j.jsonrpc.services;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -26,7 +29,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
 
 /**
  * An endpoint that reflectively delegates to {@link JsonNotification} and
- * {@link JsonRequest} methods of a given delegate object.
+ * {@link JsonRequest} methods of one or more given delegate objects.
  */
 public class GenericEndpoint implements Endpoint {
 	
@@ -34,11 +37,18 @@ public class GenericEndpoint implements Endpoint {
 	private static final Object[] NO_ARGUMENTS = {};
 
 	private final LinkedHashMap<String, Function<Object, CompletableFuture<Object>>> methodHandlers = new LinkedHashMap<>();
-	private final Object delegate;
+	private final List<Object> delegates;
 
 	public GenericEndpoint(Object delegate) {
-		this.delegate = delegate;
+		this.delegates = Collections.singletonList(delegate);
 		recursiveFindRpcMethods(delegate, new HashSet<>(), new HashSet<>());
+	}
+	
+	public GenericEndpoint(Collection<Object> delegates) {
+		this.delegates = new ArrayList<>(delegates);
+		for (Object delegate : this.delegates) {
+			recursiveFindRpcMethods(delegate, new HashSet<>(), new HashSet<>());
+		}
 	}
 
 	protected void recursiveFindRpcMethods(Object current, Set<Class<?>> visited, Set<Class<?>> visitedForDelegate) {
@@ -100,13 +110,24 @@ public class GenericEndpoint implements Endpoint {
 
 	@Override
 	public CompletableFuture<?> request(String method, Object parameter) {
+		// Check the registered method handlers
 		Function<Object, CompletableFuture<Object>> handler = methodHandlers.get(method);
 		if (handler != null) {
 			return handler.apply(parameter);
 		}
-		if (delegate instanceof Endpoint) {
-			return ((Endpoint) delegate).request(method, parameter);
+		
+		// Ask the delegate objects whether they can handle the request generically
+		List<CompletableFuture<?>> futures = new ArrayList<>(delegates.size());
+		for (Object delegate : delegates) {
+			if (delegate instanceof Endpoint) {
+				futures.add(((Endpoint) delegate).request(method, parameter));
+			}
 		}
+		if (!futures.isEmpty()) {
+			return CompletableFuture.anyOf(futures.toArray(new CompletableFuture[futures.size()]));
+		}
+		
+		// Create a log message about the unsupported method
 		String message = "Unsupported request method: " + method;
 		if (isOptionalMethod(method)) {
 			LOG.log(Level.INFO, message);
@@ -121,20 +142,30 @@ public class GenericEndpoint implements Endpoint {
 
 	@Override
 	public void notify(String method, Object parameter) {
+		// Check the registered method handlers
 		Function<Object, CompletableFuture<Object>> handler = methodHandlers.get(method);
 		if (handler != null) {
 			handler.apply(parameter);
 			return;
 		}
-		if (delegate instanceof Endpoint) {
-			((Endpoint) delegate).notify(method, parameter);
-			return;
+		
+		// Ask the delegate objects whether they can handle the notification generically
+		int notifiedDelegates = 0;
+		for (Object delegate : delegates) {
+			if (delegate instanceof Endpoint) {
+				((Endpoint) delegate).notify(method, parameter);
+				notifiedDelegates++;
+			}
 		}
-		String message = "Unsupported notification method: " + method;
-		if (isOptionalMethod(method)) {
-			LOG.log(Level.INFO, message);
-		} else {
-			LOG.log(Level.WARNING, message);
+		
+		if (notifiedDelegates == 0) {
+			// Create a log message about the unsupported method
+			String message = "Unsupported notification method: " + method;
+			if (isOptionalMethod(method)) {
+				LOG.log(Level.INFO, message);
+			} else {
+				LOG.log(Level.WARNING, message);
+			}
 		}
 	}
 	

--- a/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/annotations/impl/GenericEndpointTest.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/annotations/impl/GenericEndpointTest.java
@@ -38,6 +38,17 @@ public class GenericEndpointTest {
 		}
 
 	}
+	
+	public static class Bar {
+		
+		public int calls = 0;
+		
+		@JsonNotification
+		public void barrr() {
+			calls++;
+		}
+		
+	}
 
 	public static interface MyIf {
 
@@ -57,13 +68,25 @@ public class GenericEndpointTest {
 
 	@Test
 	public void testSimple() {
-
 		Foo foo = new Foo();
 		GenericEndpoint endpoint = new GenericEndpoint(foo);
 		endpoint.notify("myNotification", null);
 		endpoint.notify("other/myNotification", null);
 
 		Assert.assertEquals(2, foo.calls);
+	}
+	
+	@Test
+	public void testMultiServices() {
+		Foo foo = new Foo();
+		Bar bar = new Bar();
+		GenericEndpoint endpoint = new GenericEndpoint(Arrays.asList(foo, bar));
+		endpoint.notify("myNotification", null);
+		endpoint.notify("barrr", null);
+		endpoint.notify("other/myNotification", null);
+		
+		Assert.assertEquals(2, foo.calls);
+		Assert.assertEquals(1, bar.calls);
 	}
 
 	@Test


### PR DESCRIPTION
This extends LSP4J so it can handle multiple local service classes as well as multiple remote service interfaces.

Fixes #143.