### PR TITLE
Add a logging message consumer wrapper that conforms to the LSP inspector debug tool

### DIFF
--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/MessageTracer.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/MessageTracer.java
@@ -1,0 +1,41 @@
+/******************************************************************************
+ * Copyright (c) 2016-2019 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.lsp4j.jsonrpc;
+
+import org.eclipse.lsp4j.jsonrpc.TracingMessageConsumer.RequestMetadata;
+
+import java.io.PrintWriter;
+import java.time.Clock;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+
+/**
+ * Wraps a {@link MessageConsumer} with one that logs in a way that the LSP Inspector can parse. *
+ * https://microsoft.github.io/language-server-protocol/inspector/
+ */
+public class MessageTracer implements Function<MessageConsumer, MessageConsumer> {
+	private final PrintWriter printWriter;
+	private final Map<String, RequestMetadata> sentRequests = new HashMap<>();
+	private final Map<String, RequestMetadata> receivedRequests = new HashMap<>();
+
+	MessageTracer(PrintWriter printWriter) {
+		this.printWriter = Objects.requireNonNull(printWriter);
+	}
+
+	@Override
+	public MessageConsumer apply(MessageConsumer messageConsumer) {
+		return new TracingMessageConsumer(
+				messageConsumer, sentRequests, receivedRequests, printWriter, Clock.systemDefaultZone());
+	}
+}

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/TracingMessageConsumer.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/TracingMessageConsumer.java
@@ -1,0 +1,194 @@
+/******************************************************************************
+ * Copyright (c) 2016-2019 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.lsp4j.jsonrpc;
+
+import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler;
+import org.eclipse.lsp4j.jsonrpc.json.StreamMessageConsumer;
+import org.eclipse.lsp4j.jsonrpc.messages.Message;
+import org.eclipse.lsp4j.jsonrpc.messages.NotificationMessage;
+import org.eclipse.lsp4j.jsonrpc.messages.RequestMessage;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage;
+
+import java.io.PrintWriter;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.Objects;
+import java.util.logging.Logger;
+
+import static java.util.logging.Level.WARNING;
+
+/**
+ * A {@link MessageConsumer} that outputs logs in a format that can be parsed by the LSP Inspector.
+ * https://microsoft.github.io/language-server-protocol/inspector/
+ */
+public class TracingMessageConsumer implements MessageConsumer {
+	private static final Logger LOG = Logger.getLogger(TracingMessageConsumer.class.getName());
+
+	private final MessageConsumer messageConsumer;
+	private final Map<String, RequestMetadata> sentRequests;
+	private final Map<String, RequestMetadata> receivedRequests;
+	private final PrintWriter printWriter;
+	private final Clock clock;
+	private final DateTimeFormatter dateTimeFormatter;
+
+	/**
+	 * @param messageConsumer The {@link MessageConsumer} to wrap.
+	 * @param sentRequests A map that keeps track of pending sent request data.
+	 * @param receivedRequests A map that keeps track of pending received request data.
+	 * @param printWriter Where to write the log to.
+	 * @param clock The clock that is used to calculate timestamps and durations.
+	 */
+	public TracingMessageConsumer(
+			MessageConsumer messageConsumer,
+			Map<String, RequestMetadata> sentRequests,
+			Map<String, RequestMetadata> receivedRequests,
+			PrintWriter printWriter,
+			Clock clock) {
+		this.messageConsumer = Objects.requireNonNull(messageConsumer);
+		this.sentRequests = Objects.requireNonNull(sentRequests);
+		this.receivedRequests = Objects.requireNonNull(receivedRequests);
+		this.printWriter = Objects.requireNonNull(printWriter);
+		this.clock = Objects.requireNonNull(clock);
+		this.dateTimeFormatter = DateTimeFormatter.ofPattern("KK:mm:ss a").withZone(clock.getZone());
+	}
+
+	/**
+	 * Constructs a log string for a given {@link Message}. The type of the {@link MessageConsumer}
+	 * determines if we're sending or receiving a message. The type of the @{link Message} determines
+	 * if it is a request, response, or notification.
+	 */
+	@Override
+	public void consume(Message message) throws MessageIssueException, JsonRpcException {
+		final Instant now = clock.instant();
+		final String date = dateTimeFormatter.format(now);
+		final String logString;
+
+		if (messageConsumer instanceof StreamMessageConsumer) {
+			logString = consumeMessageSending(message, now, date);
+		} else if (messageConsumer instanceof RemoteEndpoint) {
+			logString = consumeMessageReceiving(message, now, date);
+		} else {
+			LOG.log(WARNING, String.format("Unknown MessageConsumer type: %s", messageConsumer));
+			logString = null;
+		}
+
+		if (logString != null) {
+			printWriter.print(logString);
+			printWriter.flush();
+		}
+
+		messageConsumer.consume(message);
+	}
+
+	private String consumeMessageSending(Message message, Instant now, String date) {
+		if (message instanceof RequestMessage) {
+			RequestMessage requestMessage = (RequestMessage) message;
+			String id = requestMessage.getId();
+			String method = requestMessage.getMethod();
+			RequestMetadata requestMetadata = new RequestMetadata(method, now);
+			sentRequests.put(id, requestMetadata);
+			Object params = requestMessage.getParams();
+			String paramsJson = MessageJsonHandler.toString(params);
+			String format = "[Trace - %s] Sending request '%s - (%s)'\nParams: %s\n\n\n";
+			return String.format(format, date, method, id, paramsJson);
+		} else if (message instanceof ResponseMessage) {
+			ResponseMessage responseMessage = (ResponseMessage) message;
+			String id = responseMessage.getId();
+			RequestMetadata requestMetadata = receivedRequests.remove(id);
+			if (requestMetadata == null) {
+				LOG.log(WARNING, String.format("Unmatched response message: %s", message));
+				return null;
+			}
+			String method = requestMetadata.method;
+			long latencyMillis = now.toEpochMilli() - requestMetadata.start.toEpochMilli();
+			Object result = responseMessage.getResult();
+			String resultJson = MessageJsonHandler.toString(result);
+			String format =
+					"[Trace - %s] Sending response '%s - (%s)'. Processing request took %sms\nResult: %s\n\n\n";
+			return String.format(format, date, method, id, latencyMillis, resultJson);
+		} else if (message instanceof NotificationMessage) {
+			NotificationMessage notificationMessage = (NotificationMessage) message;
+			String method = notificationMessage.getMethod();
+			Object params = notificationMessage.getParams();
+			String paramsJson = MessageJsonHandler.toString(params);
+			String format = "[Trace - %s] Sending notification '%s'\nParams: %s\n\n\n";
+			return String.format(format, date, method, paramsJson);
+		} else {
+			LOG.log(WARNING, String.format("Unknown message type: %s", message));
+			return null;
+		}
+	}
+
+	private String consumeMessageReceiving(Message message, Instant now, String date) {
+		if (message instanceof RequestMessage) {
+			RequestMessage requestMessage = (RequestMessage) message;
+			String method = requestMessage.getMethod();
+			String id = requestMessage.getId();
+			RequestMetadata requestMetadata = new RequestMetadata(method, now);
+			receivedRequests.put(id, requestMetadata);
+			Object params = requestMessage.getParams();
+			String paramsJson = MessageJsonHandler.toString(params);
+			String format = "[Trace - %s] Received request '%s - (%s)'\nParams: %s\n\n\n";
+			return String.format(format, date, method, id, paramsJson);
+		} else if (message instanceof ResponseMessage) {
+			ResponseMessage responseMessage = (ResponseMessage) message;
+			String id = responseMessage.getId();
+			RequestMetadata requestMetadata = sentRequests.remove(id);
+			if (requestMetadata == null) {
+				LOG.log(WARNING, String.format("Unmatched response message: %s", message));
+				return null;
+			}
+			String method = requestMetadata.method;
+			long latencyMillis = now.toEpochMilli() - requestMetadata.start.toEpochMilli();
+			Object result = responseMessage.getResult();
+			String resultJson = MessageJsonHandler.toString(result);
+			String format = "[Trace - %s] Received response '%s - (%s)' in %sms\nResult: %s\n\n\n";
+			return String.format(format, date, method, id, latencyMillis, resultJson);
+		} else if (message instanceof NotificationMessage) {
+			NotificationMessage notificationMessage = (NotificationMessage) message;
+			String method = notificationMessage.getMethod();
+			Object params = notificationMessage.getParams();
+			String paramsJson = MessageJsonHandler.toString(params);
+			String format = "[Trace - %s] Received notification '%s'\nParams: %s\n\n\n";
+			return String.format(format, date, method, paramsJson);
+		} else {
+			LOG.log(WARNING, String.format("Unknown message type: %s", message));
+			return null;
+		}
+	}
+
+	/** Data class for holding pending request metadata. */
+	public static class RequestMetadata {
+		final String method;
+		final Instant start;
+
+		public RequestMetadata(String method, Instant start) {
+			this.method = method;
+			this.start = start;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
+			RequestMetadata that = (RequestMetadata) o;
+			return Objects.equals(method, that.method) && Objects.equals(start, that.start);
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash(method, start);
+		}
+	}
+}

