### PR TITLE
GH-296: Extended the protocol with `textDocument/callHierarchy`.

### DIFF
--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/DocumentHighlightKind.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/DocumentHighlightKind.java
@@ -17,7 +17,7 @@ package org.eclipse.lsp4j;
 public enum DocumentHighlightKind {
 	
 	/**
-	 * A textual occurrance.
+	 * A textual occurrence.
 	 */
 	Text(1),
 	

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -775,8 +775,7 @@ class SemanticHighlightingCapabilities {
 }
 
 /**
- * Capabilities specific to the {@code textDocument/typeHierarchy} and the {@code typeHierarchy/resolve}
- * language server methods.
+ * Capabilities specific to the {@code textDocument/typeHierarchy}.
  * 
  * <p>
  * <b>Note:</b> the <a href=
@@ -785,15 +784,13 @@ class SemanticHighlightingCapabilities {
  */
 @Beta
 @JsonRpcData
-class TypeHierarchyCapabilities {
+class TypeHierarchyCapabilities extends DynamicRegistrationCapabilities {
 
-	/**
-	 * The language client supports super- and subtype hierarchies.
-	 */
-	Boolean typeHierarchy
+	new() {
+	}
 
-	new(Boolean typeHierarchy) {
-		this.typeHierarchy = typeHierarchy
+	new(Boolean dynamicRegistration) {
+		super(dynamicRegistration)
 	}
 
 }
@@ -2060,20 +2057,12 @@ class TypeHierarchyParams extends TextDocumentPositionParams {
 	 * The number of hierarchy levels to resolve. {@code 0} indicates no hierarchy level. It defaults to {@code 0}.
 	 */
 	int resolve
-	
+
 	/**
-	 * The direction of the type hierarchy resolution. If not defined, defaults to {@code children}.
-	 * 
-	 * <p>
-	 * The followings are the legal values:
-	 * <ul>
-	 * <li>{@code children},</li>
-	 * <li>{@code parents}, and</li>
-	 * <li>{@code both}.</li>
-	 * </ul>
-	 * </p>
+	 * The direction of the type hierarchy resolution. If not defined, defaults to {@link TypeHierarchyDirection#Children Children}.
 	 */
-	String direction
+	TypeHierarchyDirection direction
+
 }
 
 /**
@@ -2097,18 +2086,9 @@ class ResolveTypeHierarchyItemParams {
 
 	/**
 	 * The direction of the type hierarchy resolution.
-	 * 
-	 * <p>
-	 * The followings are the legal values:
-	 * <ul>
-	 * <li>{@code children},</li>
-	 * <li>{@code parents}, and</li>
-	 * <li>{@code both}.</li>
-	 * </ul>
-	 * </p>
 	 */
 	@NonNull
-	String direction
+	TypeHierarchyDirection direction
 
 }
 
@@ -2886,7 +2866,7 @@ class ServerCapabilities {
 	 * language feature</a> is not yet part of the official LSP specification.
 	 */
 	@Beta
-	Boolean typeHierarchy
+	Either<Boolean, StaticRegistrationOptions> typeHierarchyProvider
 
 	/**
 	 * The server provides Call Hierarchy support.
@@ -3117,7 +3097,7 @@ class TypeHierarchyItem {
 
 	/**
 	 * The range enclosing this type hierarchy item not including leading/trailing whitespace but everything else
-	 * like comments. This information is typically used to determine if the the clients cursor is inside the type
+	 * like comments. This information is typically used to determine if the clients cursor is inside the type
 	 * hierarchy item to reveal in the symbol in the UI.
 	 * 
 	 * @see TypeHierarchyItem#selectionRange
@@ -3176,7 +3156,7 @@ class DocumentSymbol {
 
 	/**
 	 * The range enclosing this symbol not including leading/trailing whitespace but everything else
-	 * like comments. This information is typically used to determine if the the clients cursor is
+	 * like comments. This information is typically used to determine if the clients cursor is
 	 * inside the symbol to reveal in the symbol in the UI.
 	 */
 	@NonNull
@@ -3184,7 +3164,7 @@ class DocumentSymbol {
 
 	/**
 	 * The range that should be selected and revealed when this symbol is being picked, e.g the name of a function.
-	 * Must be contained by the the `range`.
+	 * Must be contained by the `range`.
 	 */
 	@NonNull
 	Range selectionRange

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -751,10 +751,16 @@ class FoldingRangeCapabilities extends DynamicRegistrationCapabilities {
 
 /**
  * Capabilities specific to {@code textDocument/semanticHighlighting}.
+ * 
+ * <p>
+ * <b>Note:</b> the <a href=
+ * "https://github.com/Microsoft/vscode-languageserver-node/pull/367">{@code textDocument/semanticHighlighting}
+ * language feature</a> is not yet part of the official LSP specification.
  */
 @Beta
 @JsonRpcData
 class SemanticHighlightingCapabilities {
+
 	/**
 	 * The client supports semantic highlighting.
 	 */
@@ -771,6 +777,11 @@ class SemanticHighlightingCapabilities {
 /**
  * Capabilities specific to the {@code textDocument/typeHierarchy} and the {@code typeHierarchy/resolve}
  * language server methods.
+ * 
+ * <p>
+ * <b>Note:</b> the <a href=
+ * "https://github.com/Microsoft/vscode-languageserver-node/pull/426">{@code textDocument/typeHierarchy}
+ * language feature</a> is not yet part of the official LSP specification.
  */
 @Beta
 @JsonRpcData
@@ -781,11 +792,29 @@ class TypeHierarchyCapabilities {
 	 */
 	Boolean typeHierarchy
 
+	new(Boolean typeHierarchy) {
+		this.typeHierarchy = typeHierarchy
+	}
+
+}
+
+/**
+ * Capabilities specific to the {@code textDocument/callHierarchy}.
+ * 
+ * <p>
+ * <b>Note:</b> the <a href=
+ * "https://github.com/Microsoft/vscode-languageserver-node/pull/420">{@code textDocument/callHierarchy}
+ * language feature</a> is not yet part of the official LSP specification.
+ */
+@Beta
+@JsonRpcData
+class CallHierarchyCapabilities extends DynamicRegistrationCapabilities {
+
 	new() {
 	}
 
-	new(Boolean typeHierarchy) {
-		this.typeHierarchy = typeHierarchy
+	new(Boolean dynamicRegistration) {
+		super(dynamicRegistration)
 	}
 
 }
@@ -912,6 +941,13 @@ class TextDocumentClientCapabilities {
 	 */
 	@Beta
 	TypeHierarchyCapabilities typeHierarchyCapabilities
+
+	/**
+	 * Capabilities specific to {@code textDocument/callHierarchy}.
+	 */
+	@Beta
+	CallHierarchyCapabilities callHierarchy
+
 }
 
 /**
@@ -2837,13 +2873,31 @@ class ServerCapabilities {
 	/**
 	 * Semantic highlighting server capabilities.
 	 */
+	@Beta
 	SemanticHighlightingServerCapabilities semanticHighlighting
 	
 	/**
 	 * Server capability for calculating super- and subtype hierarchies.
 	 * The LS supports the type hierarchy language feature, if this capability is set to {@code true}.
+	 * 
+	 * <p>
+	 * <b>Note:</b> the <a href=
+	 * "https://github.com/Microsoft/vscode-languageserver-node/pull/426">{@code textDocument/typeHierarchy}
+	 * language feature</a> is not yet part of the official LSP specification.
 	 */
+	@Beta
 	Boolean typeHierarchy
+
+	/**
+	 * The server provides Call Hierarchy support.
+	 * 
+	 * <p>
+	 * <b>Note:</b> the <a href=
+	 * "https://github.com/Microsoft/vscode-languageserver-node/pull/420">{@code textDocument/callHierarchy}
+	 * language feature</a> is not yet part of the official LSP specification.
+	 */
+	@Beta
+	Either<Boolean, StaticRegistrationOptions> callHierarchyProvider
 
 	/**
 	 * Experimental server capabilities.
@@ -2875,6 +2929,11 @@ class WorkspaceServerCapabilities {
 
 /**
  * Semantic highlighting server capabilities.
+ * 
+ * <p>
+ * <b>Note:</b> the <a href=
+ * "https://github.com/Microsoft/vscode-languageserver-node/pull/367">{@code textDocument/semanticHighlighting}
+ * language feature</a> is not yet part of the official LSP specification.
  */
 @Beta
 @JsonRpcData
@@ -4597,4 +4656,125 @@ class SemanticHighlightingInformation {
 		this.line = line
 		this.tokens = tokens
 	}
+}
+
+/**
+ * The parameters of a {@code textDocument/callHierarchy} request.
+ */
+@Beta
+@JsonRpcData
+class CallHierarchyParams extends TextDocumentPositionParams {
+
+	/**
+	 * The number of levels to resolve.
+	 */
+	int resolve
+
+	/**
+	 * Outgoing direction for callees. Valid values are: {@code incoming} and {@code outgoing}.
+	 * The default is {@code incoming} for callers.
+	 */
+	String direction
+
+}
+
+/**
+ * The parameters of a {@code callHierarchy/resolve} request.
+ */
+@Beta
+@JsonRpcData
+class ResolveCallHierarchyItemParams {
+
+	/**
+	 * Unresolved item.
+	 */
+	@NonNull
+	CallHierarchyItem item
+
+	/**
+	 * The number of levels to resolve.
+	 */
+	int resolve
+
+	/**
+	 * Outgoing direction for callees. Valid values are: {@code incoming} and {@code outgoing}.
+	 * The default is {@code incoming} for callers.
+	 */
+	@NonNull
+	String direction
+
+}
+
+/**
+ * The result of a {@code textDocument/callHierarchy} request.
+ */
+@Beta
+@JsonRpcData
+class CallHierarchyItem {
+
+	/**
+	 * The name of the symbol targeted by the call hierarchy request.
+	 */
+	@NonNull
+	String name
+
+	/**
+	 * More detail for this symbol, e.g the signature of a function.
+	 */
+	String detail
+
+	/**
+	 * The kind of this symbol.
+	 */
+	@NonNull
+	SymbolKind kind
+
+	/**
+	 * URI of the document containing the symbol.
+	 */
+	@NonNull
+	String uri
+
+	/**
+	 * The range enclosing this symbol not including leading/trailing whitespace but everything else
+	 * like comments. This information is typically used to determine if the the clients cursor is
+	 * inside the symbol to reveal in the symbol in the UI.
+	 */
+	@NonNull
+	Range range
+
+	/**
+	 * The range that should be selected and revealed when this symbol is being picked, e.g the name of a function.
+	 * Must be contained by the the {@code range}.
+	 */
+	@NonNull
+	Range selectionRange
+
+	/**
+	 * The actual location of the call.
+	 *
+	 * <b>Must be defined</b> in resolved callers/callees.
+	 */
+	Location callLocation
+
+	/**
+	 * List of incoming calls.
+	 *
+	 * <i>Note</i>: The items is <em>unresolved</em> if {@code callers} and {@code callees} is not defined.
+	 */
+	List<CallHierarchyItem> callers
+
+	/**
+	 * List of outgoing calls.
+	 *
+	 * *Note*: The items is <em>unresolved</em> if {@code callers} and {@code callees} is not defined.
+	 */
+	List<CallHierarchyItem> callees
+
+	/**
+	 * Optional data to identify an item in a resolve request.
+	 */
+	@JsonAdapter(JsonElementTypeAdapter.Factory)
+	Object data
+
 }

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/TypeHierarchyDirection.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/TypeHierarchyDirection.java
@@ -1,0 +1,57 @@
+/******************************************************************************
+ * Copyright (c) 2019 TypeFox and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.lsp4j;
+
+import org.eclipse.lsp4j.services.TextDocumentService;
+
+/**
+ * Direction specific to the
+ * {@link TextDocumentService#typeHierarchy(TypeHierarchyParams)
+ * textDocument/typeHierarchy} and
+ * {@link TextDocumentService#resolveTypeHierarchy(ResolveTypeHierarchyItemParams)
+ * typeHierarchy/resolve} LS methods.
+ * 
+ * <p>
+ * Valid values are:
+ * <ul>
+ * <li>{@link TypeHierarchyDirection#Children Children},</li>
+ * <li>{@link TypeHierarchyDirection#Parents Parents},</li>
+ * <li>{@link TypeHierarchyDirection#Both Both}.</li>
+ * </ul>
+ *
+ */
+public enum TypeHierarchyDirection {
+
+	/**
+	 * Flag for retrieving/resolving the subtypes. Value: {@code 0}.
+	 */
+	Children,
+
+	/**
+	 * Flag to use when retrieving/resolving the supertypes. Value: {@code 1}.
+	 */
+	Parents,
+
+	/**
+	 * Flag for resolving both the super- and subtypes. Value: {@code 2}.
+	 */
+	Both;
+
+	public static TypeHierarchyDirection forValue(int value) {
+		TypeHierarchyDirection[] values = TypeHierarchyDirection.values();
+		if (value < 0 || value >= values.length) {
+			throw new IllegalArgumentException("Illegal enum value: " + value);
+		}
+		return values[value];
+	}
+
+}

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/LanguageClient.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/LanguageClient.java
@@ -130,6 +130,11 @@ public interface LanguageClient {
 	 * the server sends the semantic highlighting information for the entire document, but if the server
 	 * receives a {@code DidChangeTextDocumentNotification}, it pushes the information only about
 	 * the affected lines in the document.
+	 * 
+	 * <p>
+	 * <b>Note:</b> the <a href=
+	 * "https://github.com/Microsoft/vscode-languageserver-node/pull/367">{@code textDocument/semanticHighlighting}
+	 * language feature</a> is not yet part of the official LSP specification.
 	 */
 	@Beta
 	@JsonNotification("textDocument/semanticHighlighting")

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/TextDocumentService.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/TextDocumentService.java
@@ -14,6 +14,8 @@ package org.eclipse.lsp4j.services;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import org.eclipse.lsp4j.CallHierarchyItem;
+import org.eclipse.lsp4j.CallHierarchyParams;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.CodeLens;
@@ -47,6 +49,7 @@ import org.eclipse.lsp4j.PrepareRenameResult;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ReferenceParams;
 import org.eclipse.lsp4j.RenameParams;
+import org.eclipse.lsp4j.ResolveCallHierarchyItemParams;
 import org.eclipse.lsp4j.ResolveTypeHierarchyItemParams;
 import org.eclipse.lsp4j.SignatureHelp;
 import org.eclipse.lsp4j.SymbolInformation;
@@ -415,6 +418,11 @@ public interface TextDocumentService {
 	 * request would also allow to specify if the item should be resolved and
 	 * whether sub- or supertypes are to be resolved. If no type hierarchy item can
 	 * be found under the given text document position, resolves to {@code null}.
+	 * 
+	 * <p>
+	 * <b>Note:</b> the <a href=
+	 * "https://github.com/Microsoft/vscode-languageserver-node/pull/426">{@code textDocument/typeHierarchy}
+	 * language feature</a> is not yet part of the official LSP specification.
 	 */
 	@Beta
 	@JsonRequest
@@ -428,10 +436,50 @@ public interface TextDocumentService {
 	 * item}. A type hierarchy item is unresolved if the if the
 	 * {@link TypeHierarchyItem#getParents parents} or the
 	 * {@link TypeHierarchyItem#getChildren children} is not defined.
+	 * 
+	 * <p>
+	 * <b>Note:</b> the <a href=
+	 * "https://github.com/Microsoft/vscode-languageserver-node/pull/426">{@code textDocument/typeHierarchy}
+	 * language feature</a> is not yet part of the official LSP specification.
 	 */
 	@Beta
 	@JsonRequest(value="typeHierarchy/resolve", useSegment = false)
 	default CompletableFuture<TypeHierarchyItem> resolveTypeHierarchy(ResolveTypeHierarchyItemParams params) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Request to request the call hierarchy at a given text document position.
+	 *
+	 * The optional request's parameter defines the maximum number of levels to
+	 * {@link CallHierarchyParams#getResolve() resolve} by this request. Unresolved
+	 * items can be resolved in subsequent {@code callHierarchy/resolve} requests.
+	 * 
+	 * <p>
+	 * <b>Note:</b> the <a href=
+	 * "https://github.com/Microsoft/vscode-languageserver-node/pull/420">{@code textDocument/callHierarchy}
+	 * language feature</a> is not yet part of the official LSP specification.
+	 */
+	@Beta
+	@JsonRequest
+	default CompletableFuture<CallHierarchyItem> callHierarchy(CallHierarchyParams params) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Request to resolve a call hierarchy item.
+	 *
+	 * The request's parameter is of type {@link ResolveCallHierarchyItemParams}.
+	 * The response is of type {@link CallHierarchyItem}.
+	 * 
+	 * <p>
+	 * <b>Note:</b> the <a href=
+	 * "https://github.com/Microsoft/vscode-languageserver-node/pull/420">{@code textDocument/callHierarchy}
+	 * language feature</a> is not yet part of the official LSP specification.
+	 */
+	@Beta
+	@JsonRequest(value = "callHierarchy/resolve", useSegment = false)
+	default CompletableFuture<CallHierarchyItem> resolveCallHierarchy(ResolveCallHierarchyItemParams params) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyCapabilities.java
@@ -1,0 +1,64 @@
+/**
+ * Copyright (c) 2016-2018 TypeFox and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.lsp4j;
+
+import com.google.common.annotations.Beta;
+import org.eclipse.lsp4j.DynamicRegistrationCapabilities;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+/**
+ * Capabilities specific to the {@code textDocument/callHierarchy}.
+ * 
+ * <p>
+ * <b>Note:</b> the <a href=
+ * "https://github.com/Microsoft/vscode-languageserver-node/pull/420">{@code textDocument/callHierarchy}
+ * language feature</a> is not yet part of the official LSP specification.
+ */
+@Beta
+@SuppressWarnings("all")
+public class CallHierarchyCapabilities extends DynamicRegistrationCapabilities {
+  public CallHierarchyCapabilities() {
+  }
+  
+  public CallHierarchyCapabilities(final Boolean dynamicRegistration) {
+    super(dynamicRegistration);
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("dynamicRegistration", getDynamicRegistration());
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    if (!super.equals(obj))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return super.hashCode();
+  }
+}

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyItem.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyItem.java
@@ -1,0 +1,365 @@
+/**
+ * Copyright (c) 2016-2018 TypeFox and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.lsp4j;
+
+import com.google.common.annotations.Beta;
+import com.google.gson.annotations.JsonAdapter;
+import java.util.List;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+/**
+ * The result of a {@code textDocument/callHierarchy} request.
+ */
+@Beta
+@SuppressWarnings("all")
+public class CallHierarchyItem {
+  /**
+   * The name of the symbol targeted by the call hierarchy request.
+   */
+  @NonNull
+  private String name;
+  
+  /**
+   * More detail for this symbol, e.g the signature of a function.
+   */
+  private String detail;
+  
+  /**
+   * The kind of this symbol.
+   */
+  @NonNull
+  private SymbolKind kind;
+  
+  /**
+   * URI of the document containing the symbol.
+   */
+  @NonNull
+  private String uri;
+  
+  /**
+   * The range enclosing this symbol not including leading/trailing whitespace but everything else
+   * like comments. This information is typically used to determine if the the clients cursor is
+   * inside the symbol to reveal in the symbol in the UI.
+   */
+  @NonNull
+  private Range range;
+  
+  /**
+   * The range that should be selected and revealed when this symbol is being picked, e.g the name of a function.
+   * Must be contained by the the {@code range}.
+   */
+  @NonNull
+  private Range selectionRange;
+  
+  /**
+   * The actual location of the call.
+   * 
+   * <b>Must be defined</b> in resolved callers/callees.
+   */
+  private Location callLocation;
+  
+  /**
+   * List of incoming calls.
+   * 
+   * <i>Note</i>: The items is <em>unresolved</em> if {@code callers} and {@code callees} is not defined.
+   */
+  private List<CallHierarchyItem> callers;
+  
+  /**
+   * List of outgoing calls.
+   * 
+   * *Note*: The items is <em>unresolved</em> if {@code callers} and {@code callees} is not defined.
+   */
+  private List<CallHierarchyItem> callees;
+  
+  /**
+   * Optional data to identify an item in a resolve request.
+   */
+  @JsonAdapter(JsonElementTypeAdapter.Factory.class)
+  private Object data;
+  
+  /**
+   * The name of the symbol targeted by the call hierarchy request.
+   */
+  @Pure
+  @NonNull
+  public String getName() {
+    return this.name;
+  }
+  
+  /**
+   * The name of the symbol targeted by the call hierarchy request.
+   */
+  public void setName(@NonNull final String name) {
+    this.name = name;
+  }
+  
+  /**
+   * More detail for this symbol, e.g the signature of a function.
+   */
+  @Pure
+  public String getDetail() {
+    return this.detail;
+  }
+  
+  /**
+   * More detail for this symbol, e.g the signature of a function.
+   */
+  public void setDetail(final String detail) {
+    this.detail = detail;
+  }
+  
+  /**
+   * The kind of this symbol.
+   */
+  @Pure
+  @NonNull
+  public SymbolKind getKind() {
+    return this.kind;
+  }
+  
+  /**
+   * The kind of this symbol.
+   */
+  public void setKind(@NonNull final SymbolKind kind) {
+    this.kind = kind;
+  }
+  
+  /**
+   * URI of the document containing the symbol.
+   */
+  @Pure
+  @NonNull
+  public String getUri() {
+    return this.uri;
+  }
+  
+  /**
+   * URI of the document containing the symbol.
+   */
+  public void setUri(@NonNull final String uri) {
+    this.uri = uri;
+  }
+  
+  /**
+   * The range enclosing this symbol not including leading/trailing whitespace but everything else
+   * like comments. This information is typically used to determine if the the clients cursor is
+   * inside the symbol to reveal in the symbol in the UI.
+   */
+  @Pure
+  @NonNull
+  public Range getRange() {
+    return this.range;
+  }
+  
+  /**
+   * The range enclosing this symbol not including leading/trailing whitespace but everything else
+   * like comments. This information is typically used to determine if the the clients cursor is
+   * inside the symbol to reveal in the symbol in the UI.
+   */
+  public void setRange(@NonNull final Range range) {
+    this.range = range;
+  }
+  
+  /**
+   * The range that should be selected and revealed when this symbol is being picked, e.g the name of a function.
+   * Must be contained by the the {@code range}.
+   */
+  @Pure
+  @NonNull
+  public Range getSelectionRange() {
+    return this.selectionRange;
+  }
+  
+  /**
+   * The range that should be selected and revealed when this symbol is being picked, e.g the name of a function.
+   * Must be contained by the the {@code range}.
+   */
+  public void setSelectionRange(@NonNull final Range selectionRange) {
+    this.selectionRange = selectionRange;
+  }
+  
+  /**
+   * The actual location of the call.
+   * 
+   * <b>Must be defined</b> in resolved callers/callees.
+   */
+  @Pure
+  public Location getCallLocation() {
+    return this.callLocation;
+  }
+  
+  /**
+   * The actual location of the call.
+   * 
+   * <b>Must be defined</b> in resolved callers/callees.
+   */
+  public void setCallLocation(final Location callLocation) {
+    this.callLocation = callLocation;
+  }
+  
+  /**
+   * List of incoming calls.
+   * 
+   * <i>Note</i>: The items is <em>unresolved</em> if {@code callers} and {@code callees} is not defined.
+   */
+  @Pure
+  public List<CallHierarchyItem> getCallers() {
+    return this.callers;
+  }
+  
+  /**
+   * List of incoming calls.
+   * 
+   * <i>Note</i>: The items is <em>unresolved</em> if {@code callers} and {@code callees} is not defined.
+   */
+  public void setCallers(final List<CallHierarchyItem> callers) {
+    this.callers = callers;
+  }
+  
+  /**
+   * List of outgoing calls.
+   * 
+   * *Note*: The items is <em>unresolved</em> if {@code callers} and {@code callees} is not defined.
+   */
+  @Pure
+  public List<CallHierarchyItem> getCallees() {
+    return this.callees;
+  }
+  
+  /**
+   * List of outgoing calls.
+   * 
+   * *Note*: The items is <em>unresolved</em> if {@code callers} and {@code callees} is not defined.
+   */
+  public void setCallees(final List<CallHierarchyItem> callees) {
+    this.callees = callees;
+  }
+  
+  /**
+   * Optional data to identify an item in a resolve request.
+   */
+  @Pure
+  public Object getData() {
+    return this.data;
+  }
+  
+  /**
+   * Optional data to identify an item in a resolve request.
+   */
+  public void setData(final Object data) {
+    this.data = data;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("name", this.name);
+    b.add("detail", this.detail);
+    b.add("kind", this.kind);
+    b.add("uri", this.uri);
+    b.add("range", this.range);
+    b.add("selectionRange", this.selectionRange);
+    b.add("callLocation", this.callLocation);
+    b.add("callers", this.callers);
+    b.add("callees", this.callees);
+    b.add("data", this.data);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    CallHierarchyItem other = (CallHierarchyItem) obj;
+    if (this.name == null) {
+      if (other.name != null)
+        return false;
+    } else if (!this.name.equals(other.name))
+      return false;
+    if (this.detail == null) {
+      if (other.detail != null)
+        return false;
+    } else if (!this.detail.equals(other.detail))
+      return false;
+    if (this.kind == null) {
+      if (other.kind != null)
+        return false;
+    } else if (!this.kind.equals(other.kind))
+      return false;
+    if (this.uri == null) {
+      if (other.uri != null)
+        return false;
+    } else if (!this.uri.equals(other.uri))
+      return false;
+    if (this.range == null) {
+      if (other.range != null)
+        return false;
+    } else if (!this.range.equals(other.range))
+      return false;
+    if (this.selectionRange == null) {
+      if (other.selectionRange != null)
+        return false;
+    } else if (!this.selectionRange.equals(other.selectionRange))
+      return false;
+    if (this.callLocation == null) {
+      if (other.callLocation != null)
+        return false;
+    } else if (!this.callLocation.equals(other.callLocation))
+      return false;
+    if (this.callers == null) {
+      if (other.callers != null)
+        return false;
+    } else if (!this.callers.equals(other.callers))
+      return false;
+    if (this.callees == null) {
+      if (other.callees != null)
+        return false;
+    } else if (!this.callees.equals(other.callees))
+      return false;
+    if (this.data == null) {
+      if (other.data != null)
+        return false;
+    } else if (!this.data.equals(other.data))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.name== null) ? 0 : this.name.hashCode());
+    result = prime * result + ((this.detail== null) ? 0 : this.detail.hashCode());
+    result = prime * result + ((this.kind== null) ? 0 : this.kind.hashCode());
+    result = prime * result + ((this.uri== null) ? 0 : this.uri.hashCode());
+    result = prime * result + ((this.range== null) ? 0 : this.range.hashCode());
+    result = prime * result + ((this.selectionRange== null) ? 0 : this.selectionRange.hashCode());
+    result = prime * result + ((this.callLocation== null) ? 0 : this.callLocation.hashCode());
+    result = prime * result + ((this.callers== null) ? 0 : this.callers.hashCode());
+    result = prime * result + ((this.callees== null) ? 0 : this.callees.hashCode());
+    return prime * result + ((this.data== null) ? 0 : this.data.hashCode());
+  }
+}

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyParams.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2016-2018 TypeFox and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.lsp4j;
+
+import com.google.common.annotations.Beta;
+import org.eclipse.lsp4j.TextDocumentPositionParams;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+/**
+ * The parameters of a {@code textDocument/callHierarchy} request.
+ */
+@Beta
+@SuppressWarnings("all")
+public class CallHierarchyParams extends TextDocumentPositionParams {
+  /**
+   * The number of levels to resolve.
+   */
+  private int resolve;
+  
+  /**
+   * Outgoing direction for callees. Valid values are: {@code incoming} and {@code outgoing}.
+   * The default is {@code incoming} for callers.
+   */
+  private String direction;
+  
+  /**
+   * The number of levels to resolve.
+   */
+  @Pure
+  public int getResolve() {
+    return this.resolve;
+  }
+  
+  /**
+   * The number of levels to resolve.
+   */
+  public void setResolve(final int resolve) {
+    this.resolve = resolve;
+  }
+  
+  /**
+   * Outgoing direction for callees. Valid values are: {@code incoming} and {@code outgoing}.
+   * The default is {@code incoming} for callers.
+   */
+  @Pure
+  public String getDirection() {
+    return this.direction;
+  }
+  
+  /**
+   * Outgoing direction for callees. Valid values are: {@code incoming} and {@code outgoing}.
+   * The default is {@code incoming} for callers.
+   */
+  public void setDirection(final String direction) {
+    this.direction = direction;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("resolve", this.resolve);
+    b.add("direction", this.direction);
+    b.add("textDocument", getTextDocument());
+    b.add("uri", getUri());
+    b.add("position", getPosition());
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    if (!super.equals(obj))
+      return false;
+    CallHierarchyParams other = (CallHierarchyParams) obj;
+    if (other.resolve != this.resolve)
+      return false;
+    if (this.direction == null) {
+      if (other.direction != null)
+        return false;
+    } else if (!this.direction.equals(other.direction))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = super.hashCode();
+    result = prime * result + this.resolve;
+    return prime * result + ((this.direction== null) ? 0 : this.direction.hashCode());
+  }
+}

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentSymbol.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentSymbol.java
@@ -39,7 +39,7 @@ public class DocumentSymbol {
   
   /**
    * The range enclosing this symbol not including leading/trailing whitespace but everything else
-   * like comments. This information is typically used to determine if the the clients cursor is
+   * like comments. This information is typically used to determine if the clients cursor is
    * inside the symbol to reveal in the symbol in the UI.
    */
   @NonNull
@@ -47,7 +47,7 @@ public class DocumentSymbol {
   
   /**
    * The range that should be selected and revealed when this symbol is being picked, e.g the name of a function.
-   * Must be contained by the the `range`.
+   * Must be contained by the `range`.
    */
   @NonNull
   private Range selectionRange;
@@ -129,7 +129,7 @@ public class DocumentSymbol {
   
   /**
    * The range enclosing this symbol not including leading/trailing whitespace but everything else
-   * like comments. This information is typically used to determine if the the clients cursor is
+   * like comments. This information is typically used to determine if the clients cursor is
    * inside the symbol to reveal in the symbol in the UI.
    */
   @Pure
@@ -140,7 +140,7 @@ public class DocumentSymbol {
   
   /**
    * The range enclosing this symbol not including leading/trailing whitespace but everything else
-   * like comments. This information is typically used to determine if the the clients cursor is
+   * like comments. This information is typically used to determine if the clients cursor is
    * inside the symbol to reveal in the symbol in the UI.
    */
   public void setRange(@NonNull final Range range) {
@@ -149,7 +149,7 @@ public class DocumentSymbol {
   
   /**
    * The range that should be selected and revealed when this symbol is being picked, e.g the name of a function.
-   * Must be contained by the the `range`.
+   * Must be contained by the `range`.
    */
   @Pure
   @NonNull
@@ -159,7 +159,7 @@ public class DocumentSymbol {
   
   /**
    * The range that should be selected and revealed when this symbol is being picked, e.g the name of a function.
-   * Must be contained by the the `range`.
+   * Must be contained by the `range`.
    */
   public void setSelectionRange(@NonNull final Range selectionRange) {
     this.selectionRange = selectionRange;

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ResolveCallHierarchyItemParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ResolveCallHierarchyItemParams.java
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) 2016-2018 TypeFox and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.lsp4j;
+
+import com.google.common.annotations.Beta;
+import org.eclipse.lsp4j.CallHierarchyItem;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+/**
+ * The parameters of a {@code callHierarchy/resolve} request.
+ */
+@Beta
+@SuppressWarnings("all")
+public class ResolveCallHierarchyItemParams {
+  /**
+   * Unresolved item.
+   */
+  @NonNull
+  private CallHierarchyItem item;
+  
+  /**
+   * The number of levels to resolve.
+   */
+  private int resolve;
+  
+  /**
+   * Outgoing direction for callees. Valid values are: {@code incoming} and {@code outgoing}.
+   * The default is {@code incoming} for callers.
+   */
+  @NonNull
+  private String direction;
+  
+  /**
+   * Unresolved item.
+   */
+  @Pure
+  @NonNull
+  public CallHierarchyItem getItem() {
+    return this.item;
+  }
+  
+  /**
+   * Unresolved item.
+   */
+  public void setItem(@NonNull final CallHierarchyItem item) {
+    this.item = item;
+  }
+  
+  /**
+   * The number of levels to resolve.
+   */
+  @Pure
+  public int getResolve() {
+    return this.resolve;
+  }
+  
+  /**
+   * The number of levels to resolve.
+   */
+  public void setResolve(final int resolve) {
+    this.resolve = resolve;
+  }
+  
+  /**
+   * Outgoing direction for callees. Valid values are: {@code incoming} and {@code outgoing}.
+   * The default is {@code incoming} for callers.
+   */
+  @Pure
+  @NonNull
+  public String getDirection() {
+    return this.direction;
+  }
+  
+  /**
+   * Outgoing direction for callees. Valid values are: {@code incoming} and {@code outgoing}.
+   * The default is {@code incoming} for callers.
+   */
+  public void setDirection(@NonNull final String direction) {
+    this.direction = direction;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("item", this.item);
+    b.add("resolve", this.resolve);
+    b.add("direction", this.direction);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    ResolveCallHierarchyItemParams other = (ResolveCallHierarchyItemParams) obj;
+    if (this.item == null) {
+      if (other.item != null)
+        return false;
+    } else if (!this.item.equals(other.item))
+      return false;
+    if (other.resolve != this.resolve)
+      return false;
+    if (this.direction == null) {
+      if (other.direction != null)
+        return false;
+    } else if (!this.direction.equals(other.direction))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.item== null) ? 0 : this.item.hashCode());
+    result = prime * result + this.resolve;
+    return prime * result + ((this.direction== null) ? 0 : this.direction.hashCode());
+  }
+}

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ResolveTypeHierarchyItemParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ResolveTypeHierarchyItemParams.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j;
 
+import org.eclipse.lsp4j.TypeHierarchyDirection;
 import org.eclipse.lsp4j.TypeHierarchyItem;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
@@ -36,18 +37,9 @@ public class ResolveTypeHierarchyItemParams {
   
   /**
    * The direction of the type hierarchy resolution.
-   * 
-   * <p>
-   * The followings are the legal values:
-   * <ul>
-   * <li>{@code children},</li>
-   * <li>{@code parents}, and</li>
-   * <li>{@code both}.</li>
-   * </ul>
-   * </p>
    */
   @NonNull
-  private String direction;
+  private TypeHierarchyDirection direction;
   
   /**
    * The hierarchy item to resolve.
@@ -82,35 +74,17 @@ public class ResolveTypeHierarchyItemParams {
   
   /**
    * The direction of the type hierarchy resolution.
-   * 
-   * <p>
-   * The followings are the legal values:
-   * <ul>
-   * <li>{@code children},</li>
-   * <li>{@code parents}, and</li>
-   * <li>{@code both}.</li>
-   * </ul>
-   * </p>
    */
   @Pure
   @NonNull
-  public String getDirection() {
+  public TypeHierarchyDirection getDirection() {
     return this.direction;
   }
   
   /**
    * The direction of the type hierarchy resolution.
-   * 
-   * <p>
-   * The followings are the legal values:
-   * <ul>
-   * <li>{@code children},</li>
-   * <li>{@code parents}, and</li>
-   * <li>{@code both}.</li>
-   * </ul>
-   * </p>
    */
-  public void setDirection(@NonNull final String direction) {
+  public void setDirection(@NonNull final TypeHierarchyDirection direction) {
     this.direction = direction;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SemanticHighlightingCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SemanticHighlightingCapabilities.java
@@ -17,6 +17,11 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
  * Capabilities specific to {@code textDocument/semanticHighlighting}.
+ * 
+ * <p>
+ * <b>Note:</b> the <a href=
+ * "https://github.com/Microsoft/vscode-languageserver-node/pull/367">{@code textDocument/semanticHighlighting}
+ * language feature</a> is not yet part of the official LSP specification.
  */
 @Beta
 @SuppressWarnings("all")

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SemanticHighlightingServerCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SemanticHighlightingServerCapabilities.java
@@ -18,6 +18,11 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
  * Semantic highlighting server capabilities.
+ * 
+ * <p>
+ * <b>Note:</b> the <a href=
+ * "https://github.com/Microsoft/vscode-languageserver-node/pull/367">{@code textDocument/semanticHighlighting}
+ * language feature</a> is not yet part of the official LSP specification.
  */
 @Beta
 @SuppressWarnings("all")

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ServerCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ServerCapabilities.java
@@ -172,7 +172,7 @@ public class ServerCapabilities {
    * language feature</a> is not yet part of the official LSP specification.
    */
   @Beta
-  private Boolean typeHierarchy;
+  private Either<Boolean, StaticRegistrationOptions> typeHierarchyProvider;
   
   /**
    * The server provides Call Hierarchy support.
@@ -680,8 +680,8 @@ public class ServerCapabilities {
    * language feature</a> is not yet part of the official LSP specification.
    */
   @Pure
-  public Boolean getTypeHierarchy() {
-    return this.typeHierarchy;
+  public Either<Boolean, StaticRegistrationOptions> getTypeHierarchyProvider() {
+    return this.typeHierarchyProvider;
   }
   
   /**
@@ -693,8 +693,24 @@ public class ServerCapabilities {
    * "https://github.com/Microsoft/vscode-languageserver-node/pull/426">{@code textDocument/typeHierarchy}
    * language feature</a> is not yet part of the official LSP specification.
    */
-  public void setTypeHierarchy(final Boolean typeHierarchy) {
-    this.typeHierarchy = typeHierarchy;
+  public void setTypeHierarchyProvider(final Either<Boolean, StaticRegistrationOptions> typeHierarchyProvider) {
+    this.typeHierarchyProvider = typeHierarchyProvider;
+  }
+  
+  public void setTypeHierarchyProvider(final Boolean typeHierarchyProvider) {
+    if (typeHierarchyProvider == null) {
+      this.typeHierarchyProvider = null;
+      return;
+    }
+    this.typeHierarchyProvider = Either.forLeft(typeHierarchyProvider);
+  }
+  
+  public void setTypeHierarchyProvider(final StaticRegistrationOptions typeHierarchyProvider) {
+    if (typeHierarchyProvider == null) {
+      this.typeHierarchyProvider = null;
+      return;
+    }
+    this.typeHierarchyProvider = Either.forRight(typeHierarchyProvider);
   }
   
   /**
@@ -780,7 +796,7 @@ public class ServerCapabilities {
     b.add("executeCommandProvider", this.executeCommandProvider);
     b.add("workspace", this.workspace);
     b.add("semanticHighlighting", this.semanticHighlighting);
-    b.add("typeHierarchy", this.typeHierarchy);
+    b.add("typeHierarchyProvider", this.typeHierarchyProvider);
     b.add("callHierarchyProvider", this.callHierarchyProvider);
     b.add("experimental", this.experimental);
     return b.toString();
@@ -911,10 +927,10 @@ public class ServerCapabilities {
         return false;
     } else if (!this.semanticHighlighting.equals(other.semanticHighlighting))
       return false;
-    if (this.typeHierarchy == null) {
-      if (other.typeHierarchy != null)
+    if (this.typeHierarchyProvider == null) {
+      if (other.typeHierarchyProvider != null)
         return false;
-    } else if (!this.typeHierarchy.equals(other.typeHierarchy))
+    } else if (!this.typeHierarchyProvider.equals(other.typeHierarchyProvider))
       return false;
     if (this.callHierarchyProvider == null) {
       if (other.callHierarchyProvider != null)
@@ -957,7 +973,7 @@ public class ServerCapabilities {
     result = prime * result + ((this.executeCommandProvider== null) ? 0 : this.executeCommandProvider.hashCode());
     result = prime * result + ((this.workspace== null) ? 0 : this.workspace.hashCode());
     result = prime * result + ((this.semanticHighlighting== null) ? 0 : this.semanticHighlighting.hashCode());
-    result = prime * result + ((this.typeHierarchy== null) ? 0 : this.typeHierarchy.hashCode());
+    result = prime * result + ((this.typeHierarchyProvider== null) ? 0 : this.typeHierarchyProvider.hashCode());
     result = prime * result + ((this.callHierarchyProvider== null) ? 0 : this.callHierarchyProvider.hashCode());
     return prime * result + ((this.experimental== null) ? 0 : this.experimental.hashCode());
   }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ServerCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ServerCapabilities.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j;
 
+import com.google.common.annotations.Beta;
 import com.google.gson.annotations.JsonAdapter;
 import org.eclipse.lsp4j.CodeActionOptions;
 import org.eclipse.lsp4j.CodeLensOptions;
@@ -158,13 +159,31 @@ public class ServerCapabilities {
   /**
    * Semantic highlighting server capabilities.
    */
+  @Beta
   private SemanticHighlightingServerCapabilities semanticHighlighting;
   
   /**
    * Server capability for calculating super- and subtype hierarchies.
    * The LS supports the type hierarchy language feature, if this capability is set to {@code true}.
+   * 
+   * <p>
+   * <b>Note:</b> the <a href=
+   * "https://github.com/Microsoft/vscode-languageserver-node/pull/426">{@code textDocument/typeHierarchy}
+   * language feature</a> is not yet part of the official LSP specification.
    */
+  @Beta
   private Boolean typeHierarchy;
+  
+  /**
+   * The server provides Call Hierarchy support.
+   * 
+   * <p>
+   * <b>Note:</b> the <a href=
+   * "https://github.com/Microsoft/vscode-languageserver-node/pull/420">{@code textDocument/callHierarchy}
+   * language feature</a> is not yet part of the official LSP specification.
+   */
+  @Beta
+  private Either<Boolean, StaticRegistrationOptions> callHierarchyProvider;
   
   /**
    * Experimental server capabilities.
@@ -654,6 +673,11 @@ public class ServerCapabilities {
   /**
    * Server capability for calculating super- and subtype hierarchies.
    * The LS supports the type hierarchy language feature, if this capability is set to {@code true}.
+   * 
+   * <p>
+   * <b>Note:</b> the <a href=
+   * "https://github.com/Microsoft/vscode-languageserver-node/pull/426">{@code textDocument/typeHierarchy}
+   * language feature</a> is not yet part of the official LSP specification.
    */
   @Pure
   public Boolean getTypeHierarchy() {
@@ -663,9 +687,55 @@ public class ServerCapabilities {
   /**
    * Server capability for calculating super- and subtype hierarchies.
    * The LS supports the type hierarchy language feature, if this capability is set to {@code true}.
+   * 
+   * <p>
+   * <b>Note:</b> the <a href=
+   * "https://github.com/Microsoft/vscode-languageserver-node/pull/426">{@code textDocument/typeHierarchy}
+   * language feature</a> is not yet part of the official LSP specification.
    */
   public void setTypeHierarchy(final Boolean typeHierarchy) {
     this.typeHierarchy = typeHierarchy;
+  }
+  
+  /**
+   * The server provides Call Hierarchy support.
+   * 
+   * <p>
+   * <b>Note:</b> the <a href=
+   * "https://github.com/Microsoft/vscode-languageserver-node/pull/420">{@code textDocument/callHierarchy}
+   * language feature</a> is not yet part of the official LSP specification.
+   */
+  @Pure
+  public Either<Boolean, StaticRegistrationOptions> getCallHierarchyProvider() {
+    return this.callHierarchyProvider;
+  }
+  
+  /**
+   * The server provides Call Hierarchy support.
+   * 
+   * <p>
+   * <b>Note:</b> the <a href=
+   * "https://github.com/Microsoft/vscode-languageserver-node/pull/420">{@code textDocument/callHierarchy}
+   * language feature</a> is not yet part of the official LSP specification.
+   */
+  public void setCallHierarchyProvider(final Either<Boolean, StaticRegistrationOptions> callHierarchyProvider) {
+    this.callHierarchyProvider = callHierarchyProvider;
+  }
+  
+  public void setCallHierarchyProvider(final Boolean callHierarchyProvider) {
+    if (callHierarchyProvider == null) {
+      this.callHierarchyProvider = null;
+      return;
+    }
+    this.callHierarchyProvider = Either.forLeft(callHierarchyProvider);
+  }
+  
+  public void setCallHierarchyProvider(final StaticRegistrationOptions callHierarchyProvider) {
+    if (callHierarchyProvider == null) {
+      this.callHierarchyProvider = null;
+      return;
+    }
+    this.callHierarchyProvider = Either.forRight(callHierarchyProvider);
   }
   
   /**
@@ -711,6 +781,7 @@ public class ServerCapabilities {
     b.add("workspace", this.workspace);
     b.add("semanticHighlighting", this.semanticHighlighting);
     b.add("typeHierarchy", this.typeHierarchy);
+    b.add("callHierarchyProvider", this.callHierarchyProvider);
     b.add("experimental", this.experimental);
     return b.toString();
   }
@@ -845,6 +916,11 @@ public class ServerCapabilities {
         return false;
     } else if (!this.typeHierarchy.equals(other.typeHierarchy))
       return false;
+    if (this.callHierarchyProvider == null) {
+      if (other.callHierarchyProvider != null)
+        return false;
+    } else if (!this.callHierarchyProvider.equals(other.callHierarchyProvider))
+      return false;
     if (this.experimental == null) {
       if (other.experimental != null)
         return false;
@@ -882,6 +958,7 @@ public class ServerCapabilities {
     result = prime * result + ((this.workspace== null) ? 0 : this.workspace.hashCode());
     result = prime * result + ((this.semanticHighlighting== null) ? 0 : this.semanticHighlighting.hashCode());
     result = prime * result + ((this.typeHierarchy== null) ? 0 : this.typeHierarchy.hashCode());
+    result = prime * result + ((this.callHierarchyProvider== null) ? 0 : this.callHierarchyProvider.hashCode());
     return prime * result + ((this.experimental== null) ? 0 : this.experimental.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentClientCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentClientCapabilities.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j;
 
 import com.google.common.annotations.Beta;
+import org.eclipse.lsp4j.CallHierarchyCapabilities;
 import org.eclipse.lsp4j.CodeActionCapabilities;
 import org.eclipse.lsp4j.CodeLensCapabilities;
 import org.eclipse.lsp4j.ColorProviderCapabilities;
@@ -159,6 +160,12 @@ public class TextDocumentClientCapabilities {
    */
   @Beta
   private TypeHierarchyCapabilities typeHierarchyCapabilities;
+  
+  /**
+   * Capabilities specific to {@code textDocument/callHierarchy}.
+   */
+  @Beta
+  private CallHierarchyCapabilities callHierarchy;
   
   @Pure
   public SynchronizationCapabilities getSynchronization() {
@@ -502,6 +509,21 @@ public class TextDocumentClientCapabilities {
     this.typeHierarchyCapabilities = typeHierarchyCapabilities;
   }
   
+  /**
+   * Capabilities specific to {@code textDocument/callHierarchy}.
+   */
+  @Pure
+  public CallHierarchyCapabilities getCallHierarchy() {
+    return this.callHierarchy;
+  }
+  
+  /**
+   * Capabilities specific to {@code textDocument/callHierarchy}.
+   */
+  public void setCallHierarchy(final CallHierarchyCapabilities callHierarchy) {
+    this.callHierarchy = callHierarchy;
+  }
+  
   @Override
   @Pure
   public String toString() {
@@ -528,6 +550,7 @@ public class TextDocumentClientCapabilities {
     b.add("foldingRange", this.foldingRange);
     b.add("semanticHighlightingCapabilities", this.semanticHighlightingCapabilities);
     b.add("typeHierarchyCapabilities", this.typeHierarchyCapabilities);
+    b.add("callHierarchy", this.callHierarchy);
     return b.toString();
   }
   
@@ -651,6 +674,11 @@ public class TextDocumentClientCapabilities {
         return false;
     } else if (!this.typeHierarchyCapabilities.equals(other.typeHierarchyCapabilities))
       return false;
+    if (this.callHierarchy == null) {
+      if (other.callHierarchy != null)
+        return false;
+    } else if (!this.callHierarchy.equals(other.callHierarchy))
+      return false;
     return true;
   }
   
@@ -680,6 +708,7 @@ public class TextDocumentClientCapabilities {
     result = prime * result + ((this.publishDiagnostics== null) ? 0 : this.publishDiagnostics.hashCode());
     result = prime * result + ((this.foldingRange== null) ? 0 : this.foldingRange.hashCode());
     result = prime * result + ((this.semanticHighlightingCapabilities== null) ? 0 : this.semanticHighlightingCapabilities.hashCode());
-    return prime * result + ((this.typeHierarchyCapabilities== null) ? 0 : this.typeHierarchyCapabilities.hashCode());
+    result = prime * result + ((this.typeHierarchyCapabilities== null) ? 0 : this.typeHierarchyCapabilities.hashCode());
+    return prime * result + ((this.callHierarchy== null) ? 0 : this.callHierarchy.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TypeHierarchyCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TypeHierarchyCapabilities.java
@@ -18,6 +18,11 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 /**
  * Capabilities specific to the {@code textDocument/typeHierarchy} and the {@code typeHierarchy/resolve}
  * language server methods.
+ * 
+ * <p>
+ * <b>Note:</b> the <a href=
+ * "https://github.com/Microsoft/vscode-languageserver-node/pull/426">{@code textDocument/typeHierarchy}
+ * language feature</a> is not yet part of the official LSP specification.
  */
 @Beta
 @SuppressWarnings("all")
@@ -26,9 +31,6 @@ public class TypeHierarchyCapabilities {
    * The language client supports super- and subtype hierarchies.
    */
   private Boolean typeHierarchy;
-  
-  public TypeHierarchyCapabilities() {
-  }
   
   public TypeHierarchyCapabilities(final Boolean typeHierarchy) {
     this.typeHierarchy = typeHierarchy;

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TypeHierarchyCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TypeHierarchyCapabilities.java
@@ -12,12 +12,12 @@
 package org.eclipse.lsp4j;
 
 import com.google.common.annotations.Beta;
+import org.eclipse.lsp4j.DynamicRegistrationCapabilities;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
- * Capabilities specific to the {@code textDocument/typeHierarchy} and the {@code typeHierarchy/resolve}
- * language server methods.
+ * Capabilities specific to the {@code textDocument/typeHierarchy}.
  * 
  * <p>
  * <b>Note:</b> the <a href=
@@ -26,36 +26,19 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
  */
 @Beta
 @SuppressWarnings("all")
-public class TypeHierarchyCapabilities {
-  /**
-   * The language client supports super- and subtype hierarchies.
-   */
-  private Boolean typeHierarchy;
-  
-  public TypeHierarchyCapabilities(final Boolean typeHierarchy) {
-    this.typeHierarchy = typeHierarchy;
+public class TypeHierarchyCapabilities extends DynamicRegistrationCapabilities {
+  public TypeHierarchyCapabilities() {
   }
   
-  /**
-   * The language client supports super- and subtype hierarchies.
-   */
-  @Pure
-  public Boolean getTypeHierarchy() {
-    return this.typeHierarchy;
-  }
-  
-  /**
-   * The language client supports super- and subtype hierarchies.
-   */
-  public void setTypeHierarchy(final Boolean typeHierarchy) {
-    this.typeHierarchy = typeHierarchy;
+  public TypeHierarchyCapabilities(final Boolean dynamicRegistration) {
+    super(dynamicRegistration);
   }
   
   @Override
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
-    b.add("typeHierarchy", this.typeHierarchy);
+    b.add("dynamicRegistration", getDynamicRegistration());
     return b.toString();
   }
   
@@ -68,11 +51,7 @@ public class TypeHierarchyCapabilities {
       return false;
     if (getClass() != obj.getClass())
       return false;
-    TypeHierarchyCapabilities other = (TypeHierarchyCapabilities) obj;
-    if (this.typeHierarchy == null) {
-      if (other.typeHierarchy != null)
-        return false;
-    } else if (!this.typeHierarchy.equals(other.typeHierarchy))
+    if (!super.equals(obj))
       return false;
     return true;
   }
@@ -80,6 +59,6 @@ public class TypeHierarchyCapabilities {
   @Override
   @Pure
   public int hashCode() {
-    return 31 * 1 + ((this.typeHierarchy== null) ? 0 : this.typeHierarchy.hashCode());
+    return super.hashCode();
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TypeHierarchyItem.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TypeHierarchyItem.java
@@ -55,7 +55,7 @@ public class TypeHierarchyItem {
   
   /**
    * The range enclosing this type hierarchy item not including leading/trailing whitespace but everything else
-   * like comments. This information is typically used to determine if the the clients cursor is inside the type
+   * like comments. This information is typically used to determine if the clients cursor is inside the type
    * hierarchy item to reveal in the symbol in the UI.
    * 
    * @see TypeHierarchyItem#selectionRange
@@ -170,7 +170,7 @@ public class TypeHierarchyItem {
   
   /**
    * The range enclosing this type hierarchy item not including leading/trailing whitespace but everything else
-   * like comments. This information is typically used to determine if the the clients cursor is inside the type
+   * like comments. This information is typically used to determine if the clients cursor is inside the type
    * hierarchy item to reveal in the symbol in the UI.
    * 
    * @see TypeHierarchyItem#selectionRange
@@ -183,7 +183,7 @@ public class TypeHierarchyItem {
   
   /**
    * The range enclosing this type hierarchy item not including leading/trailing whitespace but everything else
-   * like comments. This information is typically used to determine if the the clients cursor is inside the type
+   * like comments. This information is typically used to determine if the clients cursor is inside the type
    * hierarchy item to reveal in the symbol in the UI.
    * 
    * @see TypeHierarchyItem#selectionRange

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TypeHierarchyParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TypeHierarchyParams.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j;
 
 import org.eclipse.lsp4j.TextDocumentPositionParams;
+import org.eclipse.lsp4j.TypeHierarchyDirection;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -28,18 +29,9 @@ public class TypeHierarchyParams extends TextDocumentPositionParams {
   private int resolve;
   
   /**
-   * The direction of the type hierarchy resolution. If not defined, defaults to {@code children}.
-   * 
-   * <p>
-   * The followings are the legal values:
-   * <ul>
-   * <li>{@code children},</li>
-   * <li>{@code parents}, and</li>
-   * <li>{@code both}.</li>
-   * </ul>
-   * </p>
+   * The direction of the type hierarchy resolution. If not defined, defaults to {@link TypeHierarchyDirection#Children Children}.
    */
-  private String direction;
+  private TypeHierarchyDirection direction;
   
   /**
    * The number of hierarchy levels to resolve. {@code 0} indicates no hierarchy level. It defaults to {@code 0}.
@@ -57,35 +49,17 @@ public class TypeHierarchyParams extends TextDocumentPositionParams {
   }
   
   /**
-   * The direction of the type hierarchy resolution. If not defined, defaults to {@code children}.
-   * 
-   * <p>
-   * The followings are the legal values:
-   * <ul>
-   * <li>{@code children},</li>
-   * <li>{@code parents}, and</li>
-   * <li>{@code both}.</li>
-   * </ul>
-   * </p>
+   * The direction of the type hierarchy resolution. If not defined, defaults to {@link TypeHierarchyDirection#Children Children}.
    */
   @Pure
-  public String getDirection() {
+  public TypeHierarchyDirection getDirection() {
     return this.direction;
   }
   
   /**
-   * The direction of the type hierarchy resolution. If not defined, defaults to {@code children}.
-   * 
-   * <p>
-   * The followings are the legal values:
-   * <ul>
-   * <li>{@code children},</li>
-   * <li>{@code parents}, and</li>
-   * <li>{@code both}.</li>
-   * </ul>
-   * </p>
+   * The direction of the type hierarchy resolution. If not defined, defaults to {@link TypeHierarchyDirection#Children Children}.
    */
-  public void setDirection(final String direction) {
+  public void setDirection(final TypeHierarchyDirection direction) {
     this.direction = direction;
   }
   


### PR DESCRIPTION
Closes #296.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

----

LSP PR: https://github.com/Microsoft/vscode-languageserver-node/pull/420