### PR TITLE
GH-197: Aligned with the proposed semantic highlighting LSP extension.

### DIFF
--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -633,6 +633,24 @@ class PublishDiagnosticsCapabilities {
 }
 
 /**
+ * Capabilities specific to {@code textDocument/semanticHighlighting}.
+ */
+@JsonRpcData
+class SemanticHighlightingCapabilities {
+	/**
+	 * The client supports semantic highlighting.
+	 */
+	Boolean semanticHighlighting
+
+	new() {
+	}
+
+	new(Boolean semanticHighlighting) {
+		this.semanticHighlighting = semanticHighlighting
+	}
+}
+
+/**
  * Text document specific client capabilities.
  */
 @JsonRpcData
@@ -735,6 +753,11 @@ class TextDocumentClientCapabilities {
 	 * Capabilities specific to `textDocument/publishDiagnostics`.
 	 */
 	PublishDiagnosticsCapabilities publishDiagnostics
+
+	/**
+	 * Capabilities specific to {@code textDocument/semanticHighlighting}.
+	 */
+	SemanticHighlightingCapabilities semanticHighlightingCapabilities
 }
 
 /**
@@ -2451,6 +2474,11 @@ class ServerCapabilities {
 	 * Workspace specific server capabilities
 	 */
 	WorkspaceServerCapabilities workspace
+	
+	/**
+	 * Semantic highlighting server capabilities.
+	 */
+	SemanticHighlightingServerCapabilities semanticHighlighting; 
 
 	/**
 	 * Experimental server capabilities.
@@ -2478,6 +2506,30 @@ class WorkspaceServerCapabilities {
 	new(WorkspaceFoldersOptions workspaceFolders) {
 		this.workspaceFolders = workspaceFolders
 	}
+}
+
+/**
+ * Semantic highlighting server capabilities.
+ */
+@Beta
+@JsonRpcData
+class SemanticHighlightingServerCapabilities {
+
+	/**
+	 * A "lookup table" of semantic highlighting <a href="https://manual.macromates.com/en/language_grammars">TextMate scopes</a>
+	 * supported by the language server. If not defined or empty, then the server does not support the semantic highlighting
+	 * feature. Otherwise, clients should reuse this "lookup table" when receiving semantic highlighting notifications from
+	 * the server.
+	 */
+	List<List<String>> scopes;
+	
+	new() {
+	}
+	
+	new(List<List<String>> scopes) {
+		this.scopes = scopes;
+	}
+
 }
 
 /**
@@ -3715,5 +3767,59 @@ class ColorPresentation {
 		this.label = label
 		this.textEdit = textEdit
 		this.additionalTextEdits = additionalTextEdits
+	}
+}
+
+/**
+ * Parameters for the semantic highlighting (server-side) push notification.
+ */
+@Beta
+@JsonRpcData
+class SemanticHighlightingParams {
+	/**
+	 * The text document that has to be decorated with the semantic highlighting information.
+	 */
+	@NonNull
+	VersionedTextDocumentIdentifier textDocument
+
+	/**
+	 * An array of semantic highlighting information.
+	 */
+	@NonNull
+	List<SemanticHighlightingInformation> lines
+
+	new() {
+	}
+
+	new(@NonNull VersionedTextDocumentIdentifier textDocument, @NonNull List<SemanticHighlightingInformation> lines) {
+		this.textDocument = textDocument
+		this.lines = lines
+	}
+}
+
+/**
+ * Represents a semantic highlighting information that has to be applied on a specific line of the text document.
+ */
+@Beta
+@JsonRpcData
+class SemanticHighlightingInformation {
+	/**
+	 * The zero-based line position in the text document.
+	 */
+	int line
+
+	/**
+	 * A base64 encoded string representing every single highlighted ranges in the line with its start position, length
+	 * and the "lookup table" index of of the semantic highlighting <a href="https://manual.macromates.com/en/language_grammars">
+	 * TextMate scopes</a>. If the {@code tokens} is empty or not defined, then no highlighted positions are available for the line.
+	 */
+	String tokens
+
+	new() {
+	}
+
+	new(int line, String tokens) {
+		this.line = line
+		this.tokens = tokens
 	}
 }

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/ProtocolExtensions.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/ProtocolExtensions.xtend
@@ -12,13 +12,17 @@ import java.util.ArrayList
 import java.util.List
 import org.eclipse.lsp4j.generator.JsonRpcData
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull
+import org.eclipse.lsp4j.services.LanguageClient
 
 /**
  * Representation of a computed mapping from ranges to the appropriate
  * highlighting style.
+ *
+ * @deprecated Use {@link SemanticHighlightingParams} instead.
  */
 @JsonRpcData
 @Beta
