### PR TITLE
Implemented builder class for Launcher

### DIFF
--- a/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/launch/DSPLauncher.java
+++ b/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/launch/DSPLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 TypeFox GmbH (http://www.typefox.io) and others.
+ * Copyright (c) 2016-2018 TypeFox GmbH (http://www.typefox.io) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -18,34 +18,94 @@ import org.eclipse.lsp4j.debug.services.IDebugProtocolServer;
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.jsonrpc.MessageConsumer;
 import org.eclipse.lsp4j.jsonrpc.debug.DebugLauncher;
+import org.eclipse.lsp4j.jsonrpc.validation.ReflectiveMessageValidator;
 
-public class DSPLauncher {
+/**
+ * Specialized launcher for the debug protocol.
+ */
+public final class DSPLauncher {
+	
+	private DSPLauncher() {}
 
+	/**
+	 * Create a new Launcher for a debug server and an input and output stream.
+	 * 
+	 * @param server - the server that receives method calls from the remote client
+	 * @param in - input stream to listen for incoming messages
+	 * @param out - output stream to send outgoing messages
+	 */
 	public static Launcher<IDebugProtocolClient> createServerLauncher(IDebugProtocolServer server, InputStream in,
 			OutputStream out) {
 		return DebugLauncher.createLauncher(server, IDebugProtocolClient.class, in, out);
 	}
 
+	/**
+	 * Create a new Launcher for a debug server and an input and output stream, and set up message validation and tracing.
+	 * 
+	 * @param server - the server that receives method calls from the remote client
+	 * @param in - input stream to listen for incoming messages
+	 * @param out - output stream to send outgoing messages
+	 * @param validate - whether messages should be validated with the {@link ReflectiveMessageValidator}
+	 * @param trace - a writer to which incoming and outgoing messages are traced, or {@code null} to disable tracing
+	 */
 	public static Launcher<IDebugProtocolClient> createServerLauncher(IDebugProtocolServer server, InputStream in,
 			OutputStream out, boolean validate, PrintWriter trace) {
 		return DebugLauncher.createLauncher(server, IDebugProtocolClient.class, in, out, validate, trace);
 	}
 
+	/**
+	 * Create a new Launcher for a debug server and an input and output stream. Threads are started with the given
+	 * executor service. The wrapper function is applied to the incoming and outgoing message streams so additional
+	 * message handling such as validation and tracing can be included.
+	 * 
+	 * @param server - the server that receives method calls from the remote client
+	 * @param in - input stream to listen for incoming messages
+	 * @param out - output stream to send outgoing messages
+	 * @param executorService - the executor service used to start threads
+	 * @param wrapper - a function for plugging in additional message consumers
+	 */
 	public static Launcher<IDebugProtocolClient> createServerLauncher(IDebugProtocolServer server, InputStream in,
 			OutputStream out, ExecutorService executorService, Function<MessageConsumer, MessageConsumer> wrapper) {
 		return DebugLauncher.createLauncher(server, IDebugProtocolClient.class, in, out, executorService, wrapper);
 	}
 
+	/**
+	 * Create a new Launcher for a debug client and an input and output stream.
+	 * 
+	 * @param client - the client that receives method calls from the remote server
+	 * @param in - input stream to listen for incoming messages
+	 * @param out - output stream to send outgoing messages
+	 */
 	public static Launcher<IDebugProtocolServer> createClientLauncher(IDebugProtocolClient client, InputStream in,
 			OutputStream out) {
 		return DebugLauncher.createLauncher(client, IDebugProtocolServer.class, in, out);
 	}
 
+	/**
+	 * Create a new Launcher for a debug client and an input and output stream, and set up message validation and tracing.
+	 * 
+	 * @param client - the client that receives method calls from the remote server
+	 * @param in - input stream to listen for incoming messages
+	 * @param out - output stream to send outgoing messages
+	 * @param validate - whether messages should be validated with the {@link ReflectiveMessageValidator}
+	 * @param trace - a writer to which incoming and outgoing messages are traced, or {@code null} to disable tracing
+	 */
 	public static Launcher<IDebugProtocolServer> createClientLauncher(IDebugProtocolClient client, InputStream in,
 			OutputStream out, boolean validate, PrintWriter trace) {
 		return DebugLauncher.createLauncher(client, IDebugProtocolServer.class, in, out, validate, trace);
 	}
 
+	/**
+	 * Create a new Launcher for a debug client and an input and output stream. Threads are started with the given
+	 * executor service. The wrapper function is applied to the incoming and outgoing message streams so additional
+	 * message handling such as validation and tracing can be included.
+	 * 
+	 * @param client - the client that receives method calls from the remote server
+	 * @param in - input stream to listen for incoming messages
+	 * @param out - output stream to send outgoing messages
+	 * @param executorService - the executor service used to start threads
+	 * @param wrapper - a function for plugging in additional message consumers
+	 */
 	public static Launcher<IDebugProtocolServer> createClientLauncher(IDebugProtocolClient client, InputStream in,
 			OutputStream out, ExecutorService executorService, Function<MessageConsumer, MessageConsumer> wrapper) {
 		return DebugLauncher.createLauncher(client, IDebugProtocolServer.class, in, out, executorService, wrapper);

--- a/org.eclipse.lsp4j.jsonrpc.debug/src/test/java/org/eclipse/lsp4j/jsonrpc/debug/test/DebugIntegrationTest.java
+++ b/org.eclipse.lsp4j.jsonrpc.debug/src/test/java/org/eclipse/lsp4j/jsonrpc/debug/test/DebugIntegrationTest.java
@@ -22,6 +22,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.eclipse.lsp4j.jsonrpc.CompletableFutures;
+import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.jsonrpc.RemoteEndpoint;
 import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
 import org.eclipse.lsp4j.jsonrpc.debug.DebugLauncher;
@@ -70,7 +71,7 @@ public class DebugIntegrationTest {
 				return CompletableFuture.completedFuture(param);
 			}
 		};
-		DebugLauncher<MyServer> clientSideLauncher = DebugLauncher.createLauncher(client, MyServer.class, in, out);
+		Launcher<MyServer> clientSideLauncher = DebugLauncher.createLauncher(client, MyServer.class, in, out);
 
 		// create server side
 		MyServer server = new MyServer() {
@@ -79,7 +80,7 @@ public class DebugIntegrationTest {
 				return CompletableFuture.completedFuture(param);
 			}
 		};
-		DebugLauncher<MyClient> serverSideLauncher = DebugLauncher.createLauncher(server, MyClient.class, in2, out2);
+		Launcher<MyClient> serverSideLauncher = DebugLauncher.createLauncher(server, MyClient.class, in2, out2);
 
 		clientSideLauncher.startListening();
 		serverSideLauncher.startListening();
@@ -125,7 +126,7 @@ public class DebugIntegrationTest {
 				});
 			}
 		};
-		DebugLauncher<MyServer> clientSideLauncher = DebugLauncher.createLauncher(client, MyServer.class, in, out);
+		Launcher<MyServer> clientSideLauncher = DebugLauncher.createLauncher(client, MyServer.class, in, out);
 
 		// create server side
 		MyServer server = new MyServer() {
@@ -134,7 +135,7 @@ public class DebugIntegrationTest {
 				return CompletableFuture.completedFuture(param);
 			}
 		};
-		DebugLauncher<MyClient> serverSideLauncher = DebugLauncher.createLauncher(server, MyClient.class, in2, out2);
+		Launcher<MyClient> serverSideLauncher = DebugLauncher.createLauncher(server, MyClient.class, in2, out2);
 
 		clientSideLauncher.startListening();
 		serverSideLauncher.startListening();
@@ -197,7 +198,7 @@ public class DebugIntegrationTest {
 				});
 			}
 		};
