### PR TITLE
Resolved Java 9 compatibility issue

### DIFF
--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/adapters/CollectionTypeAdapter.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/adapters/CollectionTypeAdapter.java
@@ -64,8 +64,6 @@ public class CollectionTypeAdapter<E> extends TypeAdapter<Collection<E>> {
 		protected <E> Supplier<Collection<E>> getConstructor(Class<? extends Collection<E>> rawType) {
 			try {
 				Constructor<? extends Collection<E>> constructor = rawType.getDeclaredConstructor();
-				if (!constructor.isAccessible())
-					constructor.setAccessible(true);
 				return () -> {
 					try {
 						return constructor.newInstance();
@@ -73,24 +71,15 @@ public class CollectionTypeAdapter<E> extends TypeAdapter<Collection<E>> {
 						throw new JsonParseException(e);
 					}
 				};
-			} catch (NoSuchMethodException e) {
-				if (SortedSet.class.isAssignableFrom(rawType)) {
-					return () -> {
-						return new TreeSet<E>();
-					};
-				} else if (Set.class.isAssignableFrom(rawType)) {
-					return () -> {
-						return new LinkedHashSet<E>();
-					};
-				} else if (Queue.class.isAssignableFrom(rawType)) {
-					return () -> {
-						return new LinkedList<E>();
-					};
-				} else {
-					return () -> {
-						return new ArrayList<E>();
-					};
-				}
+			} catch (Exception e) {
+				if (SortedSet.class.isAssignableFrom(rawType))
+					return () -> new TreeSet<E>();
+				else if (Set.class.isAssignableFrom(rawType))
+					return () -> new LinkedHashSet<E>();
+				else if (Queue.class.isAssignableFrom(rawType))
+					return () -> new LinkedList<E>();
+				else
+					return () -> new ArrayList<E>();
 			}
 		}
 

--- a/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/json/MessageJsonHandlerTest.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/json/MessageJsonHandlerTest.java
@@ -7,6 +7,7 @@
  *******************************************************************************/
 package org.eclipse.lsp4j.jsonrpc.test.json;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -45,7 +46,7 @@ public class MessageJsonHandlerTest {
 
 	@SuppressWarnings({ "unchecked" })
 	@Test
-	public void testParseList() {
+	public void testParseList_01() {
 		Map<String, JsonRpcMethod> supportedMethods = new LinkedHashMap<>();
 		supportedMethods.put("foo", JsonRpcMethod.request("foo",
 				new TypeToken<List<? extends Entry>>() {}.getType(),
@@ -61,7 +62,7 @@ public class MessageJsonHandlerTest {
 				+ "  {\"name\":\"additionalProperties\",\"kind\":17,\"location\":{\"uri\":\"file:/home/mistria/runtime-EclipseApplication-with-patch/EclipseConEurope/something.json\",\"range\":{\"start\":{\"line\":4,\"character\":4},\"end\":{\"line\":4,\"character\":32}}}},\n"
 				+ "  {\"name\":\"properties\",\"kind\":15,\"location\":{\"uri\":\"file:/home/mistria/runtime-EclipseApplication-with-patch/EclipseConEurope/something.json\",\"range\":{\"start\":{\"line\":5,\"character\":3},\"end\":{\"line\":5,\"character\":20}}}}\n"
 				+ "]}");
-		List<? extends Entry> result = (List<? extends Entry>) ((ResponseMessage)message).getResult();
+		List<? extends Entry> result = (List<? extends Entry>) ((ResponseMessage) message).getResult();
 		Assert.assertEquals(5, result.size());
 		for (Entry e : result) {
 			Assert.assertTrue(e.location.uri, e.location.uri.startsWith("file:/home/mistria"));
@@ -93,6 +94,29 @@ public class MessageJsonHandlerTest {
 		}
 	}
 	
+	@Test
+	public void testSerializeEmptyList() {
+		MessageJsonHandler handler = new MessageJsonHandler(Collections.emptyMap());
+		NotificationMessage message = new NotificationMessage();
+		message.setMethod("foo");
+		message.setParams(Collections.EMPTY_LIST);
+		String json = handler.serialize(message);
+		Assert.assertEquals("{\"jsonrpc\":\"2.0\",\"method\":\"foo\",\"params\":[]}", json);
+	}
+	
+	@Test
+	public void testSerializeImmutableList() {
+		MessageJsonHandler handler = new MessageJsonHandler(Collections.emptyMap());
+		NotificationMessage message = new NotificationMessage();
+		message.setMethod("foo");
+		List<Object> list = new ArrayList<>();
+		list.add("a");
+		list.add("b");
+		message.setParams(Collections.unmodifiableList(list));
+		String json = handler.serialize(message);
+		Assert.assertEquals("{\"jsonrpc\":\"2.0\",\"method\":\"foo\",\"params\":[\"a\",\"b\"]}", json);
+	}
+	
 	@SuppressWarnings({ "unchecked" })
 	@Test
 	public void testEither_01() {
@@ -119,7 +143,7 @@ public class MessageJsonHandlerTest {
 				+ "}");
 		result = (Either<String, List<Map<String,String>>>) ((ResponseMessage)message).getResult();
 		Assert.assertFalse(result.isRight());
-		Assert.assertEquals("name",result.getLeft());
+		Assert.assertEquals("name", result.getLeft());
 	}
 	
 	@SuppressWarnings({ "unchecked" })


### PR DESCRIPTION
The line `constructor.setAccessible(true)` yields a warning with Java 9 when applied to `Collections.EMPTY_LIST`. In our context it's ok to omit it because the class `Collections.EmptyList` is never referenced in the type of a data field.

Fixes #157.