+@Deprecated
 class ColoringParams {
 
 	/**
@@ -47,9 +51,12 @@ class ColoringParams {
 /**
  * Representation of a range and highlighting style identifiers that should be
  * highlighted based on the underlying model.
+ *
+ * @deprecated Use {@link SemanticHighlightingInformation} instead.
  */
 @JsonRpcData
 @Beta
+@Deprecated
 class ColoringInformation {
 
 	/**
@@ -76,7 +83,11 @@ class ColoringInformation {
 	}
 }
 
+/**
+ * @deprecated Use {@link LanguageClient#semanticHighlighting} instead.
+ */
 @Beta
+@Deprecated
 class ColoringStyle {
 	
 	public static val Identifier     = 1

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/LanguageClient.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/LanguageClient.java
@@ -17,11 +17,14 @@ import org.eclipse.lsp4j.MessageActionItem;
 import org.eclipse.lsp4j.MessageParams;
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 import org.eclipse.lsp4j.RegistrationParams;
+import org.eclipse.lsp4j.SemanticHighlightingParams;
 import org.eclipse.lsp4j.ShowMessageRequestParams;
 import org.eclipse.lsp4j.UnregistrationParams;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
+
+import com.google.common.annotations.Beta;
 
 public interface LanguageClient {
 	/**
@@ -111,6 +114,22 @@ public interface LanguageClient {
 	 */
 	@JsonRequest("workspace/configuration")
 	default CompletableFuture<List<Object>> configuration(ConfigurationParams configurationParams) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * The {@code textDocument/semanticHighlighting} notification is pushed from the server to the client
+	 * to inform the client about additional semantic highlighting information that has to be applied
+	 * on the text document. It is the server's responsibility to decide which lines are included in
+	 * the highlighting information. In other words, the server is capable of sending only a delta
+	 * information. For instance, after opening the text document ({@code DidOpenTextDocumentNotification})
+	 * the server sends the semantic highlighting information for the entire document, but if the server
+	 * receives a {@code DidChangeTextDocumentNotification}, it pushes the information only about
+	 * the affected lines in the document.
+	 */
+	@Beta
+	@JsonNotification("textDocument/semanticHighlighting")
+	default void semanticHighlighting(SemanticHighlightingParams params) {
 		throw new UnsupportedOperationException();
 	}
 }

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/LanguageClientExtensions.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/LanguageClientExtensions.java
@@ -7,8 +7,9 @@
  *******************************************************************************/
 package org.eclipse.lsp4j.services;
 
-import org.eclipse.lsp4j.ColoringParams;
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
+
+import com.google.common.annotations.Beta;
 
 /**
  * An extension interface for new methods that are not (yet) defined in the standard LSP protocol.
@@ -16,12 +17,16 @@ import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
 public interface LanguageClientExtensions extends LanguageClient {
 
 	/**
-	 * Pushes the {@link ColoringParams coloring parameter} to the client.
+	 * Pushes the {@link org.eclipse.lsp4j.ColoringParams coloring parameter} to the client.
 	 * 
 	 * @param params
 	 *            the information that should be pushed to the client side for
 	 *            coloring purposes. Must not be {@code null}.
+	 *
+	 * @deprecated Use {@link LanguageClient#semanticHighlighting} instead.
 	 */
+	@Beta
+	@Deprecated
 	@JsonNotification("textDocument/updateColoring")
-	void updateColoring(ColoringParams params);
+	void updateColoring(org.eclipse.lsp4j.ColoringParams params);
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ColoringInformation.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ColoringInformation.java
@@ -18,8 +18,11 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 /**
  * Representation of a range and highlighting style identifiers that should be
  * highlighted based on the underlying model.
+ * 
+ * @deprecated Use {@link SemanticHighlightingInformation} instead.
  */
 @Beta
+@Deprecated
 @SuppressWarnings("all")
 public class ColoringInformation {
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ColoringParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ColoringParams.java
@@ -18,8 +18,11 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 /**
  * Representation of a computed mapping from ranges to the appropriate
  * highlighting style.
+ * 
+ * @deprecated Use {@link SemanticHighlightingParams} instead.
  */
 @Beta
+@Deprecated
 @SuppressWarnings("all")
 public class ColoringParams {
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ColoringStyle.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ColoringStyle.java
@@ -8,8 +8,13 @@
 package org.eclipse.lsp4j;
 
 import com.google.common.annotations.Beta;
+import org.eclipse.lsp4j.services.LanguageClient;
 
+/**
+ * @deprecated Use {@link LanguageClient#semanticHighlighting} instead.
+ */
 @Beta
+@Deprecated
 @SuppressWarnings("all")
 public class ColoringStyle {
   public final static int Identifier = 1;

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SemanticHighlightingCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SemanticHighlightingCapabilities.java
@@ -1,0 +1,76 @@
+/**
+ * Copyright (c) 2016 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.lsp4j;
+
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+/**
+ * Capabilities specific to {@code textDocument/semanticHighlighting}.
+ */
+@SuppressWarnings("all")
+public class SemanticHighlightingCapabilities {
+  /**
+   * The client supports semantic highlighting.
+   */
+  private Boolean semanticHighlighting;
+  
+  public SemanticHighlightingCapabilities() {
+  }
+  
+  public SemanticHighlightingCapabilities(final Boolean semanticHighlighting) {
+    this.semanticHighlighting = semanticHighlighting;
+  }
+  
+  /**
+   * The client supports semantic highlighting.
+   */
+  @Pure
+  public Boolean getSemanticHighlighting() {
+    return this.semanticHighlighting;
+  }
+  
+  /**
+   * The client supports semantic highlighting.
+   */
+  public void setSemanticHighlighting(final Boolean semanticHighlighting) {
+    this.semanticHighlighting = semanticHighlighting;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("semanticHighlighting", this.semanticHighlighting);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    SemanticHighlightingCapabilities other = (SemanticHighlightingCapabilities) obj;
+    if (this.semanticHighlighting == null) {
+      if (other.semanticHighlighting != null)
+        return false;
+    } else if (!this.semanticHighlighting.equals(other.semanticHighlighting))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.semanticHighlighting== null) ? 0 : this.semanticHighlighting.hashCode());
+  }
+}

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SemanticHighlightingInformation.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SemanticHighlightingInformation.java
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) 2016 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.lsp4j;
+
+import com.google.common.annotations.Beta;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+/**
+ * Represents a semantic highlighting information that has to be applied on a specific line of the text document.
+ */
+@Beta
+@SuppressWarnings("all")
+public class SemanticHighlightingInformation {
+  /**
+   * The zero-based line position in the text document.
+   */
+  private int line;
+  
+  /**
+   * A base64 encoded string representing every single highlighted ranges in the line with its start position, length
+   * and the "lookup table" index of of the semantic highlighting <a href="https://manual.macromates.com/en/language_grammars">
+   * TextMate scopes</a>. If the {@code tokens} is empty or not defined, then no highlighted positions are available for the line.
+   */
+  private String tokens;
+  
+  public SemanticHighlightingInformation() {
+  }
+  
+  public SemanticHighlightingInformation(final int line, final String tokens) {
+    this.line = line;
+    this.tokens = tokens;
+  }
+  
+  /**
+   * The zero-based line position in the text document.
+   */
+  @Pure
+  public int getLine() {
+    return this.line;
+  }
+  
+  /**
+   * The zero-based line position in the text document.
+   */
+  public void setLine(final int line) {
+    this.line = line;
+  }
+  
+  /**
+   * A base64 encoded string representing every single highlighted ranges in the line with its start position, length
+   * and the "lookup table" index of of the semantic highlighting <a href="https://manual.macromates.com/en/language_grammars">
+   * TextMate scopes</a>. If the {@code tokens} is empty or not defined, then no highlighted positions are available for the line.
+   */
+  @Pure
+  public String getTokens() {
+    return this.tokens;
+  }
+  
+  /**
+   * A base64 encoded string representing every single highlighted ranges in the line with its start position, length
+   * and the "lookup table" index of of the semantic highlighting <a href="https://manual.macromates.com/en/language_grammars">
+   * TextMate scopes</a>. If the {@code tokens} is empty or not defined, then no highlighted positions are available for the line.
+   */
+  public void setTokens(final String tokens) {
+    this.tokens = tokens;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("line", this.line);
+    b.add("tokens", this.tokens);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    SemanticHighlightingInformation other = (SemanticHighlightingInformation) obj;
+    if (other.line != this.line)
+      return false;
+    if (this.tokens == null) {
+      if (other.tokens != null)
+        return false;
+    } else if (!this.tokens.equals(other.tokens))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + this.line;
+    return prime * result + ((this.tokens== null) ? 0 : this.tokens.hashCode());
+  }
+}

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SemanticHighlightingParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SemanticHighlightingParams.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) 2016 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.lsp4j;
+
+import com.google.common.annotations.Beta;
+import java.util.List;
+import org.eclipse.lsp4j.SemanticHighlightingInformation;
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+/**
+ * Parameters for the semantic highlighting (server-side) push notification.
+ */
+@Beta
+@SuppressWarnings("all")
+public class SemanticHighlightingParams {
+  /**
+   * The text document that has to be decorated with the semantic highlighting information.
+   */
+  @NonNull
+  private VersionedTextDocumentIdentifier textDocument;
+  
+  /**
+   * An array of semantic highlighting information.
+   */
+  @NonNull
+  private List<SemanticHighlightingInformation> lines;
+  
+  public SemanticHighlightingParams() {
+  }
+  
+  public SemanticHighlightingParams(@NonNull final VersionedTextDocumentIdentifier textDocument, @NonNull final List<SemanticHighlightingInformation> lines) {
+    this.textDocument = textDocument;
+    this.lines = lines;
+  }
+  
+  /**
+   * The text document that has to be decorated with the semantic highlighting information.
+   */
+  @Pure
+  @NonNull
+  public VersionedTextDocumentIdentifier getTextDocument() {
+    return this.textDocument;
+  }
+  
+  /**
+   * The text document that has to be decorated with the semantic highlighting information.
+   */
+  public void setTextDocument(@NonNull final VersionedTextDocumentIdentifier textDocument) {
+    this.textDocument = textDocument;
+  }
+  
+  /**
+   * An array of semantic highlighting information.
+   */
+  @Pure
+  @NonNull
+  public List<SemanticHighlightingInformation> getLines() {
+    return this.lines;
+  }
+  
+  /**
+   * An array of semantic highlighting information.
+   */
+  public void setLines(@NonNull final List<SemanticHighlightingInformation> lines) {
+    this.lines = lines;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("textDocument", this.textDocument);
+    b.add("lines", this.lines);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    SemanticHighlightingParams other = (SemanticHighlightingParams) obj;
+    if (this.textDocument == null) {
+      if (other.textDocument != null)
+        return false;
+    } else if (!this.textDocument.equals(other.textDocument))
+      return false;
+    if (this.lines == null) {
+      if (other.lines != null)
+        return false;
+    } else if (!this.lines.equals(other.lines))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.textDocument== null) ? 0 : this.textDocument.hashCode());
+    return prime * result + ((this.lines== null) ? 0 : this.lines.hashCode());
+  }
+}

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SemanticHighlightingServerCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SemanticHighlightingServerCapabilities.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016 TypeFox GmbH (http://www.typefox.io) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ */
+package org.eclipse.lsp4j;
+
+import com.google.common.annotations.Beta;
+import java.util.List;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+/**
+ * Semantic highlighting server capabilities.
+ */
+@Beta
+@SuppressWarnings("all")
+public class SemanticHighlightingServerCapabilities {
+  /**
+   * A "lookup table" of semantic highlighting <a href="https://manual.macromates.com/en/language_grammars">TextMate scopes</a>
+   * supported by the language server. If not defined or empty, then the server does not support the semantic highlighting
+   * feature. Otherwise, clients should reuse this "lookup table" when receiving semantic highlighting notifications from
+   * the server.
+   */
+  private List<List<String>> scopes;
+  
+  public SemanticHighlightingServerCapabilities() {
+  }
+  
+  public SemanticHighlightingServerCapabilities(final List<List<String>> scopes) {
+    this.scopes = scopes;
+  }
+  
+  /**
+   * A "lookup table" of semantic highlighting <a href="https://manual.macromates.com/en/language_grammars">TextMate scopes</a>
+   * supported by the language server. If not defined or empty, then the server does not support the semantic highlighting
+   * feature. Otherwise, clients should reuse this "lookup table" when receiving semantic highlighting notifications from
+   * the server.
+   */
+  @Pure
+  public List<List<String>> getScopes() {
+    return this.scopes;
+  }
+  
+  /**
+   * A "lookup table" of semantic highlighting <a href="https://manual.macromates.com/en/language_grammars">TextMate scopes</a>
+   * supported by the language server. If not defined or empty, then the server does not support the semantic highlighting
+   * feature. Otherwise, clients should reuse this "lookup table" when receiving semantic highlighting notifications from
+   * the server.
+   */
+  public void setScopes(final List<List<String>> scopes) {
+    this.scopes = scopes;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("scopes", this.scopes);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    SemanticHighlightingServerCapabilities other = (SemanticHighlightingServerCapabilities) obj;
+    if (this.scopes == null) {
+      if (other.scopes != null)
+        return false;
+    } else if (!this.scopes.equals(other.scopes))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.scopes== null) ? 0 : this.scopes.hashCode());
+  }
+}

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ServerCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ServerCapabilities.java
@@ -14,6 +14,7 @@ import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.DocumentLinkOptions;
 import org.eclipse.lsp4j.DocumentOnTypeFormattingOptions;
 import org.eclipse.lsp4j.ExecuteCommandOptions;
