### PR TITLE
Omit "arguments" if empty on DebugMessageTypeAdapter

### DIFF
--- a/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/adapters/DebugMessageTypeAdapter.java
+++ b/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/adapters/DebugMessageTypeAdapter.java
@@ -414,12 +414,11 @@ public class DebugMessageTypeAdapter extends MessageTypeAdapter {
 			writeIntId(out, requestMessage.getRawId());
 			out.name("command");
 			out.value(requestMessage.getMethod());
-			out.name("arguments");
 			Object params = requestMessage.getParams();
-			if (params == null)
-				writeNullValue(out);
-			else
+			if (params != null) {
+				out.name("arguments");		
 				gson.toJson(params, params.getClass(), out);
+			}
 		} else if (message instanceof DebugResponseMessage) {
 			DebugResponseMessage responseMessage = (DebugResponseMessage) message;
 			out.name("type");


### PR DESCRIPTION
Some endpoints throws a NPE on methods without parameters. Per JSON-RPC 2.0 Specification, If present, parameters for the rpc call MUST be provided as a Structured value.