### PR TITLE
Attempts to close a client often lead to stream closed exception logged

### DIFF
--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/StreamMessageProducer.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/StreamMessageProducer.java
@@ -114,9 +114,11 @@ public class StreamMessageProducer implements MessageProducer, Closeable, Messag
 				}
 			} // while (keepRunning)
 		} catch (IOException exception) {
-			if (JsonRpcException.indicatesStreamClosed(exception))
-				fireStreamClosed(exception);
-			else
+			if (JsonRpcException.indicatesStreamClosed(exception)) {
+				// Only log the error if we had intended to keep running
+				if( keepRunning ) 
+					fireStreamClosed(exception);
+			} else
 				throw new JsonRpcException(exception);
 		} finally {
 			this.callback = null;


### PR DESCRIPTION
I often get an error in the client when a client attempts to first close the StreamMessageProducer (which sets boolean keepRunning to false) and then closes the underlying socket.   Exception printed out on client is 

INFO: Socket closed
java.net.SocketException: Socket closed
	at java.net.SocketInputStream.socketRead0(Native Method)
	at java.net.SocketInputStream.socketRead(SocketInputStream.java:116)
	at java.net.SocketInputStream.read(SocketInputStream.java:171)
	at java.net.SocketInputStream.read(SocketInputStream.java:141)
	at java.net.SocketInputStream.read(SocketInputStream.java:224)
	at org.eclipse.lsp4j.jsonrpc.json.StreamMessageProducer.listen(StreamMessageProducer.java:79)
	at org.eclipse.lsp4j.jsonrpc.json.ConcurrentMessageProcessor.run(ConcurrentMessageProcessor.java:113)


Seems logical that if the StreamMessageProducer is blocked on reading from the stream, and you set the keepRunning to false, nothing will happen, at least until the producer reads another character so that it can check keepRunning again. So rather than wait, closing the streams seems correct. However, StreamMessageProducer then logs this error. 

I suggest the keepRunning value is checked before logging the stream was closed. See PR. 


Signed-off-by: Rob Stryker <rob@oxbeef.net>