-		DebugLauncher<MyClient> serverSideLauncher = DebugLauncher.createLauncher(server, MyClient.class, in, out);
+		Launcher<MyClient> serverSideLauncher = DebugLauncher.createLauncher(server, MyClient.class, in, out);
 		serverSideLauncher.startListening().get(TIMEOUT, TimeUnit.MILLISECONDS);
 
 		Assert.assertEquals("Content-Length: 163\r\n\r\n" +
@@ -234,7 +235,7 @@ public class DebugIntegrationTest {
 				});
 			}
 		};
-		DebugLauncher<MyServer> clientSideLauncher = DebugLauncher.createLauncher(client, MyServer.class, in, out);
+		Launcher<MyServer> clientSideLauncher = DebugLauncher.createLauncher(client, MyServer.class, in, out);
 
 		// create server side
 		MyServer server = new MyServer() {
@@ -243,7 +244,7 @@ public class DebugIntegrationTest {
 				return CompletableFuture.completedFuture(param);
 			}
 		};
-		DebugLauncher<MyClient> serverSideLauncher = DebugLauncher.createLauncher(server, MyClient.class, in2, out2);
+		Launcher<MyClient> serverSideLauncher = DebugLauncher.createLauncher(server, MyClient.class, in2, out2);
 
 		clientSideLauncher.startListening();
 		serverSideLauncher.startListening();
@@ -295,7 +296,7 @@ public class DebugIntegrationTest {
 					return CompletableFuture.completedFuture(param);
 				}
 			};
-			DebugLauncher<MyClient> serverSideLauncher = DebugLauncher.createLauncher(server, MyClient.class, in, out);
+			Launcher<MyClient> serverSideLauncher = DebugLauncher.createLauncher(server, MyClient.class, in, out);
 			serverSideLauncher.startListening();
 
 			logMessages.await(Level.WARNING, "Unsupported notification method: foo1");
@@ -338,7 +339,7 @@ public class DebugIntegrationTest {
 					return CompletableFuture.completedFuture(param);
 				}
 			};
