### PR TITLE
Fix for #227 handling of success field

### DIFF
--- a/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/adapters/DebugMessageTypeAdapter.java
+++ b/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/adapters/DebugMessageTypeAdapter.java
@@ -433,6 +433,8 @@ public class DebugMessageTypeAdapter extends MessageTypeAdapter {
 					gson.toJson(errorData, errorData.getClass(), out);
 				}
 			} else {
+				out.name("success");
+				out.value(true);
 				out.name("body");
 				Object result = responseMessage.getResult();
 				if (result == null)

--- a/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/adapters/DebugMessageTypeAdapter.java
+++ b/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/adapters/DebugMessageTypeAdapter.java
@@ -21,7 +21,6 @@ import org.eclipse.lsp4j.jsonrpc.json.adapters.MessageTypeAdapter;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.jsonrpc.messages.Message;
 import org.eclipse.lsp4j.jsonrpc.messages.MessageIssue;
-import org.eclipse.lsp4j.jsonrpc.messages.RequestMessage;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
 
@@ -192,9 +191,9 @@ public class DebugMessageTypeAdapter extends MessageTypeAdapter {
 		Boolean rawSuccess = null;
 		Object rawParams = null;
 		Object rawBody = null;
-		
+
 		try {
-			
+
 			while (in.hasNext()) {
 				String name = in.nextName();
 				switch (name) {
@@ -246,10 +245,10 @@ public class DebugMessageTypeAdapter extends MessageTypeAdapter {
 			boolean success = rawSuccess != null ? rawSuccess : false;
 			Object params = parseParams(rawParams, method);
 			Object body = parseBody(rawBody, messageType, request_seq, method, success);
-			
+
 			in.endObject();
 			return createMessage(messageType, seq, request_seq, method, success, message, params, body);
-			
+
 		} catch (JsonSyntaxException | MalformedJsonException | EOFException exception) {
 			if ("request".equals(messageType) || "event".equals(messageType) || "response".equals(messageType)) {
 				// Create a message and bundle it to an exception with an issue that wraps the original exception
@@ -337,7 +336,7 @@ public class DebugMessageTypeAdapter extends MessageTypeAdapter {
 		}
 		switch (messageType) {
 		case "request": {
-			RequestMessage message = new RequestMessage();
+			DebugRequestMessage message = new DebugRequestMessage();
 			message.setId(seq);
 			message.setMethod(method);
 			message.setParams(params);
@@ -354,7 +353,7 @@ public class DebugMessageTypeAdapter extends MessageTypeAdapter {
 			DebugResponseMessage message = new DebugResponseMessage();
 			message.setId(request_seq);
 			message.setResponseId(seq);
-			message.setMethod(method);			
+			message.setMethod(method);
 			if (!success) {
 				ResponseError error = new ResponseError();
 				error.setCode(ResponseErrorCode.UnknownErrorCode);
@@ -460,7 +459,7 @@ public class DebugMessageTypeAdapter extends MessageTypeAdapter {
 
 		out.endObject();
 	}
-	
+
 	private void writeIntId(JsonWriter out, Either<String, Number> id) throws IOException {
 		if (id == null)
 			writeNullValue(out);

--- a/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/adapters/DebugMessageTypeAdapter.java
+++ b/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/adapters/DebugMessageTypeAdapter.java
@@ -252,7 +252,8 @@ public class DebugMessageTypeAdapter extends MessageTypeAdapter {
 		} catch (JsonSyntaxException | MalformedJsonException | EOFException exception) {
 			if ("request".equals(messageType) || "event".equals(messageType) || "response".equals(messageType)) {
 				// Create a message and bundle it to an exception with an issue that wraps the original exception
-				Message resultMessage = createMessage(messageType, seq, request_seq, method, rawSuccess, message, rawParams, rawBody);
+				boolean success = rawSuccess != null ? rawSuccess : false;
+				Message resultMessage = createMessage(messageType, seq, request_seq, method, success, message, rawParams, rawBody);
 				MessageIssue issue = new MessageIssue("Message could not be parsed.", ResponseErrorCode.ParseError.getValue(), exception);
 				throw new MessageIssueException(resultMessage, issue);
 			} else {

--- a/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/adapters/DebugMessageTypeAdapter.java
+++ b/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/adapters/DebugMessageTypeAdapter.java
@@ -243,7 +243,7 @@ public class DebugMessageTypeAdapter extends MessageTypeAdapter {
 					in.skipValue();
 				}
 			}
-			boolean success = rawSuccess != null ? rawSuccess : true;
+			boolean success = rawSuccess != null ? rawSuccess : false;
 			Object params = parseParams(rawParams, method);
 			Object body = parseBody(rawBody, messageType, request_seq, method, success);
 			

--- a/org.eclipse.lsp4j.jsonrpc.debug/src/test/java/org/eclipse/lsp4j/jsonrpc/debug/test/json/DebugMessageJsonHandlerTest.java
+++ b/org.eclipse.lsp4j.jsonrpc.debug/src/test/java/org/eclipse/lsp4j/jsonrpc/debug/test/json/DebugMessageJsonHandlerTest.java
@@ -7,6 +7,8 @@
  *******************************************************************************/
 package org.eclipse.lsp4j.jsonrpc.debug.test.json;
 
+import static org.junit.Assert.fail;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -16,10 +18,13 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
 
+import org.eclipse.lsp4j.jsonrpc.MessageIssueException;
 import org.eclipse.lsp4j.jsonrpc.debug.json.DebugMessageJsonHandler;
+import org.eclipse.lsp4j.jsonrpc.debug.messages.DebugRequestMessage;
 import org.eclipse.lsp4j.jsonrpc.json.JsonRpcMethod;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.jsonrpc.messages.Message;
+import org.eclipse.lsp4j.jsonrpc.messages.MessageIssue;
 import org.eclipse.lsp4j.jsonrpc.messages.NotificationMessage;
 import org.eclipse.lsp4j.jsonrpc.messages.RequestMessage;
 import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage;
@@ -28,6 +33,7 @@ import org.junit.Test;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 import com.google.gson.reflect.TypeToken;
 
 public class DebugMessageJsonHandlerTest {
@@ -54,6 +60,7 @@ public class DebugMessageJsonHandlerTest {
 		Message message = handler.parseMessage("{"
 				+ "\"seq\":2,\n"
 				+ "\"type\":\"response\",\n"
+				+ "\"success\":true,\n"
 				+ " \"body\": [\n"
 				+ "  {\"name\":\"$schema\",\"kind\":15,\"location\":{\"uri\":\"file:/home/mistria/runtime-EclipseApplication-with-patch/EclipseConEurope/something.json\",\"range\":{\"start\":{\"line\":1,\"character\":3},\"end\":{\"line\":1,\"character\":55}}}},\n"
 				+ "  {\"name\":\"type\",\"kind\":15,\"location\":{\"uri\":\"file:/home/mistria/runtime-EclipseApplication-with-patch/EclipseConEurope/something.json\",\"range\":{\"start\":{\"line\":2,\"character\":3},\"end\":{\"line\":2,\"character\":19}}}},\n"
@@ -80,6 +87,7 @@ public class DebugMessageJsonHandlerTest {
 		Message message = handler.parseMessage("{"
 				+ "\"seq\":2,\n"
 				+ "\"type\":\"response\",\n"
+				+ "\"success\":true,\n"
 				+ " \"body\": [\n"
 				+ "  {\"name\":\"$schema\",\"kind\":15,\"location\":{\"uri\":\"file:/home/mistria/runtime-EclipseApplication-with-patch/EclipseConEurope/something.json\",\"range\":{\"start\":{\"line\":1,\"character\":3},\"end\":{\"line\":1,\"character\":55}}}},\n"
 				+ "  {\"name\":\"type\",\"kind\":15,\"location\":{\"uri\":\"file:/home/mistria/runtime-EclipseApplication-with-patch/EclipseConEurope/something.json\",\"range\":{\"start\":{\"line\":2,\"character\":3},\"end\":{\"line\":2,\"character\":19}}}},\n"
@@ -106,6 +114,7 @@ public class DebugMessageJsonHandlerTest {
 		Message message = handler.parseMessage("{"
 				+ "\"seq\":2,\n"
 				+ "\"type\":\"response\",\n"
+				+ "\"success\":true,\n"
 				+ " \"body\": [\n"
 				+ "  {\"name\":\"foo\"},\n"
 				+ "  {\"name\":\"bar\"}\n"
@@ -118,6 +127,7 @@ public class DebugMessageJsonHandlerTest {
 		message = handler.parseMessage("{"
 				+ "\"seq\":2,\n"
 				+ "\"type\":\"response\",\n"
+				+ "\"success\":true,\n"
 				+ "\"body\": \"name\"\n"
 				+ "}");
 		result = (Either<String, List<Map<String,String>>>) ((ResponseMessage)message).getResult();
@@ -137,6 +147,7 @@ public class DebugMessageJsonHandlerTest {
 		Message message = handler.parseMessage("{"
 				+ "\"seq\":2,\n"
 				+ "\"type\":\"response\",\n"
+				+ "\"success\":true,\n"
 				+ "\"body\": 2\n"
 				+ "}");
 		Either<Integer, List<Map<String, String>>> result = (Either<Integer, List<Map<String,String>>>) ((ResponseMessage)message).getResult();
@@ -157,6 +168,7 @@ public class DebugMessageJsonHandlerTest {
 		Message message = handler.parseMessage("{"
 				+ "\"seq\":2,\n"
 				+ "\"type\":\"response\",\n"
+				+ "\"success\":true,\n"
 				+ "\"body\": 2\n"
 				+ "}");
 		Either<Either<Integer, Map<String,String>>, List<Either<Integer, Map<String,String>>>> result = (Either<Either<Integer, Map<String, String>>, List<Either<Integer, Map<String, String>>>>) ((ResponseMessage)message).getResult();
@@ -167,6 +179,7 @@ public class DebugMessageJsonHandlerTest {
 		message = handler.parseMessage("{"
 				+ "\"seq\":2,\n"
 				+ "\"type\":\"response\",\n"
+				+ "\"success\":true,\n"
 				+ " \"body\": {\n"
 				+ "  \"foo\":\"1\",\n"
 				+ "  \"bar\":\"2\"\n"
@@ -180,6 +193,7 @@ public class DebugMessageJsonHandlerTest {
 		message = handler.parseMessage("{"
 				+ "\"seq\":2,\n"
 				+ "\"type\":\"response\",\n"
+				+ "\"success\":true,\n"
 				+ " \"body\": [{\n"
 				+ "  \"foo\":\"1\",\n"
 				+ "  \"bar\":\"2\"\n"
@@ -193,6 +207,7 @@ public class DebugMessageJsonHandlerTest {
 		message = handler.parseMessage("{"
 				+ "\"seq\":2,\n"
 				+ "\"type\":\"response\",\n"
+				+ "\"success\":true,\n"
 				+ " \"body\": [\n"
 				+ "  2\n"
 				+ "]}");
@@ -215,6 +230,7 @@ public class DebugMessageJsonHandlerTest {
 		Message message = handler.parseMessage("{"
 				+ "\"seq\":2,\n"
 				+ "\"type\":\"response\",\n"
+				+ "\"success\":true,\n"
 				+ "\"body\": {\n"
 				+ "  value:\"foo\"\n"
 				+ "}}");
@@ -225,6 +241,7 @@ public class DebugMessageJsonHandlerTest {
 		message = handler.parseMessage("{"
 				+ "\"seq\":2,\n"
 				+ "\"type\":\"response\",\n"
+				+ "\"success\":true,\n"
 				+ "\"body\": [{\n"
 				+ "  value:\"bar\"\n"
 				+ "}]}");
@@ -246,6 +263,7 @@ public class DebugMessageJsonHandlerTest {
 		Message message = handler.parseMessage("{"
 				+ "\"seq\":2,\n"
 				+ "\"type\":\"response\",\n"
+				+ "\"success\":true,\n"
 				+ "\"body\": [{\n"
 				+ "  value:\"foo\"\n"
 				+ "}]}");
@@ -256,6 +274,7 @@ public class DebugMessageJsonHandlerTest {
 		message = handler.parseMessage("{"
 				+ "\"seq\":2,\n"
 				+ "\"type\":\"response\",\n"
+				+ "\"success\":true,\n"
 				+ "\"body\": {\n"
 				+ "  items: [{\n"
 				+ "    value:\"bar\"\n"
@@ -739,6 +758,33 @@ public class DebugMessageJsonHandlerTest {
 			Class<? extends Object> class1 = params.getClass();
 			Assert.assertEquals(Location.class, class1);
 			Assert.assertEquals("dummy://mymodel.mydsl", ((Location)params).uri);
+		});
+	}
+
+	@Test
+	public void testMissingSuccessResponse_AllOrders() {
+		Map<String, JsonRpcMethod> supportedMethods = new LinkedHashMap<>();
+		supportedMethods.put("foo", JsonRpcMethod.request("foo",
+				new TypeToken<Location>() {}.getType(),
+				new TypeToken<Void>() {
+				}.getType()));
+		DebugMessageJsonHandler handler = new DebugMessageJsonHandler(supportedMethods);
+		handler.setMethodProvider((id) -> "foo");
+		String[] properties = new String[] {
+				"\"seq\":2",
+				"\"type\":\"response\"",
+				"\"request_seq\":5",
+				"\"message\": \"failed\"",
+				"\"body\": {\"uri\": \"failed\"}"
+				};
+		testAllPermutations(properties, json -> {
+			ResponseMessage message = (ResponseMessage) handler.parseMessage(json);
+			Assert.assertEquals("failed", message.getError().getMessage());
+			Object data = message.getError().getData();
+			Map<String, String> expected = new HashMap<>();
+			expected.put("uri", "failed");
+			Assert.assertEquals(expected, data);
+			Assert.assertNull(message.getResult());
 		});
 	}
 }


### PR DESCRIPTION
Fixes the incorrect (and sometimes inconsistent) handling of success field in response message.

With this set of changes "success" is always required and written.