--- a/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/TracingMessageConsumerTest.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/TracingMessageConsumerTest.java
@@ -1,0 +1,234 @@
+/******************************************************************************
+ * Copyright (c) 2016-2019 TypeFox and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.lsp4j.jsonrpc.test;
+
+import org.eclipse.lsp4j.jsonrpc.*;
+import org.eclipse.lsp4j.jsonrpc.TracingMessageConsumer.RequestMetadata;
+import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler;
+import org.eclipse.lsp4j.jsonrpc.json.StreamMessageConsumer;
+import org.eclipse.lsp4j.jsonrpc.messages.Message;
+import org.eclipse.lsp4j.jsonrpc.messages.NotificationMessage;
+import org.eclipse.lsp4j.jsonrpc.messages.RequestMessage;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+import static java.util.Collections.emptyMap;
+import static org.junit.Assert.assertEquals;
+
+public class TracingMessageConsumerTest {
+	private static final RemoteEndpoint TEST_REMOTE_ENDPOINT = new EmptyRemoteEndpoint();
+	private static final StreamMessageConsumer TEST_STREAM_MESSAGE_CONSUMER =
+			new StreamMessageConsumer(
+					new ByteArrayOutputStream(), new MessageJsonHandler(emptyMap()));
+	private static final Clock TEST_CLOCK_1 =
+			Clock.fixed(Instant.parse("2019-06-26T22:07:30.00Z"), ZoneId.of("America/New_York"));
+	private static final Clock TEST_CLOCK_2 =
+			Clock.fixed(Instant.parse("2019-06-26T22:07:30.10Z"), ZoneId.of("America/New_York"));
+
+	@Test
+	public void testReceivedRequest() {
+		StringWriter stringWriter = new StringWriter();
+		PrintWriter printWriter = new PrintWriter(stringWriter);
+
+		TracingMessageConsumer consumer =
+				new TracingMessageConsumer(
+						TEST_REMOTE_ENDPOINT, new HashMap<>(), new HashMap<>(), printWriter, TEST_CLOCK_1);
+
+		RequestMessage message = new RequestMessage();
+		message.setId("1");
+		message.setMethod("foo");
+		message.setParams("bar");
+
+		consumer.consume(message);
+
+		String actualTrace = stringWriter.toString();
+		String expectedTrace = "" +
+				"[Trace - 06:07:30 PM] Received request 'foo - (1)'\n" +
+				"Params: \"bar\"\n" +
+				"\n" +
+				"\n";
+
+		assertEquals(expectedTrace, actualTrace);
+	}
+
+	@Test
+	public void testReceivedResponse() {
+		StringWriter stringWriter = new StringWriter();
+		PrintWriter printWriter = new PrintWriter(stringWriter);
+
+		Map<String, RequestMetadata> sentRequests = new HashMap<>();
+		sentRequests.put("1", new RequestMetadata("foo", TEST_CLOCK_1.instant()));
+
+		TracingMessageConsumer consumer =
+				new TracingMessageConsumer(
+						TEST_REMOTE_ENDPOINT, sentRequests, new HashMap<>(), printWriter, TEST_CLOCK_2);
+
+		ResponseMessage message = new ResponseMessage();
+		message.setId("1");
+		message.setResult("bar");
+
+		consumer.consume(message);
+
+		String actualTrace = stringWriter.toString();
+		String expectedTrace = "" +
+				"[Trace - 06:07:30 PM] Received response 'foo - (1)' in 100ms\n" +
+				"Result: \"bar\"\n" +
+				"\n" +
+				"\n";
+
+		assertEquals(expectedTrace, actualTrace);
+	}
+
+	@Test
+	public void testReceivedNotification() {
+		StringWriter stringWriter = new StringWriter();
+		PrintWriter printWriter = new PrintWriter(stringWriter);
+
+		TracingMessageConsumer consumer =
+				new TracingMessageConsumer(
+						TEST_REMOTE_ENDPOINT, new HashMap<>(), new HashMap<>(), printWriter, TEST_CLOCK_1);
+
+		NotificationMessage message = new NotificationMessage();
+		message.setMethod("foo");
+		message.setParams("bar");
+
+		consumer.consume(message);
+
+		String actualTrace = stringWriter.toString();
+		String expectedTrace = "" +
+				"[Trace - 06:07:30 PM] Received notification 'foo'\n" +
+				"Params: \"bar\"\n" +
+				"\n" +
+				"\n";
+
+		assertEquals(expectedTrace, actualTrace);
+	}
+
+	@Test
+	public void testSendingRequest() {
+		StringWriter stringWriter = new StringWriter();
+		PrintWriter printWriter = new PrintWriter(stringWriter);
+
+		TracingMessageConsumer consumer =
+				new TracingMessageConsumer(
+						TEST_STREAM_MESSAGE_CONSUMER, new HashMap<>(), new HashMap<>(), printWriter, TEST_CLOCK_1);
+
+		RequestMessage message = new RequestMessage();
+		message.setId("1");
+		message.setMethod("foo");
+		message.setParams("bar");
+
+		consumer.consume(message);
+
+		String actualTrace = stringWriter.toString();
+		String expectedTrace = "" +
+				"[Trace - 06:07:30 PM] Sending request 'foo - (1)'\n" +
+				"Params: \"bar\"\n" +
+				"\n" +
+				"\n";
+
+		assertEquals(expectedTrace, actualTrace);
+	}
+
+	@Test
+	public void testSendingResponse() {
+		StringWriter stringWriter = new StringWriter();
+		PrintWriter printWriter = new PrintWriter(stringWriter);
+
+		Map<String, RequestMetadata> receivedRequests = new HashMap<>();
+		receivedRequests.put("1", new RequestMetadata("foo", TEST_CLOCK_1.instant()));
+
+		TracingMessageConsumer consumer =
+				new TracingMessageConsumer(
+						TEST_STREAM_MESSAGE_CONSUMER, new HashMap<>(), receivedRequests, printWriter, TEST_CLOCK_2);
+
+		ResponseMessage message = new ResponseMessage();
+		message.setId("1");
+		message.setResult("bar");
+
+		consumer.consume(message);
+
+		String actualTrace = stringWriter.toString();
+		String expectedTrace = "" +
+				"[Trace - 06:07:30 PM] Sending response 'foo - (1)'. Processing request took 100ms\n" +
+				"Result: \"bar\"\n" +
+				"\n" +
+				"\n";
+
+		assertEquals(expectedTrace, actualTrace);
+	}
+
+	@Test
+	public void testSendingNotification() {
+		StringWriter stringWriter = new StringWriter();
+		PrintWriter printWriter = new PrintWriter(stringWriter);
+
+		TracingMessageConsumer consumer =
+				new TracingMessageConsumer(
+						TEST_STREAM_MESSAGE_CONSUMER, emptyMap(), emptyMap(), printWriter, TEST_CLOCK_1);
+
+		NotificationMessage message = new NotificationMessage();
+		message.setMethod("foo");
+		message.setParams("bar");
+
+		consumer.consume(message);
+
+		String actualTrace = stringWriter.toString();
+		String expectedTrace = "" +
+				"[Trace - 06:07:30 PM] Sending notification 'foo'\n" +
+				"Params: \"bar\"\n" +
+				"\n" +
+				"\n";
+
+		assertEquals(expectedTrace, actualTrace);
+	}
+}
+
+class EmptyRemoteEndpoint extends RemoteEndpoint {
+	EmptyRemoteEndpoint() {
+		super(new EmptyMessageConsumer(), new EmptyEndpoint());
+	}
+
+	@Override
+	protected void handleResponse(ResponseMessage responseMessage) {
+		// no-op
+	}
+}
+
+class EmptyMessageConsumer implements MessageConsumer {
+	@Override
+	public void consume(Message message) throws MessageIssueException, JsonRpcException {
+		// no-op
+	}
+}
+
+class EmptyEndpoint implements Endpoint {
+	@Override
+	public CompletableFuture<?> request(String method, Object parameter) {
+		return CompletableFuture.completedFuture(new Object());
+	}
+
+	@Override
+	public void notify(String method, Object parameter) {
+		// no-op
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/eclipse/lsp4j/issues/328.

Still work to do here, but sharing to get early feedback. Does this look like a reasonable direction?
For context, here is some of the parsing code that the inspector uses: https://github.com/microsoft/language-server-protocol-inspector/blob/master/lsp-inspector/src/logParser/rawLogParser.ts

https://microsoft.github.io/language-server-protocol/inspector/

![image](https://user-images.githubusercontent.com/79073/60134454-84fe5280-976d-11e9-90f4-39db7428974a.png)
