### PR TITLE
make sure UTF-8 is used for java compile and javadoc

### DIFF
--- a/gradle/java-compiler-settings.gradle
+++ b/gradle/java-compiler-settings.gradle
@@ -10,6 +10,11 @@ sourceCompatibility = '1.8'
 
 tasks.withType(Javadoc) {
 	options.addStringOption('Xdoclint:none', '-quiet')
+	options.encoding = 'UTF-8'
+}
+
+tasks.withType(JavaCompile) {
+	options.encoding = 'UTF-8'
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {


### PR DESCRIPTION
make sure UTF-8 is used for java compile and javadoc
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>