+import org.eclipse.lsp4j.SemanticHighlightingServerCapabilities;
 import org.eclipse.lsp4j.SignatureHelpOptions;
 import org.eclipse.lsp4j.StaticRegistrationOptions;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
@@ -137,6 +138,11 @@ public class ServerCapabilities {
    * Workspace specific server capabilities
    */
   private WorkspaceServerCapabilities workspace;
+  
+  /**
+   * Semantic highlighting server capabilities.
+   */
+  private SemanticHighlightingServerCapabilities semanticHighlighting;
   
   /**
    * Experimental server capabilities.
@@ -506,6 +512,21 @@ public class ServerCapabilities {
   }
   
   /**
+   * Semantic highlighting server capabilities.
+   */
+  @Pure
+  public SemanticHighlightingServerCapabilities getSemanticHighlighting() {
+    return this.semanticHighlighting;
+  }
+  
+  /**
+   * Semantic highlighting server capabilities.
+   */
+  public void setSemanticHighlighting(final SemanticHighlightingServerCapabilities semanticHighlighting) {
+    this.semanticHighlighting = semanticHighlighting;
+  }
+  
+  /**
    * Experimental server capabilities.
    */
   @Pure
@@ -545,6 +566,7 @@ public class ServerCapabilities {
     b.add("colorProvider", this.colorProvider);
     b.add("executeCommandProvider", this.executeCommandProvider);
     b.add("workspace", this.workspace);
+    b.add("semanticHighlighting", this.semanticHighlighting);
     b.add("experimental", this.experimental);
     return b.toString();
   }
@@ -664,6 +686,11 @@ public class ServerCapabilities {
         return false;
     } else if (!this.workspace.equals(other.workspace))
       return false;
+    if (this.semanticHighlighting == null) {
+      if (other.semanticHighlighting != null)
+        return false;
+    } else if (!this.semanticHighlighting.equals(other.semanticHighlighting))
+      return false;
     if (this.experimental == null) {
       if (other.experimental != null)
         return false;
@@ -698,6 +725,7 @@ public class ServerCapabilities {
     result = prime * result + ((this.colorProvider== null) ? 0 : this.colorProvider.hashCode());
     result = prime * result + ((this.executeCommandProvider== null) ? 0 : this.executeCommandProvider.hashCode());
     result = prime * result + ((this.workspace== null) ? 0 : this.workspace.hashCode());
+    result = prime * result + ((this.semanticHighlighting== null) ? 0 : this.semanticHighlighting.hashCode());
     return prime * result + ((this.experimental== null) ? 0 : this.experimental.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentClientCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentClientCapabilities.java
@@ -23,6 +23,7 @@ import org.eclipse.lsp4j.PublishDiagnosticsCapabilities;
 import org.eclipse.lsp4j.RangeFormattingCapabilities;
 import org.eclipse.lsp4j.ReferencesCapabilities;
 import org.eclipse.lsp4j.RenameCapabilities;
+import org.eclipse.lsp4j.SemanticHighlightingCapabilities;
 import org.eclipse.lsp4j.SignatureHelpCapabilities;
 import org.eclipse.lsp4j.SynchronizationCapabilities;
 import org.eclipse.lsp4j.TypeDefinitionCapabilities;
@@ -132,6 +133,11 @@ public class TextDocumentClientCapabilities {
    * Capabilities specific to `textDocument/publishDiagnostics`.
    */
   private PublishDiagnosticsCapabilities publishDiagnostics;
+  
+  /**
+   * Capabilities specific to {@code textDocument/semanticHighlighting}.
+   */
+  private SemanticHighlightingCapabilities semanticHighlightingCapabilities;
   
   @Pure
   public SynchronizationCapabilities getSynchronization() {
@@ -426,6 +432,21 @@ public class TextDocumentClientCapabilities {
     this.publishDiagnostics = publishDiagnostics;
   }
   
+  /**
+   * Capabilities specific to {@code textDocument/semanticHighlighting}.
+   */
+  @Pure
+  public SemanticHighlightingCapabilities getSemanticHighlightingCapabilities() {
+    return this.semanticHighlightingCapabilities;
+  }
+  
+  /**
+   * Capabilities specific to {@code textDocument/semanticHighlighting}.
+   */
+  public void setSemanticHighlightingCapabilities(final SemanticHighlightingCapabilities semanticHighlightingCapabilities) {
+    this.semanticHighlightingCapabilities = semanticHighlightingCapabilities;
+  }
+  
   @Override
   @Pure
   public String toString() {
@@ -449,6 +470,7 @@ public class TextDocumentClientCapabilities {
     b.add("colorProvider", this.colorProvider);
     b.add("rename", this.rename);
     b.add("publishDiagnostics", this.publishDiagnostics);
+    b.add("semanticHighlightingCapabilities", this.semanticHighlightingCapabilities);
     return b.toString();
   }
   
@@ -557,6 +579,11 @@ public class TextDocumentClientCapabilities {
         return false;
     } else if (!this.publishDiagnostics.equals(other.publishDiagnostics))
       return false;
+    if (this.semanticHighlightingCapabilities == null) {
+      if (other.semanticHighlightingCapabilities != null)
+        return false;
+    } else if (!this.semanticHighlightingCapabilities.equals(other.semanticHighlightingCapabilities))
+      return false;
     return true;
   }
   
@@ -583,6 +610,7 @@ public class TextDocumentClientCapabilities {
     result = prime * result + ((this.documentLink== null) ? 0 : this.documentLink.hashCode());
     result = prime * result + ((this.colorProvider== null) ? 0 : this.colorProvider.hashCode());
     result = prime * result + ((this.rename== null) ? 0 : this.rename.hashCode());
-    return prime * result + ((this.publishDiagnostics== null) ? 0 : this.publishDiagnostics.hashCode());
+    result = prime * result + ((this.publishDiagnostics== null) ? 0 : this.publishDiagnostics.hashCode());
+    return prime * result + ((this.semanticHighlightingCapabilities== null) ? 0 : this.semanticHighlightingCapabilities.hashCode());
   }
 }


### PR DESCRIPTION
 - Deprecated the obsolete coloring params in the `ProtocolExtensions`.
 - Declared the new semantic highlighting param in the `Protocol`.
 - Aligned the language client implementations.

Closes #197.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>