-			DebugLauncher<MyClient> serverSideLauncher = DebugLauncher.createLauncher(server, MyClient.class, in, out);
+			Launcher<MyClient> serverSideLauncher = DebugLauncher.createLauncher(server, MyClient.class, in, out);
 			serverSideLauncher.startListening();
 
 			logMessages.await(Level.INFO, "Unsupported notification method: $/foo1");
@@ -378,7 +379,7 @@ public class DebugIntegrationTest {
 				public void myNotification() {
 				}
 			};
-			DebugLauncher<MyClient> serverSideLauncher = DebugLauncher.createLauncher(server, MyClient.class, in, out);
+			Launcher<MyClient> serverSideLauncher = DebugLauncher.createLauncher(server, MyClient.class, in, out);
 			serverSideLauncher.startListening();
 
 			logMessages.await(Level.WARNING, "Unexpected params '{\"value\":\"foo\"}' for " + "'public abstract void "

--- a/org.eclipse.lsp4j.jsonrpc.debug/src/test/java/org/eclipse/lsp4j/jsonrpc/debug/test/DebugLauncherTest.java
+++ b/org.eclipse.lsp4j.jsonrpc.debug/src/test/java/org/eclipse/lsp4j/jsonrpc/debug/test/DebugLauncherTest.java
@@ -15,6 +15,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
+import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.jsonrpc.debug.DebugLauncher;
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
 import org.junit.Assert;
@@ -47,7 +48,7 @@ public class DebugLauncherTest {
 			public void say(Param p) {
 			}
 		};
-		DebugLauncher<A> launcher = DebugLauncher.createLauncher(a, A.class, new ByteArrayInputStream("".getBytes()), new ByteArrayOutputStream());
+		Launcher<A> launcher = DebugLauncher.createLauncher(a, A.class, new ByteArrayInputStream("".getBytes()), new ByteArrayOutputStream());
 		Future<?> startListening = launcher.startListening();
 		startListening.get(TIMEOUT, TimeUnit.MILLISECONDS);
 		Assert.assertTrue(startListening.isDone());
@@ -60,7 +61,7 @@ public class DebugLauncherTest {
 			public void say(Param p) {
 			}
 		};
-		DebugLauncher<A> launcher = DebugLauncher.createLauncher(a, A.class, new InputStream() {
+		Launcher<A> launcher = DebugLauncher.createLauncher(a, A.class, new InputStream() {
 			@Override
 			public int read() throws IOException {
 				try {
@@ -97,7 +98,7 @@ public class DebugLauncherTest {
 				return null;
 			}
 		};
-		DebugLauncher<A> launcher = DebugLauncher.createIoLauncher(a, A.class, new ByteArrayInputStream("".getBytes()), out,
+		Launcher<A> launcher = DebugLauncher.createIoLauncher(a, A.class, new ByteArrayInputStream("".getBytes()), out,
 				Executors.newCachedThreadPool(), c -> c,
 				gsonBuilder -> {gsonBuilder.registerTypeAdapter(Param.class, typeAdapter);});
 		A remoteProxy = launcher.getRemoteProxy();

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/Launcher.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/Launcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 TypeFox GmbH (http://www.typefox.io) and others.
+ * Copyright (c) 2016-2018 TypeFox GmbH (http://www.typefox.io) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -40,43 +40,41 @@ public interface Launcher<T> {
 	/**
 	 * Create a new Launcher for a given local service object, a given remote interface and an input and output stream.
 	 * 
-	 * @param localService - an object on which classes RPC methods are looked up
+	 * @param localService - the object that receives method calls from the remote service
 	 * @param remoteInterface - an interface on which RPC methods are looked up
-	 * @param in - inputstream to listen for incoming messages
-	 * @param out - outputstream to send outgoing messages
+	 * @param in - inputs tream to listen for incoming messages
+	 * @param out - output stream to send outgoing messages
 	 */
 	static <T> Launcher<T> createLauncher(Object localService, Class<T> remoteInterface, InputStream in, OutputStream out) {
-		return createLauncher(localService, remoteInterface, in, out, false, null);
+		return new Builder<T>()
+				.setLocalService(localService)
+				.setRemoteInterface(remoteInterface)
+				.setInput(in)
+				.setOutput(out)
+				.create();
 	}
 	
 	/**
 	 * Create a new Launcher for a given local service object, a given remote interface and an input and output stream,
 	 * and set up message validation and tracing.
 	 * 
-	 * @param localService - an object on which classes RPC methods are looked up
+	 * @param localService - the object that receives method calls from the remote service
 	 * @param remoteInterface - an interface on which RPC methods are looked up
-	 * @param in - inputstream to listen for incoming messages
-	 * @param out - outputstream to send outgoing messages
+	 * @param in - input stream to listen for incoming messages
+	 * @param out - output stream to send outgoing messages
 	 * @param validate - whether messages should be validated with the {@link ReflectiveMessageValidator}
 	 * @param trace - a writer to which incoming and outgoing messages are traced, or {@code null} to disable tracing
 	 */
 	static <T> Launcher<T> createLauncher(Object localService, Class<T> remoteInterface, InputStream in, OutputStream out,
 			boolean validate, PrintWriter trace) {
-		Function<MessageConsumer, MessageConsumer> wrapper = consumer -> {
-			MessageConsumer result = consumer;
-			if (trace != null) {
-				result = message -> {
-					trace.println(message);
-					trace.flush();
-					consumer.consume(message);
-				};
-			}
-			if (validate) {
-				result = new ReflectiveMessageValidator(result);
-			}
-			return result;
-		};
-		return createIoLauncher(localService, remoteInterface, in, out, Executors.newCachedThreadPool(), wrapper);
+		return new Builder<T>()
+				.setLocalService(localService)
+				.setRemoteInterface(remoteInterface)
+				.setInput(in)
+				.setOutput(out)
+				.validateMessages(validate)
+				.traceMessages(trace)
+				.create();
 	}
 	
 	/**
@@ -84,10 +82,10 @@ public interface Launcher<T> {
 	 * Threads are started with the given executor service. The wrapper function is applied to the incoming and
 	 * outgoing message streams so additional message handling such as validation and tracing can be included.
 	 * 
-	 * @param localService - an object on which classes RPC methods are looked up
+	 * @param localService - the object that receives method calls from the remote service
 	 * @param remoteInterface - an interface on which RPC methods are looked up
-	 * @param in - inputstream to listen for incoming messages
-	 * @param out - outputstream to send outgoing messages
+	 * @param in - input stream to listen for incoming messages
+	 * @param out - output stream to send outgoing messages
 	 * @param executorService - the executor service used to start threads
 	 * @param wrapper - a function for plugging in additional message consumers
 	 */
@@ -101,17 +99,23 @@ public interface Launcher<T> {
 	 * Threads are started with the given executor service. The wrapper function is applied to the incoming and
 	 * outgoing message streams so additional message handling such as validation and tracing can be included.
 	 * 
-	 * @param localService - an object on which classes RPC methods are looked up
+	 * @param localService - the object that receives method calls from the remote service
 	 * @param remoteInterface - an interface on which RPC methods are looked up
-	 * @param in - inputstream to listen for incoming messages
-	 * @param out - outputstream to send outgoing messages
+	 * @param in - input stream to listen for incoming messages
+	 * @param out - output stream to send outgoing messages
 	 * @param executorService - the executor service used to start threads
 	 * @param wrapper - a function for plugging in additional message consumers
 	 */
 	static <T> Launcher<T> createIoLauncher(Object localService, Class<T> remoteInterface, InputStream in, OutputStream out,
 			ExecutorService executorService, Function<MessageConsumer, MessageConsumer> wrapper) {
-		Consumer<GsonBuilder> configureGson = gsonBuilder -> {};
-		return createIoLauncher(localService, remoteInterface, in, out, executorService, wrapper, configureGson);
+		return new Builder<T>()
+				.setLocalService(localService)
+				.setRemoteInterface(remoteInterface)
+				.setInput(in)
+				.setOutput(out)
+				.setExecutorService(executorService)
+				.wrapMessages(wrapper)
+				.create();
 	}
 	
 	/**
@@ -123,40 +127,23 @@ public interface Launcher<T> {
 	 * 
 	 * @param localService - the object that receives method calls from the remote service
 	 * @param remoteInterface - an interface on which RPC methods are looked up
-	 * @param in - inputstream to listen for incoming messages
-	 * @param out - outputstream to send outgoing messages
+	 * @param in - input stream to listen for incoming messages
+	 * @param out - output stream to send outgoing messages
 	 * @param executorService - the executor service used to start threads
 	 * @param wrapper - a function for plugging in additional message consumers
 	 * @param configureGson - a function for Gson configuration
 	 */
 	static <T> Launcher<T> createIoLauncher(Object localService, Class<T> remoteInterface, InputStream in, OutputStream out,
 			ExecutorService executorService, Function<MessageConsumer, MessageConsumer> wrapper, Consumer<GsonBuilder> configureGson) {
-		Collection<Object> localServiceList = Collections.singletonList(localService);
-		Collection<Class<?>> remoteInterfaceList = Collections.singletonList(remoteInterface);
-		MessageJsonHandler jsonHandler = setupJsonHandler(localServiceList, remoteInterfaceList, configureGson);
-		RemoteEndpoint remoteEndpoint = setupRemoteEndpoint(localServiceList, out, jsonHandler, wrapper);
-		
-		MessageConsumer messageConsumer = wrapper.apply(remoteEndpoint);
-		StreamMessageProducer reader = new StreamMessageProducer(in, jsonHandler, remoteEndpoint);
-		
-		T remoteProxy = ServiceEndpoints.toServiceObject(remoteEndpoint, remoteInterface);
-		
-		return new Launcher<T> () {
-			@Override
-			public Future<Void> startListening() {
-				return ConcurrentMessageProcessor.startProcessing(reader, messageConsumer, executorService);
-			}
-
-			@Override
-			public T getRemoteProxy() {
-				return remoteProxy;
-			}
-
-			@Override
-			public RemoteEndpoint getRemoteEndpoint() {
-				return remoteEndpoint;
-			}
-		};
+		return new Builder<T>()
+				.setLocalService(localService)
+				.setRemoteInterface(remoteInterface)
+				.setInput(in)
+				.setOutput(out)
+				.setExecutorService(executorService)
+				.wrapMessages(wrapper)
+				.configureGson(configureGson)
+				.create();
 	}
 	
 	/**
@@ -170,8 +157,8 @@ public interface Launcher<T> {
 	 * @param localServices - the objects that receive method calls from the remote services
 	 * @param remoteInterfaces - interfaces on which RPC methods are looked up
 	 * @param classLoader - a class loader that is able to resolve all given interfaces
-	 * @param in - inputstream to listen for incoming messages
-	 * @param out - outputstream to send outgoing messages
+	 * @param in - input stream to listen for incoming messages
+	 * @param out - output stream to send outgoing messages
 	 * @param executorService - the executor service used to start threads
 	 * @param wrapper - a function for plugging in additional message consumers
 	 * @param configureGson - a function for Gson configuration
@@ -179,68 +166,201 @@ public interface Launcher<T> {
 	static Launcher<Object> createIoLauncher(Collection<Object> localServices, Collection<Class<?>> remoteInterfaces, ClassLoader classLoader,
 			InputStream in, OutputStream out, ExecutorService executorService, Function<MessageConsumer, MessageConsumer> wrapper,
 			Consumer<GsonBuilder> configureGson) {
-		MessageJsonHandler jsonHandler = setupJsonHandler(localServices, remoteInterfaces, configureGson);
-		RemoteEndpoint remoteEndpoint = setupRemoteEndpoint(localServices, out, jsonHandler, wrapper);
-		
-		MessageConsumer messageConsumer = wrapper.apply(remoteEndpoint);
-		StreamMessageProducer reader = new StreamMessageProducer(in, jsonHandler, remoteEndpoint);
-		
-		Object remoteProxy = ServiceEndpoints.toServiceObject(remoteEndpoint, remoteInterfaces, classLoader);
-		
-		return new Launcher<Object> () {
-			@Override
-			public Future<Void> startListening() {
-				return ConcurrentMessageProcessor.startProcessing(reader, messageConsumer, executorService);
-			}
-			
-			@Override
-			public Object getRemoteProxy() {
-				return remoteProxy;
-			}
-			
-			@Override
-			public RemoteEndpoint getRemoteEndpoint() {
-				return remoteEndpoint;
-			}
-		};
+		return new Builder<Object>()
+				.setLocalServices(localServices)
+				.setRemoteInterfaces(remoteInterfaces)
+				.setClassLoader(classLoader)
+				.setInput(in)
+				.setOutput(out)
+				.setExecutorService(executorService)
+				.wrapMessages(wrapper)
+				.configureGson(configureGson)
+				.create();
 	}
 	
+	
+	//------------------------------ Builder Class ------------------------------//
+	
 	/**
-	 * Set up the JSON handler for messages between the given local and remote services.
+	 * The launcher builder wires up all components for JSON-RPC communication.
 	 */
-	static MessageJsonHandler setupJsonHandler(Collection<Object> localServices, Collection<Class<?>> remoteInterfaces, Consumer<GsonBuilder> configureGson) {
-		Map<String, JsonRpcMethod> supportedMethods = new LinkedHashMap<String, JsonRpcMethod>();
-		// Gather the supported methods of remote interfaces
-		for (Class<?> interface_ : remoteInterfaces) {
-			supportedMethods.putAll(ServiceEndpoints.getSupportedMethods(interface_));
+	public static class Builder<T> {
+		
+		protected Collection<Object> localServices;
+		protected Collection<Class<? extends T>> remoteInterfaces;
+		protected InputStream input;
+		protected OutputStream output;
+		protected ExecutorService executorService;
+		protected Function<MessageConsumer, MessageConsumer> messageWrapper;
+		protected boolean validateMessages;
+		protected PrintWriter messageTracer;
+		protected Consumer<GsonBuilder> configureGson;
+		protected ClassLoader classLoader;
+		
+		public Builder<T> setLocalService(Object localService) {
+			this.localServices = Collections.singletonList(localService);
+			return this;
+		}
+
+		public Builder<T> setLocalServices(Collection<Object> localServices) {
+			this.localServices = localServices;
+			return this;
+		}
+
+		public Builder<T> setRemoteInterface(Class<? extends T> remoteInterface) {
+			this.remoteInterfaces = Collections.singletonList(remoteInterface);
+			return this;
 		}
 		
-		// Gather the supported methods of local services
-		for (Object localService : localServices) {
-			if (localService instanceof JsonRpcMethodProvider) {
-				JsonRpcMethodProvider rpcMethodProvider = (JsonRpcMethodProvider) localService;
-				supportedMethods.putAll(rpcMethodProvider.supportedMethods());
+		public Builder<T> setRemoteInterfaces(Collection<Class<? extends T>> remoteInterfaces) {
+			this.remoteInterfaces = remoteInterfaces;
+			return this;
+		}
+
+		public Builder<T> setInput(InputStream input) {
+			this.input = input;
+			return this;
+		}
+
+		public Builder<T> setOutput(OutputStream output) {
+			this.output = output;
+			return this;
+		}
+
+		public Builder<T> setExecutorService(ExecutorService executorService) {
+			this.executorService = executorService;
+			return this;
+		}
+
+		public Builder<T> setClassLoader(ClassLoader classLoader) {
+			this.classLoader = classLoader;
+			return this;
+		}
+
+		public Builder<T> wrapMessages(Function<MessageConsumer, MessageConsumer> wrapper) {
+			this.messageWrapper = wrapper;
+			return this;
+		}
+		
+		public Builder<T> validateMessages(boolean validate) {
+			this.validateMessages = validate;
+			return this;
+		}
+		
+		public Builder<T> traceMessages(PrintWriter tracer) {
+			this.messageTracer = tracer;
+			return this;
+		}
+
+		public Builder<T> configureGson(Consumer<GsonBuilder> configureGson) {
+			this.configureGson = configureGson;
+			return this;
+		}
+
+		@SuppressWarnings("unchecked")
+		public Launcher<T> create() {
+			if (input == null)
+				throw new IllegalStateException("Input stream must be configured.");
+			if (output == null)
+				throw new IllegalStateException("Output stream must be configured.");
+			if (localServices == null)
+				throw new IllegalStateException("Local service must be configured.");
+			if (remoteInterfaces == null)
+				throw new IllegalStateException("Remote interface must be configured.");
+			
+			MessageJsonHandler jsonHandler = createJsonHandler();
+			RemoteEndpoint remoteEndpoint = createRemoteEndpoint(jsonHandler);
+			T remoteProxy;
+			if (localServices.size() == 1 && remoteInterfaces.size() == 1) {
+				remoteProxy = ServiceEndpoints.toServiceObject(remoteEndpoint, remoteInterfaces.iterator().next());
 			} else {
-				supportedMethods.putAll(ServiceEndpoints.getSupportedMethods(localService.getClass()));
+				remoteProxy = (T) ServiceEndpoints.toServiceObject(remoteEndpoint, (Collection<Class<?>>) (Object) remoteInterfaces, classLoader);
 			}
+			StreamMessageProducer reader = new StreamMessageProducer(input, jsonHandler, remoteEndpoint);
+			MessageConsumer messageConsumer = wrapMessageConsumer(remoteEndpoint);
+			ExecutorService execService = executorService != null ? executorService : Executors.newCachedThreadPool();
+			
+			return new Launcher<T> () {
+				@Override
+				public Future<Void> startListening() {
+					return ConcurrentMessageProcessor.startProcessing(reader, messageConsumer, execService);
+				}
+
+				@Override
+				public T getRemoteProxy() {
+					return remoteProxy;
+				}
+
+				@Override
+				public RemoteEndpoint getRemoteEndpoint() {
+					return remoteEndpoint;
+				}
+			};
 		}
 		
-		if (configureGson != null)
-			return new MessageJsonHandler(supportedMethods, configureGson);
-		else
-			return new MessageJsonHandler(supportedMethods);
-	}
-	
-	/**
-	 * Set up the remote endpoint that communicates with the local services.
-	 */
-	static RemoteEndpoint setupRemoteEndpoint(Collection<Object> localServices, OutputStream out, MessageJsonHandler jsonHandler,
-			Function<MessageConsumer, MessageConsumer> wrapper) {
-		MessageConsumer outgoingMessageStream = new StreamMessageConsumer(out, jsonHandler);
-		outgoingMessageStream = wrapper.apply(outgoingMessageStream);
-		RemoteEndpoint remoteEndpoint = new RemoteEndpoint(outgoingMessageStream, ServiceEndpoints.toEndpoint(localServices));
-		jsonHandler.setMethodProvider(remoteEndpoint);
-		return remoteEndpoint;
+		protected MessageConsumer wrapMessageConsumer(MessageConsumer consumer) {
+			MessageConsumer result = consumer;
+			if (messageTracer != null) {
+				final PrintWriter tracer = messageTracer;
+				result = message -> {
+					tracer.println(message);
+					tracer.flush();
+					consumer.consume(message);
+				};
+			}
+			if (validateMessages) {
+				result = new ReflectiveMessageValidator(result);
+			}
+			if (messageWrapper != null) {
+				result = messageWrapper.apply(result);
+			}
+			return result;
+		}
+		
+		/**
+		 * Gather all JSON-RPC methods from the local and remote services.
+		 */
+		protected Map<String, JsonRpcMethod> getSupportedMethods() {
+			Map<String, JsonRpcMethod> supportedMethods = new LinkedHashMap<>();
+			// Gather the supported methods of remote interfaces
+			for (Class<?> interface_ : remoteInterfaces) {
+				supportedMethods.putAll(ServiceEndpoints.getSupportedMethods(interface_));
+			}
+			
+			// Gather the supported methods of local services
+			for (Object localService : localServices) {
+				if (localService instanceof JsonRpcMethodProvider) {
+					JsonRpcMethodProvider rpcMethodProvider = (JsonRpcMethodProvider) localService;
+					supportedMethods.putAll(rpcMethodProvider.supportedMethods());
+				} else {
+					supportedMethods.putAll(ServiceEndpoints.getSupportedMethods(localService.getClass()));
+				}
+			}
+			
+			return supportedMethods;
+		}
+		
+		/**
+		 * Create the JSON handler for messages between the local and remote services.
+		 */
+		protected MessageJsonHandler createJsonHandler() {
+			Map<String, JsonRpcMethod> supportedMethods = getSupportedMethods();
+			if (configureGson != null)
+				return new MessageJsonHandler(supportedMethods, configureGson);
+			else
+				return new MessageJsonHandler(supportedMethods);
+		}
+		
+		/**
+		 * Create the remote endpoint that communicates with the local services.
+		 */
+		protected RemoteEndpoint createRemoteEndpoint(MessageJsonHandler jsonHandler) {
+			MessageConsumer outgoingMessageStream = new StreamMessageConsumer(output, jsonHandler);
+			outgoingMessageStream = wrapMessageConsumer(outgoingMessageStream);
+			RemoteEndpoint remoteEndpoint = new RemoteEndpoint(outgoingMessageStream, ServiceEndpoints.toEndpoint(localServices));
+			jsonHandler.setMethodProvider(remoteEndpoint);
+			return remoteEndpoint;
+		}
 	}
 	
 	

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/launch/LSPLauncher.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/launch/LSPLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 TypeFox GmbH (http://www.typefox.io) and others.
+ * Copyright (c) 2016-2018 TypeFox GmbH (http://www.typefox.io) and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -15,33 +15,142 @@ import java.util.function.Function;
 
 import org.eclipse.lsp4j.jsonrpc.Launcher;
 import org.eclipse.lsp4j.jsonrpc.MessageConsumer;
+import org.eclipse.lsp4j.jsonrpc.validation.ReflectiveMessageValidator;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageServer;
 
-public class LSPLauncher {
+/**
+ * Specialized launcher for the Language Server Protocol.
+ */
+public final class LSPLauncher {
 	
+	private LSPLauncher() {}
+	
+	/**
+	 * Create a new Launcher for a language server and an input and output stream.
+	 * 
+	 * @param server - the server that receives method calls from the remote client
+	 * @param in - input stream to listen for incoming messages
+	 * @param out - output stream to send outgoing messages
+	 */
 	public static Launcher<LanguageClient> createServerLauncher(LanguageServer server, InputStream in, OutputStream out) {
-		return Launcher.createLauncher(server, LanguageClient.class, in, out);
+		return new Builder<LanguageClient>()
+				.setLocalService(server)
+				.setRemoteInterface(LanguageClient.class)
+				.setInput(in)
+				.setOutput(out)
+				.create();
 	}
 	
-	public static Launcher<LanguageClient> createServerLauncher(LanguageServer server, InputStream in, OutputStream out, boolean validate, PrintWriter trace) {
-		return Launcher.createLauncher(server, LanguageClient.class, in, out, validate, trace);
+	/**
+	 * Create a new Launcher for a language server and an input and output stream, and set up message validation and tracing.
+	 * 
+	 * @param server - the server that receives method calls from the remote client
+	 * @param in - input stream to listen for incoming messages
+	 * @param out - output stream to send outgoing messages
+	 * @param validate - whether messages should be validated with the {@link ReflectiveMessageValidator}
+	 * @param trace - a writer to which incoming and outgoing messages are traced, or {@code null} to disable tracing
+	 */
+	public static Launcher<LanguageClient> createServerLauncher(LanguageServer server, InputStream in, OutputStream out,
+			boolean validate, PrintWriter trace) {
+		return new Builder<LanguageClient>()
+				.setLocalService(server)
+				.setRemoteInterface(LanguageClient.class)
+				.setInput(in)
+				.setOutput(out)
+				.validateMessages(validate)
+				.traceMessages(trace)
+				.create();
 	}
 	
-	public static Launcher<LanguageClient> createServerLauncher(LanguageServer server, InputStream in, OutputStream out, ExecutorService executorService, Function<MessageConsumer, MessageConsumer> wrapper) {
-		return Launcher.createLauncher(server, LanguageClient.class, in, out, executorService, wrapper);
+	/**
+	 * Create a new Launcher for a language server and an input and output stream. Threads are started with the given
+	 * executor service. The wrapper function is applied to the incoming and outgoing message streams so additional
+	 * message handling such as validation and tracing can be included.
+	 * 
+	 * @param server - the server that receives method calls from the remote client
+	 * @param in - input stream to listen for incoming messages
+	 * @param out - output stream to send outgoing messages
+	 * @param executorService - the executor service used to start threads
+	 * @param wrapper - a function for plugging in additional message consumers
+	 */
+	public static Launcher<LanguageClient> createServerLauncher(LanguageServer server, InputStream in, OutputStream out,
+			ExecutorService executorService, Function<MessageConsumer, MessageConsumer> wrapper) {
+		return new Builder<LanguageClient>()
+				.setLocalService(server)
+				.setRemoteInterface(LanguageClient.class)
+				.setInput(in)
+				.setOutput(out)
+				.setExecutorService(executorService)
+				.wrapMessages(wrapper)
+				.create();
 	}
 	
+	/**
+	 * Create a new Launcher for a language client and an input and output stream.
+	 * 
+	 * @param client - the client that receives method calls from the remote server
+	 * @param in - input stream to listen for incoming messages
+	 * @param out - output stream to send outgoing messages
+	 */
 	public static Launcher<LanguageServer> createClientLauncher(LanguageClient client, InputStream in, OutputStream out) {
-		return Launcher.createLauncher(client, LanguageServer.class, in, out);
+		return new Builder<LanguageServer>()
+				.setLocalService(client)
+				.setRemoteInterface(LanguageServer.class)
+				.setInput(in)
+				.setOutput(out)
+				.create();
 	}
 	
-	public static Launcher<LanguageServer> createClientLauncher(LanguageClient client, InputStream in, OutputStream out, boolean validate, PrintWriter trace) {
-		return Launcher.createLauncher(client, LanguageServer.class, in, out, validate, trace);
+	/**
+	 * Create a new Launcher for a language client and an input and output stream, and set up message validation and tracing.
+	 * 
+	 * @param client - the client that receives method calls from the remote server
+	 * @param in - input stream to listen for incoming messages
+	 * @param out - output stream to send outgoing messages
+	 * @param validate - whether messages should be validated with the {@link ReflectiveMessageValidator}
+	 * @param trace - a writer to which incoming and outgoing messages are traced, or {@code null} to disable tracing
+	 */
+	public static Launcher<LanguageServer> createClientLauncher(LanguageClient client, InputStream in, OutputStream out,
+			boolean validate, PrintWriter trace) {
+		return new Builder<LanguageServer>()
+				.setLocalService(client)
+				.setRemoteInterface(LanguageServer.class)
+				.setInput(in)
+				.setOutput(out)
+				.validateMessages(validate)
+				.traceMessages(trace)
+				.create();
 	}
 	
-	public static Launcher<LanguageServer> createClientLauncher(LanguageClient client, InputStream in, OutputStream out, ExecutorService executorService, Function<MessageConsumer, MessageConsumer> wrapper) {
-		return Launcher.createLauncher(client, LanguageServer.class, in, out, executorService, wrapper);
+	/**
+	 * Create a new Launcher for a language client and an input and output stream. Threads are started with the given
+	 * executor service. The wrapper function is applied to the incoming and outgoing message streams so additional
+	 * message handling such as validation and tracing can be included.
+	 * 
+	 * @param client - the client that receives method calls from the remote server
+	 * @param in - input stream to listen for incoming messages
+	 * @param out - output stream to send outgoing messages
+	 * @param executorService - the executor service used to start threads
+	 * @param wrapper - a function for plugging in additional message consumers
+	 */
+	public static Launcher<LanguageServer> createClientLauncher(LanguageClient client, InputStream in, OutputStream out,
+			ExecutorService executorService, Function<MessageConsumer, MessageConsumer> wrapper) {
+		return new Builder<LanguageServer>()
+				.setLocalService(client)
+				.setRemoteInterface(LanguageServer.class)
+				.setInput(in)
+				.setOutput(out)
+				.setExecutorService(executorService)
+				.wrapMessages(wrapper)
+				.create();
+	}
+	
+	/**
+	 * Launcher builder for the Language Server Protocol.
+	 */
+	public static class Builder<T> extends Launcher.Builder<T> {
+		
 	}
 
 }


### PR DESCRIPTION
This patch has been extracted from #175 since it's unrelated to the original problem of supporting Hover.

The goal is to customize the JSON-RPC wiring more easily. I applied this customization approach to the DebugLauncher used by the debug protocol.

@jonahkichwacoders could you check this change regarding the debug protocol?