### PR TITLE
Aligned the `textDocument/callHierarchy` implementation with the LSP.

### DIFF
--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/CallHierarchyDirection.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/CallHierarchyDirection.java
@@ -1,0 +1,46 @@
+/******************************************************************************
+ * Copyright (c) 2019 TypeFox and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.lsp4j;
+
+/**
+ * The direction of a call hierarchy.
+ */
+public enum CallHierarchyDirection {
+
+	/**
+	 * The callers of a symbol.
+	 */
+	Incoming(1),
+
+	/**
+	 * The callees of a symbol.
+	 */
+	Outgoing(2);
+
+	private final int value;
+
+	private CallHierarchyDirection(int value) {
+		this.value = value;
+	}
+
+	public int getValue() {
+		return value;
+	}
+
+	public static InsertTextFormat forValue(int value) {
+		InsertTextFormat[] allValues = InsertTextFormat.values();
+		if (value < 1 || value > allValues.length)
+			throw new IllegalArgumentException("Illegal enum value: " + value);
+		return allValues[value - 1];
+	}
+
+}

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -4651,10 +4651,9 @@ class CallHierarchyParams extends TextDocumentPositionParams {
 	int resolve
 
 	/**
-	 * Outgoing direction for callees. Valid values are: {@code incoming} and {@code outgoing}.
-	 * The default is {@code incoming} for callers.
+	 * The direction of calls to resolve.
 	 */
-	String direction
+	CallHierarchyDirection direction
 
 }
 
@@ -4677,11 +4676,10 @@ class ResolveCallHierarchyItemParams {
 	int resolve
 
 	/**
-	 * Outgoing direction for callees. Valid values are: {@code incoming} and {@code outgoing}.
-	 * The default is {@code incoming} for callers.
+	 * The direction of calls to resolve.
 	 */
 	@NonNull
-	String direction
+	CallHierarchyDirection direction
 
 }
 
@@ -4716,6 +4714,11 @@ class CallHierarchyItem {
 	String uri
 
 	/**
+	 * {@code true} if the hierarchy item is deprecated. Otherwise, {@code false}. It is {@code false} by default.
+	 */
+	Boolean deprecated
+
+	/**
 	 * The range enclosing this symbol not including leading/trailing whitespace but everything else
 	 * like comments. This information is typically used to determine if the the clients cursor is
 	 * inside the symbol to reveal in the symbol in the UI.
@@ -4731,25 +4734,18 @@ class CallHierarchyItem {
 	Range selectionRange
 
 	/**
-	 * The actual location of the call.
+	 * The actual locations of incoming (or outgoing) calls to (or from) a callable identified by this item.
 	 *
-	 * <b>Must be defined</b> in resolved callers/callees.
+	 * <b>Note</b>: undefined in root item.
 	 */
-	Location callLocation
+	List<Location> callLocations
 
 	/**
-	 * List of incoming calls.
+	 * List of incoming (or outgoing) calls to (or from) a callable identified by this item.
 	 *
-	 * <i>Note</i>: The items is <em>unresolved</em> if {@code callers} and {@code callees} is not defined.
+	 * <b>Note</b>: if undefined, this item is unresolved.
 	 */
-	List<CallHierarchyItem> callers
-
-	/**
-	 * List of outgoing calls.
-	 *
-	 * *Note*: The items is <em>unresolved</em> if {@code callers} and {@code callees} is not defined.
-	 */
-	List<CallHierarchyItem> callees
+	List<CallHierarchyItem> calls
 
 	/**
 	 * Optional data to identify an item in a resolve request.

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyParams.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j;
 
 import com.google.common.annotations.Beta;
+import org.eclipse.lsp4j.CallHierarchyDirection;
 import org.eclipse.lsp4j.TextDocumentPositionParams;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -28,10 +29,9 @@ public class CallHierarchyParams extends TextDocumentPositionParams {
   private int resolve;
   
   /**
-   * Outgoing direction for callees. Valid values are: {@code incoming} and {@code outgoing}.
-   * The default is {@code incoming} for callers.
+   * The direction of calls to resolve.
    */
-  private String direction;
+  private CallHierarchyDirection direction;
   
   /**
    * The number of levels to resolve.
@@ -49,19 +49,17 @@ public class CallHierarchyParams extends TextDocumentPositionParams {
   }
   
   /**
-   * Outgoing direction for callees. Valid values are: {@code incoming} and {@code outgoing}.
-   * The default is {@code incoming} for callers.
+   * The direction of calls to resolve.
    */
   @Pure
-  public String getDirection() {
+  public CallHierarchyDirection getDirection() {
     return this.direction;
   }
   
   /**
-   * Outgoing direction for callees. Valid values are: {@code incoming} and {@code outgoing}.
-   * The default is {@code incoming} for callers.
+   * The direction of calls to resolve.
    */
-  public void setDirection(final String direction) {
+  public void setDirection(final CallHierarchyDirection direction) {
     this.direction = direction;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ResolveCallHierarchyItemParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ResolveCallHierarchyItemParams.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j;
 
 import com.google.common.annotations.Beta;
+import org.eclipse.lsp4j.CallHierarchyDirection;
 import org.eclipse.lsp4j.CallHierarchyItem;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
@@ -35,11 +36,10 @@ public class ResolveCallHierarchyItemParams {
   private int resolve;
   
   /**
-   * Outgoing direction for callees. Valid values are: {@code incoming} and {@code outgoing}.
-   * The default is {@code incoming} for callers.
+   * The direction of calls to resolve.
    */
   @NonNull
-  private String direction;
+  private CallHierarchyDirection direction;
   
   /**
    * Unresolved item.
@@ -73,20 +73,18 @@ public class ResolveCallHierarchyItemParams {
   }
   
   /**
-   * Outgoing direction for callees. Valid values are: {@code incoming} and {@code outgoing}.
-   * The default is {@code incoming} for callers.
+   * The direction of calls to resolve.
    */
   @Pure
   @NonNull
-  public String getDirection() {
+  public CallHierarchyDirection getDirection() {
     return this.direction;
   }
   
   /**
-   * Outgoing direction for callees. Valid values are: {@code incoming} and {@code outgoing}.
-   * The default is {@code incoming} for callers.
+   * The direction of calls to resolve.
    */
-  public void setDirection(@NonNull final String direction) {
+  public void setDirection(@NonNull final CallHierarchyDirection direction) {
     this.direction = direction;
   }
   


### PR DESCRIPTION
The corresponding protocol change was made here: https://github.com/Microsoft/vscode-languageserver-node/compare/b6887d8c59de9cb0db47608f215ccff615bd376d..ca78873fed86883c455f5d1674f17edc8ba09a4c

I adjusted the Java implementation.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>