### PR TITLE
Review using null for fields with no values #240 

### DIFF
--- a/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/adapters/DebugMessageTypeAdapter.java
+++ b/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/adapters/DebugMessageTypeAdapter.java
@@ -448,12 +448,11 @@ public class DebugMessageTypeAdapter extends MessageTypeAdapter {
 			} else {
 				out.name("success");
 				out.value(true);
-				out.name("body");
 				Object result = responseMessage.getResult();
-				if (result == null)
-					writeNullValue(out);
-				else
+				if (result != null) {
+					out.name("body");
 					gson.toJson(result, result.getClass(), out);
+				}
 			}
 		} else if (message instanceof DebugNotificationMessage) {
 			DebugNotificationMessage notificationMessage = (DebugNotificationMessage) message;
@@ -463,12 +462,11 @@ public class DebugMessageTypeAdapter extends MessageTypeAdapter {
 			writeIntId(out, notificationMessage.getRawId());
 			out.name("event");
 			out.value(notificationMessage.getMethod());
-			out.name("body");
-			Object params = notificationMessage.getParams();
-			if (params == null)
-				writeNullValue(out);
-			else
+      Object params = notificationMessage.getParams();
+			if (params != null)
+			  out.name("body");
 				gson.toJson(params, params.getClass(), out);
+				
 		}
 
 		out.endObject();

--- a/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/adapters/DebugMessageTypeAdapter.java
+++ b/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/adapters/DebugMessageTypeAdapter.java
@@ -462,11 +462,11 @@ public class DebugMessageTypeAdapter extends MessageTypeAdapter {
 			writeIntId(out, notificationMessage.getRawId());
 			out.name("event");
 			out.value(notificationMessage.getMethod());
-      Object params = notificationMessage.getParams();
-			if (params != null)
-			  out.name("body");
+			Object params = notificationMessage.getParams();
+			if (params != null) {
+				out.name("body");
 				gson.toJson(params, params.getClass(), out);
-				
+			}
 		}
 
 		out.endObject();

--- a/org.eclipse.lsp4j.jsonrpc.debug/src/test/java/org/eclipse/lsp4j/jsonrpc/debug/test/DebugIntegrationTest.java
+++ b/org.eclipse.lsp4j.jsonrpc.debug/src/test/java/org/eclipse/lsp4j/jsonrpc/debug/test/DebugIntegrationTest.java
@@ -350,8 +350,8 @@ public class DebugIntegrationTest {
 			logMessages.await(Level.INFO, "Unsupported notification method: $/foo1");
 			logMessages.await(Level.INFO, "Unsupported request method: $/foo2");
 
-			Assert.assertEquals("Content-Length: 89\r\n\r\n" +
-					"{\"type\":\"response\",\"seq\":1,\"request_seq\":1,\"command\":\"$/foo2\",\"success\":true,\"body\":null}",
+			Assert.assertEquals("Content-Length: 77\r\n\r\n" +
+					"{\"type\":\"response\",\"seq\":1,\"request_seq\":1,\"command\":\"$/foo2\",\"success\":true}",
 					out.toString());
 		} finally {
 			logMessages.unregister();


### PR DESCRIPTION
The body is omitted on responses in Visual Studio Code. On notifications threre is always a body, since the only notification without argument is "initialized", which is sent by the Java Debug Server with a body. I believe it is safe to omit the body in the notifications also.