### PR TITLE
GH-330: Adapted `textDocument/callHierarchy` to the spec.

### DIFF
--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/CallHierarchyDirection.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/CallHierarchyDirection.java
@@ -16,15 +16,9 @@ package org.eclipse.lsp4j;
  */
 public enum CallHierarchyDirection {
 
-	/**
-	 * The callers of a symbol.
-	 */
-	Incoming(1),
+	CallsFrom(1),
 
-	/**
-	 * The callees of a symbol.
-	 */
-	Outgoing(2);
+	CallsTo(2);
 
 	private final int value;
 
@@ -38,8 +32,9 @@ public enum CallHierarchyDirection {
 
 	public static InsertTextFormat forValue(int value) {
 		InsertTextFormat[] allValues = InsertTextFormat.values();
-		if (value < 1 || value > allValues.length)
+		if (value < 1 || value > allValues.length) {
 			throw new IllegalArgumentException("Illegal enum value: " + value);
+		}
 		return allValues[value - 1];
 	}
 

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -4833,7 +4833,7 @@ class SemanticHighlightingInformation {
 class CallHierarchyParams extends TextDocumentPositionParams {
 
 	/**
-	 * The direction of calls to resolve.
+	 * The direction of calls to provide.
 	 */
 	@NonNull
 	CallHierarchyDirection direction

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/TextDocumentService.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/TextDocumentService.java
@@ -14,6 +14,7 @@ package org.eclipse.lsp4j.services;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
+import org.eclipse.lsp4j.CallHierarchyCall;
 import org.eclipse.lsp4j.CallHierarchyParams;
 import org.eclipse.lsp4j.CallHierarchySymbol;
 import org.eclipse.lsp4j.CodeAction;
@@ -468,12 +469,17 @@ public interface TextDocumentService {
 	}
 
 	/**
-	 * The {@code textDocument/callHierarchy} request is sent from the client to the server to request
-	 * the call hierarchy for a symbol defined (or referenced) at the given text document position.
+	 * The {@code textDocument/callHierarchy} request is sent from the client to the
+	 * server to request the call hierarchy for a symbol defined (or referenced) at
+	 * the given text document position. Returns a collection of calls from one
+	 * symbol to another. The server will send a collection of
+	 * {@link CallHierarchyCall} objects, or {@code null} if no callable symbol is
+	 * found at the given document position. Each {@code CallHierarchyCall} object
+	 * defines a call from one {@link CallHierarchySymbol} to another.
 	 */
 	@Beta
 	@JsonRequest
-	default CompletableFuture<CallHierarchySymbol> callHierarchy(CallHierarchyParams params) {
+	default CompletableFuture<List<CallHierarchyCall>> callHierarchy(CallHierarchyParams params) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyParams.java
@@ -25,13 +25,13 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 @SuppressWarnings("all")
 public class CallHierarchyParams extends TextDocumentPositionParams {
   /**
-   * The direction of calls to resolve.
+   * The direction of calls to provide.
    */
   @NonNull
   private CallHierarchyDirection direction;
   
   /**
-   * The direction of calls to resolve.
+   * The direction of calls to provide.
    */
   @Pure
   @NonNull
@@ -40,7 +40,7 @@ public class CallHierarchyParams extends TextDocumentPositionParams {
   }
   
   /**
-   * The direction of calls to resolve.
+   * The direction of calls to provide.
    */
   public void setDirection(@NonNull final CallHierarchyDirection direction) {
     if (direction == null) {


### PR DESCRIPTION
Spec: https://github.com/microsoft/vscode-languageserver-node/blob/9523944b663877dceb578cc8b72ed1c1decb2653/protocol/src/protocol.callHierarchy.proposed.md

Closes #330.

Signed-off-by: Akos Kitta <kittaakos@typefox.io>

@xcariba, can you please check if my proposed adjustments are in sync with the spec? Thanks for the help!