### PR TITLE
Allow to globally disable null-checks of LSP data structures

### DIFF
--- a/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/util/Preconditions.java
+++ b/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/util/Preconditions.java
@@ -9,7 +9,7 @@
  * 
  * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
  ******************************************************************************/
-package org.eclipse.lsp4j.util;
+package org.eclipse.lsp4j.debug.util;
 
 /**
  * Utilities for checking method and constructor arguments.

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/Breakpoint.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/Breakpoint.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j.debug;
 
 import org.eclipse.lsp4j.debug.Source;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -110,10 +111,7 @@ public class Breakpoint {
    * If true breakpoint could be set (but not necessarily at the desired location).
    */
   public void setVerified(@NonNull final Boolean verified) {
-    if (verified == null) {
-      throw new IllegalArgumentException("Property must not be null: verified");
-    }
-    this.verified = verified;
+    this.verified = Preconditions.checkNotNull(verified, "verified");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/BreakpointEventArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/BreakpointEventArguments.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j.debug;
 
 import org.eclipse.lsp4j.debug.Breakpoint;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -52,10 +53,7 @@ public class BreakpointEventArguments {
    * Possible values include - but not limited to those defined in {@link BreakpointEventArgumentsReason}
    */
   public void setReason(@NonNull final String reason) {
-    if (reason == null) {
-      throw new IllegalArgumentException("Property must not be null: reason");
-    }
-    this.reason = reason;
+    this.reason = Preconditions.checkNotNull(reason, "reason");
   }
   
   /**
@@ -71,10 +69,7 @@ public class BreakpointEventArguments {
    * The breakpoint.
    */
   public void setBreakpoint(@NonNull final Breakpoint breakpoint) {
-    if (breakpoint == null) {
-      throw new IllegalArgumentException("Property must not be null: breakpoint");
-    }
-    this.breakpoint = breakpoint;
+    this.breakpoint = Preconditions.checkNotNull(breakpoint, "breakpoint");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/CapabilitiesEventArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/CapabilitiesEventArguments.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j.debug;
 
 import org.eclipse.lsp4j.debug.Capabilities;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -48,10 +49,7 @@ public class CapabilitiesEventArguments {
    * The set of updated capabilities.
    */
   public void setCapabilities(@NonNull final Capabilities capabilities) {
-    if (capabilities == null) {
-      throw new IllegalArgumentException("Property must not be null: capabilities");
-    }
-    this.capabilities = capabilities;
+    this.capabilities = Preconditions.checkNotNull(capabilities, "capabilities");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/Checksum.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/Checksum.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j.debug;
 
 import org.eclipse.lsp4j.debug.ChecksumAlgorithm;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -46,10 +47,7 @@ public class Checksum {
    * The algorithm used to calculate this checksum.
    */
   public void setAlgorithm(@NonNull final ChecksumAlgorithm algorithm) {
-    if (algorithm == null) {
-      throw new IllegalArgumentException("Property must not be null: algorithm");
-    }
-    this.algorithm = algorithm;
+    this.algorithm = Preconditions.checkNotNull(algorithm, "algorithm");
   }
   
   /**
@@ -65,10 +63,7 @@ public class Checksum {
    * Value of the checksum.
    */
   public void setChecksum(@NonNull final String checksum) {
-    if (checksum == null) {
-      throw new IllegalArgumentException("Property must not be null: checksum");
-    }
-    this.checksum = checksum;
+    this.checksum = Preconditions.checkNotNull(checksum, "checksum");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ColumnDescriptor.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ColumnDescriptor.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j.debug;
 
 import org.eclipse.lsp4j.debug.ColumnDescriptorType;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -70,10 +71,7 @@ public class ColumnDescriptor {
    * Name of the attribute rendered in this column.
    */
   public void setAttributeName(@NonNull final String attributeName) {
-    if (attributeName == null) {
-      throw new IllegalArgumentException("Property must not be null: attributeName");
-    }
-    this.attributeName = attributeName;
+    this.attributeName = Preconditions.checkNotNull(attributeName, "attributeName");
   }
   
   /**
@@ -89,10 +87,7 @@ public class ColumnDescriptor {
    * Header UI label of column.
    */
   public void setLabel(@NonNull final String label) {
-    if (label == null) {
-      throw new IllegalArgumentException("Property must not be null: label");
-    }
-    this.label = label;
+    this.label = Preconditions.checkNotNull(label, "label");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/CompletionItem.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/CompletionItem.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j.debug;
 
 import org.eclipse.lsp4j.debug.CompletionItemType;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -76,10 +77,7 @@ public class CompletionItem {
    * completion.
    */
   public void setLabel(@NonNull final String label) {
-    if (label == null) {
-      throw new IllegalArgumentException("Property must not be null: label");
-    }
-    this.label = label;
+    this.label = Preconditions.checkNotNull(label, "label");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/CompletionsArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/CompletionsArguments.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j.debug;
 
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -85,10 +86,7 @@ public class CompletionsArguments {
    * for completion.
    */
   public void setText(@NonNull final String text) {
-    if (text == null) {
-      throw new IllegalArgumentException("Property must not be null: text");
-    }
-    this.text = text;
+    this.text = Preconditions.checkNotNull(text, "text");
   }
   
   /**
@@ -104,10 +102,7 @@ public class CompletionsArguments {
    * The character position for which to determine the completion proposals.
    */
   public void setColumn(@NonNull final Long column) {
-    if (column == null) {
-      throw new IllegalArgumentException("Property must not be null: column");
-    }
-    this.column = column;
+    this.column = Preconditions.checkNotNull(column, "column");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/CompletionsResponse.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/CompletionsResponse.java
@@ -13,6 +13,7 @@ package org.eclipse.lsp4j.debug;
 
 import java.util.Arrays;
 import org.eclipse.lsp4j.debug.CompletionItem;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -41,10 +42,7 @@ public class CompletionsResponse {
    * The possible completions for .
    */
   public void setTargets(@NonNull final CompletionItem[] targets) {
-    if (targets == null) {
-      throw new IllegalArgumentException("Property must not be null: targets");
-    }
-    this.targets = targets;
+    this.targets = Preconditions.checkNotNull(targets, "targets");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ContinueArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ContinueArguments.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j.debug;
 
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -42,10 +43,7 @@ public class ContinueArguments {
    * but will continue on all threads, it should set the 'allThreadsContinued' attribute in the response to true.
    */
   public void setThreadId(@NonNull final Long threadId) {
-    if (threadId == null) {
-      throw new IllegalArgumentException("Property must not be null: threadId");
-    }
-    this.threadId = threadId;
+    this.threadId = Preconditions.checkNotNull(threadId, "threadId");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ContinuedEventArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ContinuedEventArguments.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j.debug;
 
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -51,10 +52,7 @@ public class ContinuedEventArguments {
    * The thread which was continued.
    */
   public void setThreadId(@NonNull final Long threadId) {
-    if (threadId == null) {
-      throw new IllegalArgumentException("Property must not be null: threadId");
-    }
-    this.threadId = threadId;
+    this.threadId = Preconditions.checkNotNull(threadId, "threadId");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/EvaluateArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/EvaluateArguments.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j.debug;
 
 import org.eclipse.lsp4j.debug.ValueFormat;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -64,10 +65,7 @@ public class EvaluateArguments {
    * The expression to evaluate.
    */
   public void setExpression(@NonNull final String expression) {
-    if (expression == null) {
-      throw new IllegalArgumentException("Property must not be null: expression");
-    }
-    this.expression = expression;
+    this.expression = Preconditions.checkNotNull(expression, "expression");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/EvaluateResponse.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/EvaluateResponse.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j.debug;
 
 import org.eclipse.lsp4j.debug.VariablePresentationHint;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -79,10 +80,7 @@ public class EvaluateResponse {
    * The result of the evaluate request.
    */
   public void setResult(@NonNull final String result) {
-    if (result == null) {
-      throw new IllegalArgumentException("Property must not be null: result");
-    }
-    this.result = result;
+    this.result = Preconditions.checkNotNull(result, "result");
   }
   
   /**
@@ -138,10 +136,7 @@ public class EvaluateResponse {
    * variablesReference to the VariablesRequest.
    */
   public void setVariablesReference(@NonNull final Long variablesReference) {
-    if (variablesReference == null) {
-      throw new IllegalArgumentException("Property must not be null: variablesReference");
-    }
-    this.variablesReference = variablesReference;
+    this.variablesReference = Preconditions.checkNotNull(variablesReference, "variablesReference");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ExceptionBreakpointsFilter.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ExceptionBreakpointsFilter.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j.debug;
 
 import com.google.gson.annotations.SerializedName;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -54,10 +55,7 @@ public class ExceptionBreakpointsFilter {
    * The internal ID of the filter. This value is passed to the setExceptionBreakpoints request.
    */
   public void setFilter(@NonNull final String filter) {
-    if (filter == null) {
-      throw new IllegalArgumentException("Property must not be null: filter");
-    }
-    this.filter = filter;
+    this.filter = Preconditions.checkNotNull(filter, "filter");
   }
   
   /**
@@ -73,10 +71,7 @@ public class ExceptionBreakpointsFilter {
    * The name of the filter. This will be shown in the UI.
    */
   public void setLabel(@NonNull final String label) {
-    if (label == null) {
-      throw new IllegalArgumentException("Property must not be null: label");
-    }
-    this.label = label;
+    this.label = Preconditions.checkNotNull(label, "label");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ExceptionInfoArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ExceptionInfoArguments.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j.debug;
 
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -39,10 +40,7 @@ public class ExceptionInfoArguments {
    * Thread for which exception information should be retrieved.
    */
   public void setThreadId(@NonNull final Long threadId) {
-    if (threadId == null) {
-      throw new IllegalArgumentException("Property must not be null: threadId");
-    }
-    this.threadId = threadId;
+    this.threadId = Preconditions.checkNotNull(threadId, "threadId");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ExceptionInfoResponse.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ExceptionInfoResponse.java
@@ -13,6 +13,7 @@ package org.eclipse.lsp4j.debug;
 
 import org.eclipse.lsp4j.debug.ExceptionBreakMode;
 import org.eclipse.lsp4j.debug.ExceptionDetails;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -61,10 +62,7 @@ public class ExceptionInfoResponse {
    * ID of the exception that was thrown.
    */
   public void setExceptionId(@NonNull final String exceptionId) {
-    if (exceptionId == null) {
-      throw new IllegalArgumentException("Property must not be null: exceptionId");
-    }
-    this.exceptionId = exceptionId;
+    this.exceptionId = Preconditions.checkNotNull(exceptionId, "exceptionId");
   }
   
   /**
@@ -99,10 +97,7 @@ public class ExceptionInfoResponse {
    * Mode that caused the exception notification to be raised.
    */
   public void setBreakMode(@NonNull final ExceptionBreakMode breakMode) {
-    if (breakMode == null) {
-      throw new IllegalArgumentException("Property must not be null: breakMode");
-    }
-    this.breakMode = breakMode;
+    this.breakMode = Preconditions.checkNotNull(breakMode, "breakMode");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ExceptionOptions.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ExceptionOptions.java
@@ -14,6 +14,7 @@ package org.eclipse.lsp4j.debug;
 import java.util.Arrays;
 import org.eclipse.lsp4j.debug.ExceptionBreakMode;
 import org.eclipse.lsp4j.debug.ExceptionPathSegment;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -71,10 +72,7 @@ public class ExceptionOptions {
    * Condition when a thrown exception should result in a break.
    */
   public void setBreakMode(@NonNull final ExceptionBreakMode breakMode) {
-    if (breakMode == null) {
-      throw new IllegalArgumentException("Property must not be null: breakMode");
-    }
-    this.breakMode = breakMode;
+    this.breakMode = Preconditions.checkNotNull(breakMode, "breakMode");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ExceptionPathSegment.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ExceptionPathSegment.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j.debug;
 
 import java.util.Arrays;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -71,10 +72,7 @@ public class ExceptionPathSegment {
    * Depending on the value of 'negate' the names that should match or not match.
    */
   public void setNames(@NonNull final String[] names) {
-    if (names == null) {
-      throw new IllegalArgumentException("Property must not be null: names");
-    }
-    this.names = names;
+    this.names = Preconditions.checkNotNull(names, "names");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ExitedEventArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ExitedEventArguments.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j.debug;
 
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -39,10 +40,7 @@ public class ExitedEventArguments {
    * The exit code returned from the debuggee.
    */
   public void setExitCode(@NonNull final Long exitCode) {
-    if (exitCode == null) {
-      throw new IllegalArgumentException("Property must not be null: exitCode");
-    }
-    this.exitCode = exitCode;
+    this.exitCode = Preconditions.checkNotNull(exitCode, "exitCode");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/FunctionBreakpoint.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/FunctionBreakpoint.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j.debug;
 
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -54,10 +55,7 @@ public class FunctionBreakpoint {
    * The name of the function.
    */
   public void setName(@NonNull final String name) {
-    if (name == null) {
-      throw new IllegalArgumentException("Property must not be null: name");
-    }
-    this.name = name;
+    this.name = Preconditions.checkNotNull(name, "name");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/GotoArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/GotoArguments.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j.debug;
 
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -45,10 +46,7 @@ public class GotoArguments {
    * Set the goto target for this thread.
    */
   public void setThreadId(@NonNull final Long threadId) {
-    if (threadId == null) {
-      throw new IllegalArgumentException("Property must not be null: threadId");
-    }
-    this.threadId = threadId;
+    this.threadId = Preconditions.checkNotNull(threadId, "threadId");
   }
   
   /**
@@ -64,10 +62,7 @@ public class GotoArguments {
    * The location where the debuggee will continue to run.
    */
   public void setTargetId(@NonNull final Long targetId) {
-    if (targetId == null) {
-      throw new IllegalArgumentException("Property must not be null: targetId");
-    }
-    this.targetId = targetId;
+    this.targetId = Preconditions.checkNotNull(targetId, "targetId");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/GotoTarget.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/GotoTarget.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j.debug;
 
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -74,10 +75,7 @@ public class GotoTarget {
    * Unique identifier for a goto target. This is used in the goto request.
    */
   public void setId(@NonNull final Long id) {
-    if (id == null) {
-      throw new IllegalArgumentException("Property must not be null: id");
-    }
-    this.id = id;
+    this.id = Preconditions.checkNotNull(id, "id");
   }
   
   /**
@@ -93,10 +91,7 @@ public class GotoTarget {
    * The name of the goto target (shown in the UI).
    */
   public void setLabel(@NonNull final String label) {
-    if (label == null) {
-      throw new IllegalArgumentException("Property must not be null: label");
-    }
-    this.label = label;
+    this.label = Preconditions.checkNotNull(label, "label");
   }
   
   /**
@@ -112,10 +107,7 @@ public class GotoTarget {
    * The line of the goto target.
    */
   public void setLine(@NonNull final Long line) {
-    if (line == null) {
-      throw new IllegalArgumentException("Property must not be null: line");
-    }
-    this.line = line;
+    this.line = Preconditions.checkNotNull(line, "line");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/GotoTargetsArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/GotoTargetsArguments.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j.debug;
 
 import org.eclipse.lsp4j.debug.Source;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -53,10 +54,7 @@ public class GotoTargetsArguments {
    * The source location for which the goto targets are determined.
    */
   public void setSource(@NonNull final Source source) {
-    if (source == null) {
-      throw new IllegalArgumentException("Property must not be null: source");
-    }
-    this.source = source;
+    this.source = Preconditions.checkNotNull(source, "source");
   }
   
   /**
@@ -72,10 +70,7 @@ public class GotoTargetsArguments {
    * The line location for which the goto targets are determined.
    */
   public void setLine(@NonNull final Long line) {
-    if (line == null) {
-      throw new IllegalArgumentException("Property must not be null: line");
-    }
-    this.line = line;
+    this.line = Preconditions.checkNotNull(line, "line");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/GotoTargetsResponse.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/GotoTargetsResponse.java
@@ -13,6 +13,7 @@ package org.eclipse.lsp4j.debug;
 
 import java.util.Arrays;
 import org.eclipse.lsp4j.debug.GotoTarget;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -41,10 +42,7 @@ public class GotoTargetsResponse {
    * The possible goto targets of the specified location.
    */
   public void setTargets(@NonNull final GotoTarget[] targets) {
-    if (targets == null) {
-      throw new IllegalArgumentException("Property must not be null: targets");
-    }
-    this.targets = targets;
+    this.targets = Preconditions.checkNotNull(targets, "targets");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/InitializeRequestArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/InitializeRequestArguments.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j.debug;
 
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -142,10 +143,7 @@ public class InitializeRequestArguments {
    * The ID of the debug adapter.
    */
   public void setAdapterID(@NonNull final String adapterID) {
-    if (adapterID == null) {
-      throw new IllegalArgumentException("Property must not be null: adapterID");
-    }
-    this.adapterID = adapterID;
+    this.adapterID = Preconditions.checkNotNull(adapterID, "adapterID");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/LoadedSourceEventArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/LoadedSourceEventArguments.java
@@ -13,6 +13,7 @@ package org.eclipse.lsp4j.debug;
 
 import org.eclipse.lsp4j.debug.LoadedSourceEventArgumentsReason;
 import org.eclipse.lsp4j.debug.Source;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -47,10 +48,7 @@ public class LoadedSourceEventArguments {
    * The reason for the event.
    */
   public void setReason(@NonNull final LoadedSourceEventArgumentsReason reason) {
-    if (reason == null) {
-      throw new IllegalArgumentException("Property must not be null: reason");
-    }
-    this.reason = reason;
+    this.reason = Preconditions.checkNotNull(reason, "reason");
   }
   
   /**
@@ -66,10 +64,7 @@ public class LoadedSourceEventArguments {
    * The new, changed, or removed source.
    */
   public void setSource(@NonNull final Source source) {
-    if (source == null) {
-      throw new IllegalArgumentException("Property must not be null: source");
-    }
-    this.source = source;
+    this.source = Preconditions.checkNotNull(source, "source");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/LoadedSourcesResponse.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/LoadedSourcesResponse.java
@@ -13,6 +13,7 @@ package org.eclipse.lsp4j.debug;
 
 import java.util.Arrays;
 import org.eclipse.lsp4j.debug.Source;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -41,10 +42,7 @@ public class LoadedSourcesResponse {
    * Set of loaded sources.
    */
   public void setSources(@NonNull final Source[] sources) {
-    if (sources == null) {
-      throw new IllegalArgumentException("Property must not be null: sources");
-    }
-    this.sources = sources;
+    this.sources = Preconditions.checkNotNull(sources, "sources");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/Message.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/Message.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j.debug;
 
 import java.util.Map;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -84,10 +85,7 @@ public class Message {
    * Unique identifier for the message.
    */
   public void setId(@NonNull final Long id) {
-    if (id == null) {
-      throw new IllegalArgumentException("Property must not be null: id");
-    }
-    this.id = id;
+    this.id = Preconditions.checkNotNull(id, "id");
   }
   
   /**
@@ -109,10 +107,7 @@ public class Message {
    * safely used for telemetry purposes.
    */
   public void setFormat(@NonNull final String format) {
-    if (format == null) {
-      throw new IllegalArgumentException("Property must not be null: format");
-    }
-    this.format = format;
+    this.format = Preconditions.checkNotNull(format, "format");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/Module.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/Module.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j.debug;
 
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
@@ -127,22 +128,23 @@ public class Module {
    * Unique identifier for the module.
    */
   public void setId(@NonNull final Either<Long, String> id) {
-    if (id == null) {
-      throw new IllegalArgumentException("Property must not be null: id");
-    }
-    this.id = id;
+    this.id = Preconditions.checkNotNull(id, "id");
   }
   
   public void setId(final Long id) {
     if (id == null) {
-      throw new IllegalArgumentException("Property must not be null: id");
+      Preconditions.checkNotNull(id, "id");
+      this.id = null;
+      return;
     }
     this.id = Either.forLeft(id);
   }
   
   public void setId(final String id) {
     if (id == null) {
-      throw new IllegalArgumentException("Property must not be null: id");
+      Preconditions.checkNotNull(id, "id");
+      this.id = null;
+      return;
     }
     this.id = Either.forRight(id);
   }
@@ -160,10 +162,7 @@ public class Module {
    * A name of the module.
    */
   public void setName(@NonNull final String name) {
-    if (name == null) {
-      throw new IllegalArgumentException("Property must not be null: name");
-    }
-    this.name = name;
+    this.name = Preconditions.checkNotNull(name, "name");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ModuleEventArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ModuleEventArguments.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j.debug;
 
 import org.eclipse.lsp4j.debug.ModuleEventArgumentsReason;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -46,10 +47,7 @@ public class ModuleEventArguments {
    * The reason for the event.
    */
   public void setReason(@NonNull final ModuleEventArgumentsReason reason) {
-    if (reason == null) {
-      throw new IllegalArgumentException("Property must not be null: reason");
-    }
-    this.reason = reason;
+    this.reason = Preconditions.checkNotNull(reason, "reason");
   }
   
   /**
@@ -65,10 +63,7 @@ public class ModuleEventArguments {
    * The new, changed, or removed module. In case of 'removed' only the module id is used.
    */
   public void setModule(@NonNull final org.eclipse.lsp4j.debug.Module module) {
-    if (module == null) {
-      throw new IllegalArgumentException("Property must not be null: module");
-    }
-    this.module = module;
+    this.module = Preconditions.checkNotNull(module, "module");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ModulesResponse.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ModulesResponse.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j.debug;
 
 import java.util.Arrays;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -47,10 +48,7 @@ public class ModulesResponse {
    * All modules or range of modules.
    */
   public void setModules(@NonNull final org.eclipse.lsp4j.debug.Module[] modules) {
-    if (modules == null) {
-      throw new IllegalArgumentException("Property must not be null: modules");
-    }
-    this.modules = modules;
+    this.modules = Preconditions.checkNotNull(modules, "modules");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ModulesViewDescriptor.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ModulesViewDescriptor.java
@@ -13,6 +13,7 @@ package org.eclipse.lsp4j.debug;
 
 import java.util.Arrays;
 import org.eclipse.lsp4j.debug.ColumnDescriptor;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -34,10 +35,7 @@ public class ModulesViewDescriptor {
   }
   
   public void setColumns(@NonNull final ColumnDescriptor[] columns) {
-    if (columns == null) {
-      throw new IllegalArgumentException("Property must not be null: columns");
-    }
-    this.columns = columns;
+    this.columns = Preconditions.checkNotNull(columns, "columns");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/NextArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/NextArguments.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j.debug;
 
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -39,10 +40,7 @@ public class NextArguments {
    * Execute 'next' for this thread.
    */
   public void setThreadId(@NonNull final Long threadId) {
-    if (threadId == null) {
-      throw new IllegalArgumentException("Property must not be null: threadId");
-    }
-    this.threadId = threadId;
+    this.threadId = Preconditions.checkNotNull(threadId, "threadId");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/OutputEventArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/OutputEventArguments.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j.debug;
 
 import org.eclipse.lsp4j.debug.Source;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -109,10 +110,7 @@ public class OutputEventArguments {
    * The output to report.
    */
   public void setOutput(@NonNull final String output) {
-    if (output == null) {
-      throw new IllegalArgumentException("Property must not be null: output");
-    }
-    this.output = output;
+    this.output = Preconditions.checkNotNull(output, "output");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/PauseArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/PauseArguments.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j.debug;
 
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -39,10 +40,7 @@ public class PauseArguments {
    * Pause execution for this thread.
    */
   public void setThreadId(@NonNull final Long threadId) {
-    if (threadId == null) {
-      throw new IllegalArgumentException("Property must not be null: threadId");
-    }
-    this.threadId = threadId;
+    this.threadId = Preconditions.checkNotNull(threadId, "threadId");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ProcessEventArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ProcessEventArguments.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j.debug;
 
 import org.eclipse.lsp4j.debug.ProcessEventArgumentsStartMethod;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -65,10 +66,7 @@ public class ProcessEventArguments {
    * /home/example/myproj/program.js.
    */
   public void setName(@NonNull final String name) {
-    if (name == null) {
-      throw new IllegalArgumentException("Property must not be null: name");
-    }
-    this.name = name;
+    this.name = Preconditions.checkNotNull(name, "name");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/RestartFrameArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/RestartFrameArguments.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j.debug;
 
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -39,10 +40,7 @@ public class RestartFrameArguments {
    * Restart this stackframe.
    */
   public void setFrameId(@NonNull final Long frameId) {
-    if (frameId == null) {
-      throw new IllegalArgumentException("Property must not be null: frameId");
-    }
-    this.frameId = frameId;
+    this.frameId = Preconditions.checkNotNull(frameId, "frameId");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ReverseContinueArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ReverseContinueArguments.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j.debug;
 
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -39,10 +40,7 @@ public class ReverseContinueArguments {
    * Execute 'reverseContinue' for this thread.
    */
   public void setThreadId(@NonNull final Long threadId) {
-    if (threadId == null) {
-      throw new IllegalArgumentException("Property must not be null: threadId");
-    }
-    this.threadId = threadId;
+    this.threadId = Preconditions.checkNotNull(threadId, "threadId");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/RunInTerminalRequestArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/RunInTerminalRequestArguments.java
@@ -14,6 +14,7 @@ package org.eclipse.lsp4j.debug;
 import java.util.Arrays;
 import java.util.Map;
 import org.eclipse.lsp4j.debug.RunInTerminalRequestArgumentsKind;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -107,10 +108,7 @@ public class RunInTerminalRequestArguments {
    * Working directory of the command.
    */
   public void setCwd(@NonNull final String cwd) {
-    if (cwd == null) {
-      throw new IllegalArgumentException("Property must not be null: cwd");
-    }
-    this.cwd = cwd;
+    this.cwd = Preconditions.checkNotNull(cwd, "cwd");
   }
   
   /**
@@ -126,10 +124,7 @@ public class RunInTerminalRequestArguments {
    * List of arguments. The first argument is the command to run.
    */
   public void setArgs(@NonNull final String[] args) {
-    if (args == null) {
-      throw new IllegalArgumentException("Property must not be null: args");
-    }
-    this.args = args;
+    this.args = Preconditions.checkNotNull(args, "args");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/Scope.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/Scope.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j.debug;
 
 import org.eclipse.lsp4j.debug.Source;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -106,10 +107,7 @@ public class Scope {
    * Name of the scope such as 'Arguments', 'Locals'.
    */
   public void setName(@NonNull final String name) {
-    if (name == null) {
-      throw new IllegalArgumentException("Property must not be null: name");
-    }
-    this.name = name;
+    this.name = Preconditions.checkNotNull(name, "name");
   }
   
   /**
@@ -127,10 +125,7 @@ public class Scope {
    * VariablesRequest.
    */
   public void setVariablesReference(@NonNull final Long variablesReference) {
-    if (variablesReference == null) {
-      throw new IllegalArgumentException("Property must not be null: variablesReference");
-    }
-    this.variablesReference = variablesReference;
+    this.variablesReference = Preconditions.checkNotNull(variablesReference, "variablesReference");
   }
   
   /**
@@ -192,10 +187,7 @@ public class Scope {
    * If true, the number of variables in this scope is large or expensive to retrieve.
    */
   public void setExpensive(@NonNull final Boolean expensive) {
-    if (expensive == null) {
-      throw new IllegalArgumentException("Property must not be null: expensive");
-    }
-    this.expensive = expensive;
+    this.expensive = Preconditions.checkNotNull(expensive, "expensive");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ScopesArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ScopesArguments.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j.debug;
 
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -39,10 +40,7 @@ public class ScopesArguments {
    * Retrieve the scopes for this stackframe.
    */
   public void setFrameId(@NonNull final Long frameId) {
-    if (frameId == null) {
-      throw new IllegalArgumentException("Property must not be null: frameId");
-    }
-    this.frameId = frameId;
+    this.frameId = Preconditions.checkNotNull(frameId, "frameId");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ScopesResponse.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ScopesResponse.java
@@ -13,6 +13,7 @@ package org.eclipse.lsp4j.debug;
 
 import java.util.Arrays;
 import org.eclipse.lsp4j.debug.Scope;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -41,10 +42,7 @@ public class ScopesResponse {
    * The scopes of the stackframe. If the array has length zero, there are no scopes available.
    */
   public void setScopes(@NonNull final Scope[] scopes) {
-    if (scopes == null) {
-      throw new IllegalArgumentException("Property must not be null: scopes");
-    }
-    this.scopes = scopes;
+    this.scopes = Preconditions.checkNotNull(scopes, "scopes");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/SetBreakpointsArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/SetBreakpointsArguments.java
@@ -14,6 +14,7 @@ package org.eclipse.lsp4j.debug;
 import java.util.Arrays;
 import org.eclipse.lsp4j.debug.Source;
 import org.eclipse.lsp4j.debug.SourceBreakpoint;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -64,10 +65,7 @@ public class SetBreakpointsArguments {
    * The source location of the breakpoints; either 'source.path' or 'source.reference' must be specified.
    */
   public void setSource(@NonNull final Source source) {
-    if (source == null) {
-      throw new IllegalArgumentException("Property must not be null: source");
-    }
-    this.source = source;
+    this.source = Preconditions.checkNotNull(source, "source");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/SetBreakpointsResponse.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/SetBreakpointsResponse.java
@@ -13,6 +13,7 @@ package org.eclipse.lsp4j.debug;
 
 import java.util.Arrays;
 import org.eclipse.lsp4j.debug.Breakpoint;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -52,10 +53,7 @@ public class SetBreakpointsResponse {
    * 'breakpoints' (or the deprecated 'lines') array in the arguments.
    */
   public void setBreakpoints(@NonNull final Breakpoint[] breakpoints) {
-    if (breakpoints == null) {
-      throw new IllegalArgumentException("Property must not be null: breakpoints");
-    }
-    this.breakpoints = breakpoints;
+    this.breakpoints = Preconditions.checkNotNull(breakpoints, "breakpoints");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/SetExceptionBreakpointsArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/SetExceptionBreakpointsArguments.java
@@ -13,6 +13,7 @@ package org.eclipse.lsp4j.debug;
 
 import java.util.Arrays;
 import org.eclipse.lsp4j.debug.ExceptionOptions;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -48,10 +49,7 @@ public class SetExceptionBreakpointsArguments {
    * IDs of checked exception options. The set of IDs is returned via the 'exceptionBreakpointFilters' capability.
    */
   public void setFilters(@NonNull final String[] filters) {
-    if (filters == null) {
-      throw new IllegalArgumentException("Property must not be null: filters");
-    }
-    this.filters = filters;
+    this.filters = Preconditions.checkNotNull(filters, "filters");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/SetExpressionArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/SetExpressionArguments.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j.debug;
 
 import org.eclipse.lsp4j.debug.ValueFormat;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -61,10 +62,7 @@ public class SetExpressionArguments {
    * The l-value expression to assign to.
    */
   public void setExpression(@NonNull final String expression) {
-    if (expression == null) {
-      throw new IllegalArgumentException("Property must not be null: expression");
-    }
-    this.expression = expression;
+    this.expression = Preconditions.checkNotNull(expression, "expression");
   }
   
   /**
@@ -80,10 +78,7 @@ public class SetExpressionArguments {
    * The value expression to assign to the l-value expression.
    */
   public void setValue(@NonNull final String value) {
-    if (value == null) {
-      throw new IllegalArgumentException("Property must not be null: value");
-    }
-    this.value = value;
+    this.value = Preconditions.checkNotNull(value, "value");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/SetExpressionResponse.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/SetExpressionResponse.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j.debug;
 
 import org.eclipse.lsp4j.debug.VariablePresentationHint;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -80,10 +81,7 @@ public class SetExpressionResponse {
    * The new value of the expression.
    */
   public void setValue(@NonNull final String value) {
-    if (value == null) {
-      throw new IllegalArgumentException("Property must not be null: value");
-    }
-    this.value = value;
+    this.value = Preconditions.checkNotNull(value, "value");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/SetFunctionBreakpointsArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/SetFunctionBreakpointsArguments.java
@@ -13,6 +13,7 @@ package org.eclipse.lsp4j.debug;
 
 import java.util.Arrays;
 import org.eclipse.lsp4j.debug.FunctionBreakpoint;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -41,10 +42,7 @@ public class SetFunctionBreakpointsArguments {
    * The function names of the breakpoints.
    */
   public void setBreakpoints(@NonNull final FunctionBreakpoint[] breakpoints) {
-    if (breakpoints == null) {
-      throw new IllegalArgumentException("Property must not be null: breakpoints");
-    }
-    this.breakpoints = breakpoints;
+    this.breakpoints = Preconditions.checkNotNull(breakpoints, "breakpoints");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/SetFunctionBreakpointsResponse.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/SetFunctionBreakpointsResponse.java
@@ -13,6 +13,7 @@ package org.eclipse.lsp4j.debug;
 
 import java.util.Arrays;
 import org.eclipse.lsp4j.debug.Breakpoint;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -43,10 +44,7 @@ public class SetFunctionBreakpointsResponse {
    * Information about the breakpoints. The array elements correspond to the elements of the 'breakpoints' array.
    */
   public void setBreakpoints(@NonNull final Breakpoint[] breakpoints) {
-    if (breakpoints == null) {
-      throw new IllegalArgumentException("Property must not be null: breakpoints");
-    }
-    this.breakpoints = breakpoints;
+    this.breakpoints = Preconditions.checkNotNull(breakpoints, "breakpoints");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/SetVariableArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/SetVariableArguments.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j.debug;
 
 import org.eclipse.lsp4j.debug.ValueFormat;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -59,10 +60,7 @@ public class SetVariableArguments {
    * The reference of the variable container.
    */
   public void setVariablesReference(@NonNull final Long variablesReference) {
-    if (variablesReference == null) {
-      throw new IllegalArgumentException("Property must not be null: variablesReference");
-    }
-    this.variablesReference = variablesReference;
+    this.variablesReference = Preconditions.checkNotNull(variablesReference, "variablesReference");
   }
   
   /**
@@ -78,10 +76,7 @@ public class SetVariableArguments {
    * The name of the variable.
    */
   public void setName(@NonNull final String name) {
-    if (name == null) {
-      throw new IllegalArgumentException("Property must not be null: name");
-    }
-    this.name = name;
+    this.name = Preconditions.checkNotNull(name, "name");
   }
   
   /**
@@ -97,10 +92,7 @@ public class SetVariableArguments {
    * The value of the variable.
    */
   public void setValue(@NonNull final String value) {
-    if (value == null) {
-      throw new IllegalArgumentException("Property must not be null: value");
-    }
-    this.value = value;
+    this.value = Preconditions.checkNotNull(value, "value");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/SetVariableResponse.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/SetVariableResponse.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j.debug;
 
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -72,10 +73,7 @@ public class SetVariableResponse {
    * The new value of the variable.
    */
   public void setValue(@NonNull final String value) {
-    if (value == null) {
-      throw new IllegalArgumentException("Property must not be null: value");
-    }
-    this.value = value;
+    this.value = Preconditions.checkNotNull(value, "value");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/SourceArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/SourceArguments.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j.debug;
 
 import org.eclipse.lsp4j.debug.Source;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -69,10 +70,7 @@ public class SourceArguments {
    * compatibility since old backends do not understand the 'source' attribute.
    */
   public void setSourceReference(@NonNull final Long sourceReference) {
-    if (sourceReference == null) {
-      throw new IllegalArgumentException("Property must not be null: sourceReference");
-    }
-    this.sourceReference = sourceReference;
+    this.sourceReference = Preconditions.checkNotNull(sourceReference, "sourceReference");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/SourceBreakpoint.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/SourceBreakpoint.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j.debug;
 
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -69,10 +70,7 @@ public class SourceBreakpoint {
    * The source line of the breakpoint or logpoint.
    */
   public void setLine(@NonNull final Long line) {
-    if (line == null) {
-      throw new IllegalArgumentException("Property must not be null: line");
-    }
-    this.line = line;
+    this.line = Preconditions.checkNotNull(line, "line");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/SourceResponse.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/SourceResponse.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j.debug;
 
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -46,10 +47,7 @@ public class SourceResponse {
    * Content of the source reference.
    */
   public void setContent(@NonNull final String content) {
-    if (content == null) {
-      throw new IllegalArgumentException("Property must not be null: content");
-    }
-    this.content = content;
+    this.content = Preconditions.checkNotNull(content, "content");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/StackFrame.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/StackFrame.java
@@ -13,6 +13,7 @@ package org.eclipse.lsp4j.debug;
 
 import org.eclipse.lsp4j.debug.Source;
 import org.eclipse.lsp4j.debug.StackFramePresentationHint;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
@@ -100,10 +101,7 @@ public class StackFrame {
    * scopes of the frame with the 'scopesRequest' or to restart the execution of a stackframe.
    */
   public void setId(@NonNull final Long id) {
-    if (id == null) {
-      throw new IllegalArgumentException("Property must not be null: id");
-    }
-    this.id = id;
+    this.id = Preconditions.checkNotNull(id, "id");
   }
   
   /**
@@ -119,10 +117,7 @@ public class StackFrame {
    * The name of the stack frame, typically a method name.
    */
   public void setName(@NonNull final String name) {
-    if (name == null) {
-      throw new IllegalArgumentException("Property must not be null: name");
-    }
-    this.name = name;
+    this.name = Preconditions.checkNotNull(name, "name");
   }
   
   /**
@@ -157,10 +152,7 @@ public class StackFrame {
    * The line within the file of the frame. If source is null or doesn't exist, line is 0 and must be ignored.
    */
   public void setLine(@NonNull final Long line) {
-    if (line == null) {
-      throw new IllegalArgumentException("Property must not be null: line");
-    }
-    this.line = line;
+    this.line = Preconditions.checkNotNull(line, "line");
   }
   
   /**
@@ -176,10 +168,7 @@ public class StackFrame {
    * The column within the line. If source is null or doesn't exist, column is 0 and must be ignored.
    */
   public void setColumn(@NonNull final Long column) {
-    if (column == null) {
-      throw new IllegalArgumentException("Property must not be null: column");
-    }
-    this.column = column;
+    this.column = Preconditions.checkNotNull(column, "column");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/StackTraceArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/StackTraceArguments.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j.debug;
 
 import org.eclipse.lsp4j.debug.StackFrameFormat;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -61,10 +62,7 @@ public class StackTraceArguments {
    * Retrieve the stacktrace for this thread.
    */
   public void setThreadId(@NonNull final Long threadId) {
-    if (threadId == null) {
-      throw new IllegalArgumentException("Property must not be null: threadId");
-    }
-    this.threadId = threadId;
+    this.threadId = Preconditions.checkNotNull(threadId, "threadId");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/StackTraceResponse.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/StackTraceResponse.java
@@ -13,6 +13,7 @@ package org.eclipse.lsp4j.debug;
 
 import java.util.Arrays;
 import org.eclipse.lsp4j.debug.StackFrame;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -54,10 +55,7 @@ public class StackTraceResponse {
    * This means that there is no location information available.
    */
   public void setStackFrames(@NonNull final StackFrame[] stackFrames) {
-    if (stackFrames == null) {
-      throw new IllegalArgumentException("Property must not be null: stackFrames");
-    }
-    this.stackFrames = stackFrames;
+    this.stackFrames = Preconditions.checkNotNull(stackFrames, "stackFrames");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/StepBackArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/StepBackArguments.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j.debug;
 
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -39,10 +40,7 @@ public class StepBackArguments {
    * Execute 'stepBack' for this thread.
    */
   public void setThreadId(@NonNull final Long threadId) {
-    if (threadId == null) {
-      throw new IllegalArgumentException("Property must not be null: threadId");
-    }
-    this.threadId = threadId;
+    this.threadId = Preconditions.checkNotNull(threadId, "threadId");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/StepInArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/StepInArguments.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j.debug;
 
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -46,10 +47,7 @@ public class StepInArguments {
    * Execute 'stepIn' for this thread.
    */
   public void setThreadId(@NonNull final Long threadId) {
-    if (threadId == null) {
-      throw new IllegalArgumentException("Property must not be null: threadId");
-    }
-    this.threadId = threadId;
+    this.threadId = Preconditions.checkNotNull(threadId, "threadId");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/StepInTarget.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/StepInTarget.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j.debug;
 
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -46,10 +47,7 @@ public class StepInTarget {
    * Unique identifier for a stepIn target.
    */
   public void setId(@NonNull final Long id) {
-    if (id == null) {
-      throw new IllegalArgumentException("Property must not be null: id");
-    }
-    this.id = id;
+    this.id = Preconditions.checkNotNull(id, "id");
   }
   
   /**
@@ -65,10 +63,7 @@ public class StepInTarget {
    * The name of the stepIn target (shown in the UI).
    */
   public void setLabel(@NonNull final String label) {
-    if (label == null) {
-      throw new IllegalArgumentException("Property must not be null: label");
-    }
-    this.label = label;
+    this.label = Preconditions.checkNotNull(label, "label");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/StepInTargetsArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/StepInTargetsArguments.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j.debug;
 
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -39,10 +40,7 @@ public class StepInTargetsArguments {
    * The stack frame for which to retrieve the possible stepIn targets.
    */
   public void setFrameId(@NonNull final Long frameId) {
-    if (frameId == null) {
-      throw new IllegalArgumentException("Property must not be null: frameId");
-    }
-    this.frameId = frameId;
+    this.frameId = Preconditions.checkNotNull(frameId, "frameId");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/StepInTargetsResponse.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/StepInTargetsResponse.java
@@ -13,6 +13,7 @@ package org.eclipse.lsp4j.debug;
 
 import java.util.Arrays;
 import org.eclipse.lsp4j.debug.StepInTarget;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -41,10 +42,7 @@ public class StepInTargetsResponse {
    * The possible stepIn targets of the specified source location.
    */
   public void setTargets(@NonNull final StepInTarget[] targets) {
-    if (targets == null) {
-      throw new IllegalArgumentException("Property must not be null: targets");
-    }
-    this.targets = targets;
+    this.targets = Preconditions.checkNotNull(targets, "targets");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/StepOutArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/StepOutArguments.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j.debug;
 
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -39,10 +40,7 @@ public class StepOutArguments {
    * Execute 'stepOut' for this thread.
    */
   public void setThreadId(@NonNull final Long threadId) {
-    if (threadId == null) {
-      throw new IllegalArgumentException("Property must not be null: threadId");
-    }
-    this.threadId = threadId;
+    this.threadId = Preconditions.checkNotNull(threadId, "threadId");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/StoppedEventArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/StoppedEventArguments.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j.debug;
 
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -99,10 +100,7 @@ public class StoppedEventArguments {
    * Possible values include - but not limited to those defined in {@link StoppedEventArgumentsReason}
    */
   public void setReason(@NonNull final String reason) {
-    if (reason == null) {
-      throw new IllegalArgumentException("Property must not be null: reason");
-    }
-    this.reason = reason;
+    this.reason = Preconditions.checkNotNull(reason, "reason");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/Thread.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/Thread.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j.debug;
 
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -45,10 +46,7 @@ public class Thread {
    * Unique identifier for the thread.
    */
   public void setId(@NonNull final Long id) {
-    if (id == null) {
-      throw new IllegalArgumentException("Property must not be null: id");
-    }
-    this.id = id;
+    this.id = Preconditions.checkNotNull(id, "id");
   }
   
   /**
@@ -64,10 +62,7 @@ public class Thread {
    * A name of the thread.
    */
   public void setName(@NonNull final String name) {
-    if (name == null) {
-      throw new IllegalArgumentException("Property must not be null: name");
-    }
-    this.name = name;
+    this.name = Preconditions.checkNotNull(name, "name");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ThreadEventArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ThreadEventArguments.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j.debug;
 
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -51,10 +52,7 @@ public class ThreadEventArguments {
    * Possible values include - but not limited to those defined in {@link ThreadEventArgumentsReason}
    */
   public void setReason(@NonNull final String reason) {
-    if (reason == null) {
-      throw new IllegalArgumentException("Property must not be null: reason");
-    }
-    this.reason = reason;
+    this.reason = Preconditions.checkNotNull(reason, "reason");
   }
   
   /**
@@ -70,10 +68,7 @@ public class ThreadEventArguments {
    * The identifier of the thread.
    */
   public void setThreadId(@NonNull final Long threadId) {
-    if (threadId == null) {
-      throw new IllegalArgumentException("Property must not be null: threadId");
-    }
-    this.threadId = threadId;
+    this.threadId = Preconditions.checkNotNull(threadId, "threadId");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ThreadsResponse.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/ThreadsResponse.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j.debug;
 
 import java.util.Arrays;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -40,10 +41,7 @@ public class ThreadsResponse {
    * All threads.
    */
   public void setThreads(@NonNull final org.eclipse.lsp4j.debug.Thread[] threads) {
-    if (threads == null) {
-      throw new IllegalArgumentException("Property must not be null: threads");
-    }
-    this.threads = threads;
+    this.threads = Preconditions.checkNotNull(threads, "threads");
   }
   
   @Override

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/Variable.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/Variable.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j.debug;
 
 import org.eclipse.lsp4j.debug.VariablePresentationHint;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -107,10 +108,7 @@ public class Variable {
    * The variable's name.
    */
   public void setName(@NonNull final String name) {
-    if (name == null) {
-      throw new IllegalArgumentException("Property must not be null: name");
-    }
-    this.name = name;
+    this.name = Preconditions.checkNotNull(name, "name");
   }
   
   /**
@@ -126,10 +124,7 @@ public class Variable {
    * The variable's value. This can be a multi-line text, e.g. for a function the body of a function.
    */
   public void setValue(@NonNull final String value) {
-    if (value == null) {
-      throw new IllegalArgumentException("Property must not be null: value");
-    }
-    this.value = value;
+    this.value = Preconditions.checkNotNull(value, "value");
   }
   
   /**
@@ -206,10 +201,7 @@ public class Variable {
    * variablesReference to the VariablesRequest.
    */
   public void setVariablesReference(@NonNull final Long variablesReference) {
-    if (variablesReference == null) {
-      throw new IllegalArgumentException("Property must not be null: variablesReference");
-    }
-    this.variablesReference = variablesReference;
+    this.variablesReference = Preconditions.checkNotNull(variablesReference, "variablesReference");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/VariablesArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/VariablesArguments.java
@@ -13,6 +13,7 @@ package org.eclipse.lsp4j.debug;
 
 import org.eclipse.lsp4j.debug.ValueFormat;
 import org.eclipse.lsp4j.debug.VariablesArgumentsFilter;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -69,10 +70,7 @@ public class VariablesArguments {
    * The Variable reference.
    */
   public void setVariablesReference(@NonNull final Long variablesReference) {
-    if (variablesReference == null) {
-      throw new IllegalArgumentException("Property must not be null: variablesReference");
-    }
-    this.variablesReference = variablesReference;
+    this.variablesReference = Preconditions.checkNotNull(variablesReference, "variablesReference");
   }
   
   /**

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/VariablesResponse.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/VariablesResponse.java
@@ -13,6 +13,7 @@ package org.eclipse.lsp4j.debug;
 
 import java.util.Arrays;
 import org.eclipse.lsp4j.debug.Variable;
+import org.eclipse.lsp4j.debug.util.Preconditions;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -41,10 +42,7 @@ public class VariablesResponse {
    * All (or a range) of variables for the given variable reference.
    */
   public void setVariables(@NonNull final Variable[] variables) {
-    if (variables == null) {
-      throw new IllegalArgumentException("Property must not be null: variables");
-    }
-    this.variables = variables;
+    this.variables = Preconditions.checkNotNull(variables, "variables");
   }
   
   @Override

--- a/org.eclipse.lsp4j.generator/src/main/xtend-gen/org/eclipse/lsp4j/generator/JsonRpcDataProcessor.java
+++ b/org.eclipse.lsp4j.generator/src/main/xtend-gen/org/eclipse/lsp4j/generator/JsonRpcDataProcessor.java
@@ -117,26 +117,19 @@ public class JsonRpcDataProcessor extends AbstractClassProcessor {
             StringConcatenationClient _client = new StringConcatenationClient() {
               @Override
               protected void appendTo(StringConcatenationClient.TargetStringConcatenation _builder) {
-                _builder.append("if (");
-                String _simpleName = parameter.getSimpleName();
-                _builder.append(_simpleName);
-                _builder.append(" == null) {");
-                _builder.newLineIfNotEmpty();
-                _builder.append("  ");
-                _builder.append("throw new IllegalArgumentException(\"Property must not be null: ");
-                String _simpleName_1 = field.getSimpleName();
-                _builder.append(_simpleName_1, "  ");
-                _builder.append("\");");
-                _builder.newLineIfNotEmpty();
-                _builder.append("}");
-                _builder.newLine();
                 _builder.append("this.");
+                String _simpleName = field.getSimpleName();
+                _builder.append(_simpleName);
+                _builder.append(" = ");
+                TypeReference _preconditionsUtil = JsonRpcDataProcessor.this.getPreconditionsUtil(impl, context);
+                _builder.append(_preconditionsUtil);
+                _builder.append(".checkNotNull(");
+                String _simpleName_1 = parameter.getSimpleName();
+                _builder.append(_simpleName_1);
+                _builder.append(", \"");
                 String _simpleName_2 = field.getSimpleName();
                 _builder.append(_simpleName_2);
-                _builder.append(" = ");
-                String _simpleName_3 = parameter.getSimpleName();
-                _builder.append(_simpleName_3);
-                _builder.append(";");
+                _builder.append("\");");
                 _builder.newLineIfNotEmpty();
               }
             };
@@ -209,7 +202,7 @@ public class JsonRpcDataProcessor extends AbstractClassProcessor {
       _builder.append("(");
       _builder.append(variableName);
       _builder.append(")");
-      final String compileNewEither = _builder.toString();
+      final CharSequence compileNewEither = _builder;
       StringConcatenation _builder_1 = new StringConcatenation();
       _builder_1.append("if (");
       _builder_1.append(variableName);
@@ -218,23 +211,26 @@ public class JsonRpcDataProcessor extends AbstractClassProcessor {
       {
         if (hasNonNull) {
           _builder_1.append("  ");
-          _builder_1.append("throw new IllegalArgumentException(\"Property must not be null: ");
+          TypeReference _preconditionsUtil = this.getPreconditionsUtil(field.getDeclaringType(), context);
+          _builder_1.append(_preconditionsUtil, "  ");
+          _builder_1.append(".checkNotNull(");
+          _builder_1.append(variableName, "  ");
+          _builder_1.append(", \"");
           String _simpleName = field.getSimpleName();
           _builder_1.append(_simpleName, "  ");
           _builder_1.append("\");");
           _builder_1.newLineIfNotEmpty();
-        } else {
-          _builder_1.append("  ");
-          _builder_1.append("this.");
-          String _simpleName_1 = field.getSimpleName();
-          _builder_1.append(_simpleName_1, "  ");
-          _builder_1.append(" = null;");
-          _builder_1.newLineIfNotEmpty();
-          _builder_1.append("  ");
-          _builder_1.append("return;");
-          _builder_1.newLine();
         }
       }
+      _builder_1.append("  ");
+      _builder_1.append("this.");
+      String _simpleName_1 = field.getSimpleName();
+      _builder_1.append(_simpleName_1, "  ");
+      _builder_1.append(" = null;");
+      _builder_1.newLineIfNotEmpty();
+      _builder_1.append("  ");
+      _builder_1.append("return;");
+      _builder_1.newLine();
       _builder_1.append("}");
       _builder_1.newLine();
       {
@@ -330,5 +326,16 @@ public class JsonRpcDataProcessor extends AbstractClassProcessor {
       _xblockexpression = impl.addMethod("toString", _function);
     }
     return _xblockexpression;
+  }
+  
+  private TypeReference getPreconditionsUtil(final Type type, @Extension final TransformationContext context) {
+    TypeReference _xifexpression = null;
+    boolean _startsWith = type.getQualifiedName().startsWith("org.eclipse.lsp4j.debug");
+    if (_startsWith) {
+      _xifexpression = context.newTypeReference("org.eclipse.lsp4j.debug.util.Preconditions");
+    } else {
+      _xifexpression = context.newTypeReference("org.eclipse.lsp4j.util.Preconditions");
+    }
+    return _xifexpression;
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ApplyWorkspaceEditParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ApplyWorkspaceEditParams.java
@@ -60,10 +60,7 @@ public class ApplyWorkspaceEditParams {
    * The edits to apply.
    */
   public void setEdit(@NonNull final WorkspaceEdit edit) {
-    if (edit == null) {
-      throw new IllegalArgumentException("Property must not be null: edit");
-    }
-    this.edit = edit;
+    this.edit = Preconditions.checkNotNull(edit, "edit");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyCall.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyCall.java
@@ -15,6 +15,7 @@ import com.google.common.annotations.Beta;
 import org.eclipse.lsp4j.CallHierarchySymbol;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -55,10 +56,7 @@ public class CallHierarchyCall {
    * The source range of the reference. The range is a sub range of the {@link CallHierarchyCall#getFrom from} symbol range.
    */
   public void setRange(@NonNull final Range range) {
-    if (range == null) {
-      throw new IllegalArgumentException("Property must not be null: range");
-    }
-    this.range = range;
+    this.range = Preconditions.checkNotNull(range, "range");
   }
   
   /**
@@ -74,10 +72,7 @@ public class CallHierarchyCall {
    * The symbol that contains the reference.
    */
   public void setFrom(@NonNull final CallHierarchySymbol from) {
-    if (from == null) {
-      throw new IllegalArgumentException("Property must not be null: from");
-    }
-    this.from = from;
+    this.from = Preconditions.checkNotNull(from, "from");
   }
   
   /**
@@ -93,10 +88,7 @@ public class CallHierarchyCall {
    * The symbol that is referenced.
    */
   public void setTo(@NonNull final CallHierarchySymbol to) {
-    if (to == null) {
-      throw new IllegalArgumentException("Property must not be null: to");
-    }
-    this.to = to;
+    this.to = Preconditions.checkNotNull(to, "to");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyParams.java
@@ -15,6 +15,7 @@ import com.google.common.annotations.Beta;
 import org.eclipse.lsp4j.CallHierarchyDirection;
 import org.eclipse.lsp4j.TextDocumentPositionParams;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -43,10 +44,7 @@ public class CallHierarchyParams extends TextDocumentPositionParams {
    * The direction of calls to provide.
    */
   public void setDirection(@NonNull final CallHierarchyDirection direction) {
-    if (direction == null) {
-      throw new IllegalArgumentException("Property must not be null: direction");
-    }
-    this.direction = direction;
+    this.direction = Preconditions.checkNotNull(direction, "direction");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchySymbol.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchySymbol.java
@@ -15,6 +15,7 @@ import com.google.common.annotations.Beta;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -75,10 +76,7 @@ public class CallHierarchySymbol {
    * The name of the symbol targeted by the call hierarchy request.
    */
   public void setName(@NonNull final String name) {
-    if (name == null) {
-      throw new IllegalArgumentException("Property must not be null: name");
-    }
-    this.name = name;
+    this.name = Preconditions.checkNotNull(name, "name");
   }
   
   /**
@@ -109,10 +107,7 @@ public class CallHierarchySymbol {
    * The kind of this symbol.
    */
   public void setKind(@NonNull final SymbolKind kind) {
-    if (kind == null) {
-      throw new IllegalArgumentException("Property must not be null: kind");
-    }
-    this.kind = kind;
+    this.kind = Preconditions.checkNotNull(kind, "kind");
   }
   
   /**
@@ -128,10 +123,7 @@ public class CallHierarchySymbol {
    * URI of the document containing the symbol.
    */
   public void setUri(@NonNull final String uri) {
-    if (uri == null) {
-      throw new IllegalArgumentException("Property must not be null: uri");
-    }
-    this.uri = uri;
+    this.uri = Preconditions.checkNotNull(uri, "uri");
   }
   
   /**
@@ -151,10 +143,7 @@ public class CallHierarchySymbol {
    * inside the symbol to reveal in the symbol in the UI.
    */
   public void setRange(@NonNull final Range range) {
-    if (range == null) {
-      throw new IllegalArgumentException("Property must not be null: range");
-    }
-    this.range = range;
+    this.range = Preconditions.checkNotNull(range, "range");
   }
   
   /**
@@ -172,10 +161,7 @@ public class CallHierarchySymbol {
    * Must be contained by the the {@link CallHierarchySymbol#getRange range}.
    */
   public void setSelectionRange(@NonNull final Range selectionRange) {
-    if (selectionRange == null) {
-      throw new IllegalArgumentException("Property must not be null: selectionRange");
-    }
-    this.selectionRange = selectionRange;
+    this.selectionRange = Preconditions.checkNotNull(selectionRange, "selectionRange");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeAction.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeAction.java
@@ -78,10 +78,7 @@ public class CodeAction {
    * A short, human-readable, title for this code action.
    */
   public void setTitle(@NonNull final String title) {
-    if (title == null) {
-      throw new IllegalArgumentException("Property must not be null: title");
-    }
-    this.title = title;
+    this.title = Preconditions.checkNotNull(title, "title");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeActionContext.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeActionContext.java
@@ -64,10 +64,7 @@ public class CodeActionContext {
    * An array of diagnostics.
    */
   public void setDiagnostics(@NonNull final List<Diagnostic> diagnostics) {
-    if (diagnostics == null) {
-      throw new IllegalArgumentException("Property must not be null: diagnostics");
-    }
-    this.diagnostics = diagnostics;
+    this.diagnostics = Preconditions.checkNotNull(diagnostics, "diagnostics");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeActionParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeActionParams.java
@@ -66,10 +66,7 @@ public class CodeActionParams {
    * The document in which the command was invoked.
    */
   public void setTextDocument(@NonNull final TextDocumentIdentifier textDocument) {
-    if (textDocument == null) {
-      throw new IllegalArgumentException("Property must not be null: textDocument");
-    }
-    this.textDocument = textDocument;
+    this.textDocument = Preconditions.checkNotNull(textDocument, "textDocument");
   }
   
   /**
@@ -85,10 +82,7 @@ public class CodeActionParams {
    * The range for which the command was invoked.
    */
   public void setRange(@NonNull final Range range) {
-    if (range == null) {
-      throw new IllegalArgumentException("Property must not be null: range");
-    }
-    this.range = range;
+    this.range = Preconditions.checkNotNull(range, "range");
   }
   
   /**
@@ -104,10 +98,7 @@ public class CodeActionParams {
    * Context carrying additional information.
    */
   public void setContext(@NonNull final CodeActionContext context) {
-    if (context == null) {
-      throw new IllegalArgumentException("Property must not be null: context");
-    }
-    this.context = context;
+    this.context = Preconditions.checkNotNull(context, "context");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeLens.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeLens.java
@@ -72,10 +72,7 @@ public class CodeLens {
    * The range in which this code lens is valid. Should only span a single line.
    */
   public void setRange(@NonNull final Range range) {
-    if (range == null) {
-      throw new IllegalArgumentException("Property must not be null: range");
-    }
-    this.range = range;
+    this.range = Preconditions.checkNotNull(range, "range");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeLensParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeLensParams.java
@@ -48,10 +48,7 @@ public class CodeLensParams {
    * The document to request code lens for.
    */
   public void setTextDocument(@NonNull final TextDocumentIdentifier textDocument) {
-    if (textDocument == null) {
-      throw new IllegalArgumentException("Property must not be null: textDocument");
-    }
-    this.textDocument = textDocument;
+    this.textDocument = Preconditions.checkNotNull(textDocument, "textDocument");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ColorInformation.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ColorInformation.java
@@ -53,10 +53,7 @@ public class ColorInformation {
    * The range in the document where this color appers.
    */
   public void setRange(@NonNull final Range range) {
-    if (range == null) {
-      throw new IllegalArgumentException("Property must not be null: range");
-    }
-    this.range = range;
+    this.range = Preconditions.checkNotNull(range, "range");
   }
   
   /**
@@ -72,10 +69,7 @@ public class ColorInformation {
    * The actual color value for this color range.
    */
   public void setColor(@NonNull final Color color) {
-    if (color == null) {
-      throw new IllegalArgumentException("Property must not be null: color");
-    }
-    this.color = color;
+    this.color = Preconditions.checkNotNull(color, "color");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ColorPresentation.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ColorPresentation.java
@@ -75,10 +75,7 @@ public class ColorPresentation {
    * this color presentation.
    */
   public void setLabel(@NonNull final String label) {
-    if (label == null) {
-      throw new IllegalArgumentException("Property must not be null: label");
-    }
-    this.label = label;
+    this.label = Preconditions.checkNotNull(label, "label");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ColorPresentationParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ColorPresentationParams.java
@@ -67,10 +67,7 @@ public class ColorPresentationParams {
    * The text document.
    */
   public void setTextDocument(@NonNull final TextDocumentIdentifier textDocument) {
-    if (textDocument == null) {
-      throw new IllegalArgumentException("Property must not be null: textDocument");
-    }
-    this.textDocument = textDocument;
+    this.textDocument = Preconditions.checkNotNull(textDocument, "textDocument");
   }
   
   /**
@@ -86,10 +83,7 @@ public class ColorPresentationParams {
    * The color information to request presentations for.
    */
   public void setColor(@NonNull final Color color) {
-    if (color == null) {
-      throw new IllegalArgumentException("Property must not be null: color");
-    }
-    this.color = color;
+    this.color = Preconditions.checkNotNull(color, "color");
   }
   
   /**
@@ -105,10 +99,7 @@ public class ColorPresentationParams {
    * The range where the color would be inserted. Serves as a context.
    */
   public void setRange(@NonNull final Range range) {
-    if (range == null) {
-      throw new IllegalArgumentException("Property must not be null: range");
-    }
-    this.range = range;
+    this.range = Preconditions.checkNotNull(range, "range");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ColoringInformation.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ColoringInformation.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -66,10 +67,7 @@ public class ColoringInformation {
    * The range that should be highlighted on the client-side.
    */
   public void setRange(@NonNull final Range range) {
-    if (range == null) {
-      throw new IllegalArgumentException("Property must not be null: range");
-    }
-    this.range = range;
+    this.range = Preconditions.checkNotNull(range, "range");
   }
   
   /**
@@ -89,10 +87,7 @@ public class ColoringInformation {
    * applying all styles on the range.
    */
   public void setStyles(@NonNull final List<Integer> styles) {
-    if (styles == null) {
-      throw new IllegalArgumentException("Property must not be null: styles");
-    }
-    this.styles = styles;
+    this.styles = Preconditions.checkNotNull(styles, "styles");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ColoringParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ColoringParams.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.lsp4j.ColoringInformation;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -64,10 +65,7 @@ public class ColoringParams {
    * The URI for which coloring information is reported.
    */
   public void setUri(@NonNull final String uri) {
-    if (uri == null) {
-      throw new IllegalArgumentException("Property must not be null: uri");
-    }
-    this.uri = uri;
+    this.uri = Preconditions.checkNotNull(uri, "uri");
   }
   
   /**
@@ -83,10 +81,7 @@ public class ColoringParams {
    * A list of coloring information instances.
    */
   public void setInfos(@NonNull final List<? extends ColoringInformation> infos) {
-    if (infos == null) {
-      throw new IllegalArgumentException("Property must not be null: infos");
-    }
-    this.infos = infos;
+    this.infos = Preconditions.checkNotNull(infos, "infos");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Command.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Command.java
@@ -66,10 +66,7 @@ public class Command {
    * Title of the command, like `save`.
    */
   public void setTitle(@NonNull final String title) {
-    if (title == null) {
-      throw new IllegalArgumentException("Property must not be null: title");
-    }
-    this.title = title;
+    this.title = Preconditions.checkNotNull(title, "title");
   }
   
   /**
@@ -85,10 +82,7 @@ public class Command {
    * The identifier of the actual command handler.
    */
   public void setCommand(@NonNull final String command) {
-    if (command == null) {
-      throw new IllegalArgumentException("Property must not be null: command");
-    }
-    this.command = command;
+    this.command = Preconditions.checkNotNull(command, "command");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionContext.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionContext.java
@@ -56,10 +56,7 @@ public class CompletionContext {
    * How the completion was triggered.
    */
   public void setTriggerKind(@NonNull final CompletionTriggerKind triggerKind) {
-    if (triggerKind == null) {
-      throw new IllegalArgumentException("Property must not be null: triggerKind");
-    }
-    this.triggerKind = triggerKind;
+    this.triggerKind = Preconditions.checkNotNull(triggerKind, "triggerKind");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionItem.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionItem.java
@@ -149,10 +149,7 @@ public class CompletionItem {
    * The label of this completion item. By default also the text that is inserted when selecting this completion.
    */
   public void setLabel(@NonNull final String label) {
-    if (label == null) {
-      throw new IllegalArgumentException("Property must not be null: label");
-    }
-    this.label = label;
+    this.label = Preconditions.checkNotNull(label, "label");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionList.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionList.java
@@ -76,10 +76,7 @@ public class CompletionList {
    * The completion items.
    */
   public void setItems(@NonNull final List<CompletionItem> items) {
-    if (items == null) {
-      throw new IllegalArgumentException("Property must not be null: items");
-    }
-    this.items = items;
+    this.items = Preconditions.checkNotNull(items, "items");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ConfigurationParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ConfigurationParams.java
@@ -46,10 +46,7 @@ public class ConfigurationParams {
   }
   
   public void setItems(@NonNull final List<ConfigurationItem> items) {
-    if (items == null) {
-      throw new IllegalArgumentException("Property must not be null: items");
-    }
-    this.items = items;
+    this.items = Preconditions.checkNotNull(items, "items");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CreateFile.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CreateFile.java
@@ -63,10 +63,7 @@ public class CreateFile extends ResourceOperation {
    * The resource to create.
    */
   public void setUri(@NonNull final String uri) {
-    if (uri == null) {
-      throw new IllegalArgumentException("Property must not be null: uri");
-    }
-    this.uri = uri;
+    this.uri = Preconditions.checkNotNull(uri, "uri");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DeleteFile.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DeleteFile.java
@@ -63,10 +63,7 @@ public class DeleteFile extends ResourceOperation {
    * The file to delete.
    */
   public void setUri(@NonNull final String uri) {
-    if (uri == null) {
-      throw new IllegalArgumentException("Property must not be null: uri");
-    }
-    this.uri = uri;
+    this.uri = Preconditions.checkNotNull(uri, "uri");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Diagnostic.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Diagnostic.java
@@ -93,10 +93,7 @@ public class Diagnostic {
    * The range at which the message applies
    */
   public void setRange(@NonNull final Range range) {
-    if (range == null) {
-      throw new IllegalArgumentException("Property must not be null: range");
-    }
-    this.range = range;
+    this.range = Preconditions.checkNotNull(range, "range");
   }
   
   /**
@@ -159,10 +156,7 @@ public class Diagnostic {
    * The diagnostic's message.
    */
   public void setMessage(@NonNull final String message) {
-    if (message == null) {
-      throw new IllegalArgumentException("Property must not be null: message");
-    }
-    this.message = message;
+    this.message = Preconditions.checkNotNull(message, "message");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DiagnosticRelatedInformation.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DiagnosticRelatedInformation.java
@@ -59,10 +59,7 @@ public class DiagnosticRelatedInformation {
    * The location of this related diagnostic information.
    */
   public void setLocation(@NonNull final Location location) {
-    if (location == null) {
-      throw new IllegalArgumentException("Property must not be null: location");
-    }
-    this.location = location;
+    this.location = Preconditions.checkNotNull(location, "location");
   }
   
   /**
@@ -78,10 +75,7 @@ public class DiagnosticRelatedInformation {
    * The message of this related diagnostic information.
    */
   public void setMessage(@NonNull final String message) {
-    if (message == null) {
-      throw new IllegalArgumentException("Property must not be null: message");
-    }
-    this.message = message;
+    this.message = Preconditions.checkNotNull(message, "message");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidChangeConfigurationParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidChangeConfigurationParams.java
@@ -50,10 +50,7 @@ public class DidChangeConfigurationParams {
    * The actual changed settings.
    */
   public void setSettings(@NonNull final Object settings) {
-    if (settings == null) {
-      throw new IllegalArgumentException("Property must not be null: settings");
-    }
-    this.settings = settings;
+    this.settings = Preconditions.checkNotNull(settings, "settings");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidChangeTextDocumentParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidChangeTextDocumentParams.java
@@ -73,10 +73,7 @@ public class DidChangeTextDocumentParams {
    * been applied.
    */
   public void setTextDocument(@NonNull final VersionedTextDocumentIdentifier textDocument) {
-    if (textDocument == null) {
-      throw new IllegalArgumentException("Property must not be null: textDocument");
-    }
-    this.textDocument = textDocument;
+    this.textDocument = Preconditions.checkNotNull(textDocument, "textDocument");
   }
   
   /**
@@ -109,10 +106,7 @@ public class DidChangeTextDocumentParams {
    * The actual content changes.
    */
   public void setContentChanges(@NonNull final List<TextDocumentContentChangeEvent> contentChanges) {
-    if (contentChanges == null) {
-      throw new IllegalArgumentException("Property must not be null: contentChanges");
-    }
-    this.contentChanges = contentChanges;
+    this.contentChanges = Preconditions.checkNotNull(contentChanges, "contentChanges");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidChangeWatchedFilesParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidChangeWatchedFilesParams.java
@@ -52,10 +52,7 @@ public class DidChangeWatchedFilesParams {
    * The actual file events.
    */
   public void setChanges(@NonNull final List<FileEvent> changes) {
-    if (changes == null) {
-      throw new IllegalArgumentException("Property must not be null: changes");
-    }
-    this.changes = changes;
+    this.changes = Preconditions.checkNotNull(changes, "changes");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidChangeWatchedFilesRegistrationOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidChangeWatchedFilesRegistrationOptions.java
@@ -46,10 +46,7 @@ public class DidChangeWatchedFilesRegistrationOptions {
    * The watchers to register.
    */
   public void setWatchers(@NonNull final List<FileSystemWatcher> watchers) {
-    if (watchers == null) {
-      throw new IllegalArgumentException("Property must not be null: watchers");
-    }
-    this.watchers = watchers;
+    this.watchers = Preconditions.checkNotNull(watchers, "watchers");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidChangeWorkspaceFoldersParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidChangeWorkspaceFoldersParams.java
@@ -52,10 +52,7 @@ public class DidChangeWorkspaceFoldersParams {
    * The actual workspace folder change event.
    */
   public void setEvent(@NonNull final WorkspaceFoldersChangeEvent event) {
-    if (event == null) {
-      throw new IllegalArgumentException("Property must not be null: event");
-    }
-    this.event = event;
+    this.event = Preconditions.checkNotNull(event, "event");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidCloseTextDocumentParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidCloseTextDocumentParams.java
@@ -50,10 +50,7 @@ public class DidCloseTextDocumentParams {
    * The document that was closed.
    */
   public void setTextDocument(@NonNull final TextDocumentIdentifier textDocument) {
-    if (textDocument == null) {
-      throw new IllegalArgumentException("Property must not be null: textDocument");
-    }
-    this.textDocument = textDocument;
+    this.textDocument = Preconditions.checkNotNull(textDocument, "textDocument");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidOpenTextDocumentParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidOpenTextDocumentParams.java
@@ -62,10 +62,7 @@ public class DidOpenTextDocumentParams {
    * The document that was opened.
    */
   public void setTextDocument(@NonNull final TextDocumentItem textDocument) {
-    if (textDocument == null) {
-      throw new IllegalArgumentException("Property must not be null: textDocument");
-    }
-    this.textDocument = textDocument;
+    this.textDocument = Preconditions.checkNotNull(textDocument, "textDocument");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidSaveTextDocumentParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidSaveTextDocumentParams.java
@@ -59,10 +59,7 @@ public class DidSaveTextDocumentParams {
    * The document that was closed.
    */
   public void setTextDocument(@NonNull final TextDocumentIdentifier textDocument) {
-    if (textDocument == null) {
-      throw new IllegalArgumentException("Property must not be null: textDocument");
-    }
-    this.textDocument = textDocument;
+    this.textDocument = Preconditions.checkNotNull(textDocument, "textDocument");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentColorParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentColorParams.java
@@ -51,10 +51,7 @@ public class DocumentColorParams {
    * The text document.
    */
   public void setTextDocument(@NonNull final TextDocumentIdentifier textDocument) {
-    if (textDocument == null) {
-      throw new IllegalArgumentException("Property must not be null: textDocument");
-    }
-    this.textDocument = textDocument;
+    this.textDocument = Preconditions.checkNotNull(textDocument, "textDocument");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentFormattingParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentFormattingParams.java
@@ -56,10 +56,7 @@ public class DocumentFormattingParams {
    * The document to format.
    */
   public void setTextDocument(@NonNull final TextDocumentIdentifier textDocument) {
-    if (textDocument == null) {
-      throw new IllegalArgumentException("Property must not be null: textDocument");
-    }
-    this.textDocument = textDocument;
+    this.textDocument = Preconditions.checkNotNull(textDocument, "textDocument");
   }
   
   /**
@@ -75,10 +72,7 @@ public class DocumentFormattingParams {
    * The format options
    */
   public void setOptions(@NonNull final FormattingOptions options) {
-    if (options == null) {
-      throw new IllegalArgumentException("Property must not be null: options");
-    }
-    this.options = options;
+    this.options = Preconditions.checkNotNull(options, "options");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentHighlight.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentHighlight.java
@@ -60,10 +60,7 @@ public class DocumentHighlight {
    * The range this highlight applies to.
    */
   public void setRange(@NonNull final Range range) {
-    if (range == null) {
-      throw new IllegalArgumentException("Property must not be null: range");
-    }
-    this.range = range;
+    this.range = Preconditions.checkNotNull(range, "range");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentLink.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentLink.java
@@ -73,10 +73,7 @@ public class DocumentLink {
    * The range this link applies to.
    */
   public void setRange(@NonNull final Range range) {
-    if (range == null) {
-      throw new IllegalArgumentException("Property must not be null: range");
-    }
-    this.range = range;
+    this.range = Preconditions.checkNotNull(range, "range");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentLinkParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentLinkParams.java
@@ -48,10 +48,7 @@ public class DocumentLinkParams {
    * The document to provide document links for.
    */
   public void setTextDocument(@NonNull final TextDocumentIdentifier textDocument) {
-    if (textDocument == null) {
-      throw new IllegalArgumentException("Property must not be null: textDocument");
-    }
-    this.textDocument = textDocument;
+    this.textDocument = Preconditions.checkNotNull(textDocument, "textDocument");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentOnTypeFormattingOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentOnTypeFormattingOptions.java
@@ -58,10 +58,7 @@ public class DocumentOnTypeFormattingOptions {
    * A character on which formatting should be triggered, like `}`.
    */
   public void setFirstTriggerCharacter(@NonNull final String firstTriggerCharacter) {
-    if (firstTriggerCharacter == null) {
-      throw new IllegalArgumentException("Property must not be null: firstTriggerCharacter");
-    }
-    this.firstTriggerCharacter = firstTriggerCharacter;
+    this.firstTriggerCharacter = Preconditions.checkNotNull(firstTriggerCharacter, "firstTriggerCharacter");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentOnTypeFormattingParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentOnTypeFormattingParams.java
@@ -56,10 +56,7 @@ public class DocumentOnTypeFormattingParams extends DocumentFormattingParams {
    * The position at which this request was send.
    */
   public void setPosition(@NonNull final Position position) {
-    if (position == null) {
-      throw new IllegalArgumentException("Property must not be null: position");
-    }
-    this.position = position;
+    this.position = Preconditions.checkNotNull(position, "position");
   }
   
   /**
@@ -75,10 +72,7 @@ public class DocumentOnTypeFormattingParams extends DocumentFormattingParams {
    * The character that has been typed.
    */
   public void setCh(@NonNull final String ch) {
-    if (ch == null) {
-      throw new IllegalArgumentException("Property must not be null: ch");
-    }
-    this.ch = ch;
+    this.ch = Preconditions.checkNotNull(ch, "ch");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentOnTypeFormattingRegistrationOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentOnTypeFormattingRegistrationOptions.java
@@ -56,10 +56,7 @@ public class DocumentOnTypeFormattingRegistrationOptions extends TextDocumentReg
    * A character on which formatting should be triggered, like `}`.
    */
   public void setFirstTriggerCharacter(@NonNull final String firstTriggerCharacter) {
-    if (firstTriggerCharacter == null) {
-      throw new IllegalArgumentException("Property must not be null: firstTriggerCharacter");
-    }
-    this.firstTriggerCharacter = firstTriggerCharacter;
+    this.firstTriggerCharacter = Preconditions.checkNotNull(firstTriggerCharacter, "firstTriggerCharacter");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentRangeFormattingParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentRangeFormattingParams.java
@@ -49,10 +49,7 @@ public class DocumentRangeFormattingParams extends DocumentFormattingParams {
    * The range to format
    */
   public void setRange(@NonNull final Range range) {
-    if (range == null) {
-      throw new IllegalArgumentException("Property must not be null: range");
-    }
-    this.range = range;
+    this.range = Preconditions.checkNotNull(range, "range");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentSymbol.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentSymbol.java
@@ -103,10 +103,7 @@ public class DocumentSymbol {
    * The name of this symbol.
    */
   public void setName(@NonNull final String name) {
-    if (name == null) {
-      throw new IllegalArgumentException("Property must not be null: name");
-    }
-    this.name = name;
+    this.name = Preconditions.checkNotNull(name, "name");
   }
   
   /**
@@ -122,10 +119,7 @@ public class DocumentSymbol {
    * The kind of this symbol.
    */
   public void setKind(@NonNull final SymbolKind kind) {
-    if (kind == null) {
-      throw new IllegalArgumentException("Property must not be null: kind");
-    }
-    this.kind = kind;
+    this.kind = Preconditions.checkNotNull(kind, "kind");
   }
   
   /**
@@ -145,10 +139,7 @@ public class DocumentSymbol {
    * inside the symbol to reveal in the symbol in the UI.
    */
   public void setRange(@NonNull final Range range) {
-    if (range == null) {
-      throw new IllegalArgumentException("Property must not be null: range");
-    }
-    this.range = range;
+    this.range = Preconditions.checkNotNull(range, "range");
   }
   
   /**
@@ -166,10 +157,7 @@ public class DocumentSymbol {
    * Must be contained by the `range`.
    */
   public void setSelectionRange(@NonNull final Range selectionRange) {
-    if (selectionRange == null) {
-      throw new IllegalArgumentException("Property must not be null: selectionRange");
-    }
-    this.selectionRange = selectionRange;
+    this.selectionRange = Preconditions.checkNotNull(selectionRange, "selectionRange");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentSymbolParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentSymbolParams.java
@@ -48,10 +48,7 @@ public class DocumentSymbolParams {
    * The text document.
    */
   public void setTextDocument(@NonNull final TextDocumentIdentifier textDocument) {
-    if (textDocument == null) {
-      throw new IllegalArgumentException("Property must not be null: textDocument");
-    }
-    this.textDocument = textDocument;
+    this.textDocument = Preconditions.checkNotNull(textDocument, "textDocument");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ExecuteCommandOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ExecuteCommandOptions.java
@@ -50,10 +50,7 @@ public class ExecuteCommandOptions {
    * The commands to be executed on the server
    */
   public void setCommands(@NonNull final List<String> commands) {
-    if (commands == null) {
-      throw new IllegalArgumentException("Property must not be null: commands");
-    }
-    this.commands = commands;
+    this.commands = Preconditions.checkNotNull(commands, "commands");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ExecuteCommandParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ExecuteCommandParams.java
@@ -59,10 +59,7 @@ public class ExecuteCommandParams {
    * The identifier of the actual command handler.
    */
   public void setCommand(@NonNull final String command) {
-    if (command == null) {
-      throw new IllegalArgumentException("Property must not be null: command");
-    }
-    this.command = command;
+    this.command = Preconditions.checkNotNull(command, "command");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ExecuteCommandRegistrationOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ExecuteCommandRegistrationOptions.java
@@ -48,10 +48,7 @@ public class ExecuteCommandRegistrationOptions {
    * The commands to be executed on the server
    */
   public void setCommands(@NonNull final List<String> commands) {
-    if (commands == null) {
-      throw new IllegalArgumentException("Property must not be null: commands");
-    }
-    this.commands = commands;
+    this.commands = Preconditions.checkNotNull(commands, "commands");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/FileEvent.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/FileEvent.java
@@ -55,10 +55,7 @@ public class FileEvent {
    * The file's uri.
    */
   public void setUri(@NonNull final String uri) {
-    if (uri == null) {
-      throw new IllegalArgumentException("Property must not be null: uri");
-    }
-    this.uri = uri;
+    this.uri = Preconditions.checkNotNull(uri, "uri");
   }
   
   /**
@@ -74,10 +71,7 @@ public class FileEvent {
    * The change type.
    */
   public void setType(@NonNull final FileChangeType type) {
-    if (type == null) {
-      throw new IllegalArgumentException("Property must not be null: type");
-    }
-    this.type = type;
+    this.type = Preconditions.checkNotNull(type, "type");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/FileSystemWatcher.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/FileSystemWatcher.java
@@ -56,10 +56,7 @@ public class FileSystemWatcher {
    * The  glob pattern to watch
    */
   public void setGlobPattern(@NonNull final String globPattern) {
-    if (globPattern == null) {
-      throw new IllegalArgumentException("Property must not be null: globPattern");
-    }
-    this.globPattern = globPattern;
+    this.globPattern = Preconditions.checkNotNull(globPattern, "globPattern");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/FoldingRangeRequestParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/FoldingRangeRequestParams.java
@@ -49,10 +49,7 @@ public class FoldingRangeRequestParams {
    * The text document.
    */
   public void setTextDocument(@NonNull final TextDocumentIdentifier textDocument) {
-    if (textDocument == null) {
-      throw new IllegalArgumentException("Property must not be null: textDocument");
-    }
-    this.textDocument = textDocument;
+    this.textDocument = Preconditions.checkNotNull(textDocument, "textDocument");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Hover.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Hover.java
@@ -74,22 +74,23 @@ public class Hover {
    * The hover's content as markdown
    */
   public void setContents(@NonNull final Either<List<Either<String, MarkedString>>, MarkupContent> contents) {
-    if (contents == null) {
-      throw new IllegalArgumentException("Property must not be null: contents");
-    }
-    this.contents = contents;
+    this.contents = Preconditions.checkNotNull(contents, "contents");
   }
   
   public void setContents(final List<Either<String, MarkedString>> contents) {
     if (contents == null) {
-      throw new IllegalArgumentException("Property must not be null: contents");
+      Preconditions.checkNotNull(contents, "contents");
+      this.contents = null;
+      return;
     }
     this.contents = Either.forLeft(contents);
   }
   
   public void setContents(final MarkupContent contents) {
     if (contents == null) {
-      throw new IllegalArgumentException("Property must not be null: contents");
+      Preconditions.checkNotNull(contents, "contents");
+      this.contents = null;
+      return;
     }
     this.contents = Either.forRight(contents);
   }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/InitializeResult.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/InitializeResult.java
@@ -45,10 +45,7 @@ public class InitializeResult {
    * The capabilities the language server provides.
    */
   public void setCapabilities(@NonNull final ServerCapabilities capabilities) {
-    if (capabilities == null) {
-      throw new IllegalArgumentException("Property must not be null: capabilities");
-    }
-    this.capabilities = capabilities;
+    this.capabilities = Preconditions.checkNotNull(capabilities, "capabilities");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Location.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Location.java
@@ -43,10 +43,7 @@ public class Location {
   }
   
   public void setUri(@NonNull final String uri) {
-    if (uri == null) {
-      throw new IllegalArgumentException("Property must not be null: uri");
-    }
-    this.uri = uri;
+    this.uri = Preconditions.checkNotNull(uri, "uri");
   }
   
   @Pure
@@ -56,10 +53,7 @@ public class Location {
   }
   
   public void setRange(@NonNull final Range range) {
-    if (range == null) {
-      throw new IllegalArgumentException("Property must not be null: range");
-    }
-    this.range = range;
+    this.range = Preconditions.checkNotNull(range, "range");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/LocationLink.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/LocationLink.java
@@ -99,10 +99,7 @@ public class LocationLink {
    * The target resource identifier of this link.
    */
   public void setTargetUri(@NonNull final String targetUri) {
-    if (targetUri == null) {
-      throw new IllegalArgumentException("Property must not be null: targetUri");
-    }
-    this.targetUri = targetUri;
+    this.targetUri = Preconditions.checkNotNull(targetUri, "targetUri");
   }
   
   /**
@@ -122,10 +119,7 @@ public class LocationLink {
    * like comments. This information is typically used to highlight the range in the editor.
    */
   public void setTargetRange(@NonNull final Range targetRange) {
-    if (targetRange == null) {
-      throw new IllegalArgumentException("Property must not be null: targetRange");
-    }
-    this.targetRange = targetRange;
+    this.targetRange = Preconditions.checkNotNull(targetRange, "targetRange");
   }
   
   /**
@@ -143,10 +137,7 @@ public class LocationLink {
    * Must be contained by the the `targetRange`. See also `DocumentSymbol#range`
    */
   public void setTargetSelectionRange(@NonNull final Range targetSelectionRange) {
-    if (targetSelectionRange == null) {
-      throw new IllegalArgumentException("Property must not be null: targetSelectionRange");
-    }
-    this.targetSelectionRange = targetSelectionRange;
+    this.targetSelectionRange = Preconditions.checkNotNull(targetSelectionRange, "targetSelectionRange");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/MarkedString.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/MarkedString.java
@@ -52,10 +52,7 @@ public class MarkedString {
   }
   
   public void setLanguage(@NonNull final String language) {
-    if (language == null) {
-      throw new IllegalArgumentException("Property must not be null: language");
-    }
-    this.language = language;
+    this.language = Preconditions.checkNotNull(language, "language");
   }
   
   @Pure
@@ -65,10 +62,7 @@ public class MarkedString {
   }
   
   public void setValue(@NonNull final String value) {
-    if (value == null) {
-      throw new IllegalArgumentException("Property must not be null: value");
-    }
-    this.value = value;
+    this.value = Preconditions.checkNotNull(value, "value");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/MarkupContent.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/MarkupContent.java
@@ -61,10 +61,7 @@ public class MarkupContent {
    * The type of the Markup.
    */
   public void setKind(@NonNull final String kind) {
-    if (kind == null) {
-      throw new IllegalArgumentException("Property must not be null: kind");
-    }
-    this.kind = kind;
+    this.kind = Preconditions.checkNotNull(kind, "kind");
   }
   
   /**
@@ -80,10 +77,7 @@ public class MarkupContent {
    * The content itself.
    */
   public void setValue(@NonNull final String value) {
-    if (value == null) {
-      throw new IllegalArgumentException("Property must not be null: value");
-    }
-    this.value = value;
+    this.value = Preconditions.checkNotNull(value, "value");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/MessageActionItem.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/MessageActionItem.java
@@ -49,10 +49,7 @@ public class MessageActionItem {
    * A short title like 'Retry', 'Open Log' etc.
    */
   public void setTitle(@NonNull final String title) {
-    if (title == null) {
-      throw new IllegalArgumentException("Property must not be null: title");
-    }
-    this.title = title;
+    this.title = Preconditions.checkNotNull(title, "title");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/MessageParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/MessageParams.java
@@ -58,10 +58,7 @@ public class MessageParams {
    * The message type.
    */
   public void setType(@NonNull final MessageType type) {
-    if (type == null) {
-      throw new IllegalArgumentException("Property must not be null: type");
-    }
-    this.type = type;
+    this.type = Preconditions.checkNotNull(type, "type");
   }
   
   /**
@@ -77,10 +74,7 @@ public class MessageParams {
    * The actual message.
    */
   public void setMessage(@NonNull final String message) {
-    if (message == null) {
-      throw new IllegalArgumentException("Property must not be null: message");
-    }
-    this.message = message;
+    this.message = Preconditions.checkNotNull(message, "message");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ParameterInformation.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ParameterInformation.java
@@ -86,22 +86,23 @@ public class ParameterInformation {
    * Its intended use case is to highlight the parameter label part in the {@link SignatureInformation#label}.
    */
   public void setLabel(@NonNull final Either<String, Tuple.Two<Integer, Integer>> label) {
-    if (label == null) {
-      throw new IllegalArgumentException("Property must not be null: label");
-    }
-    this.label = label;
+    this.label = Preconditions.checkNotNull(label, "label");
   }
   
   public void setLabel(final String label) {
     if (label == null) {
-      throw new IllegalArgumentException("Property must not be null: label");
+      Preconditions.checkNotNull(label, "label");
+      this.label = null;
+      return;
     }
     this.label = Either.forLeft(label);
   }
   
   public void setLabel(final Tuple.Two<Integer, Integer> label) {
     if (label == null) {
-      throw new IllegalArgumentException("Property must not be null: label");
+      Preconditions.checkNotNull(label, "label");
+      this.label = null;
+      return;
     }
     this.label = Either.forRight(label);
   }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/PrepareRenameResult.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/PrepareRenameResult.java
@@ -52,10 +52,7 @@ public class PrepareRenameResult {
    * The range of the string to rename
    */
   public void setRange(@NonNull final Range range) {
-    if (range == null) {
-      throw new IllegalArgumentException("Property must not be null: range");
-    }
-    this.range = range;
+    this.range = Preconditions.checkNotNull(range, "range");
   }
   
   /**
@@ -71,10 +68,7 @@ public class PrepareRenameResult {
    * A placeholder text of the string content to be renamed.
    */
   public void setPlaceholder(@NonNull final String placeholder) {
-    if (placeholder == null) {
-      throw new IllegalArgumentException("Property must not be null: placeholder");
-    }
-    this.placeholder = placeholder;
+    this.placeholder = Preconditions.checkNotNull(placeholder, "placeholder");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/PublishDiagnosticsParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/PublishDiagnosticsParams.java
@@ -59,10 +59,7 @@ public class PublishDiagnosticsParams {
    * The URI for which diagnostic information is reported.
    */
   public void setUri(@NonNull final String uri) {
-    if (uri == null) {
-      throw new IllegalArgumentException("Property must not be null: uri");
-    }
-    this.uri = uri;
+    this.uri = Preconditions.checkNotNull(uri, "uri");
   }
   
   /**
@@ -78,10 +75,7 @@ public class PublishDiagnosticsParams {
    * An array of diagnostic information items.
    */
   public void setDiagnostics(@NonNull final List<Diagnostic> diagnostics) {
-    if (diagnostics == null) {
-      throw new IllegalArgumentException("Property must not be null: diagnostics");
-    }
-    this.diagnostics = diagnostics;
+    this.diagnostics = Preconditions.checkNotNull(diagnostics, "diagnostics");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Range.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Range.java
@@ -55,10 +55,7 @@ public class Range {
    * The range's start position
    */
   public void setStart(@NonNull final Position start) {
-    if (start == null) {
-      throw new IllegalArgumentException("Property must not be null: start");
-    }
-    this.start = start;
+    this.start = Preconditions.checkNotNull(start, "start");
   }
   
   /**
@@ -74,10 +71,7 @@ public class Range {
    * The range's end position
    */
   public void setEnd(@NonNull final Position end) {
-    if (end == null) {
-      throw new IllegalArgumentException("Property must not be null: end");
-    }
-    this.end = end;
+    this.end = Preconditions.checkNotNull(end, "end");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ReferenceParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ReferenceParams.java
@@ -41,10 +41,7 @@ public class ReferenceParams extends TextDocumentPositionParams {
   }
   
   public void setContext(@NonNull final ReferenceContext context) {
-    if (context == null) {
-      throw new IllegalArgumentException("Property must not be null: context");
-    }
-    this.context = context;
+    this.context = Preconditions.checkNotNull(context, "context");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Registration.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Registration.java
@@ -70,10 +70,7 @@ public class Registration {
    * the request again.
    */
   public void setId(@NonNull final String id) {
-    if (id == null) {
-      throw new IllegalArgumentException("Property must not be null: id");
-    }
-    this.id = id;
+    this.id = Preconditions.checkNotNull(id, "id");
   }
   
   /**
@@ -89,10 +86,7 @@ public class Registration {
    * The method / capability to register for.
    */
   public void setMethod(@NonNull final String method) {
-    if (method == null) {
-      throw new IllegalArgumentException("Property must not be null: method");
-    }
-    this.method = method;
+    this.method = Preconditions.checkNotNull(method, "method");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/RegistrationParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/RegistrationParams.java
@@ -46,10 +46,7 @@ public class RegistrationParams {
   }
   
   public void setRegistrations(@NonNull final List<Registration> registrations) {
-    if (registrations == null) {
-      throw new IllegalArgumentException("Property must not be null: registrations");
-    }
-    this.registrations = registrations;
+    this.registrations = Preconditions.checkNotNull(registrations, "registrations");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/RenameFile.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/RenameFile.java
@@ -71,10 +71,7 @@ public class RenameFile extends ResourceOperation {
    * The old (existing) location.
    */
   public void setOldUri(@NonNull final String oldUri) {
-    if (oldUri == null) {
-      throw new IllegalArgumentException("Property must not be null: oldUri");
-    }
-    this.oldUri = oldUri;
+    this.oldUri = Preconditions.checkNotNull(oldUri, "oldUri");
   }
   
   /**
@@ -90,10 +87,7 @@ public class RenameFile extends ResourceOperation {
    * The new location.
    */
   public void setNewUri(@NonNull final String newUri) {
-    if (newUri == null) {
-      throw new IllegalArgumentException("Property must not be null: newUri");
-    }
-    this.newUri = newUri;
+    this.newUri = Preconditions.checkNotNull(newUri, "newUri");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/RenameParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/RenameParams.java
@@ -64,10 +64,7 @@ public class RenameParams {
    * The document in which to find the symbol.
    */
   public void setTextDocument(@NonNull final TextDocumentIdentifier textDocument) {
-    if (textDocument == null) {
-      throw new IllegalArgumentException("Property must not be null: textDocument");
-    }
-    this.textDocument = textDocument;
+    this.textDocument = Preconditions.checkNotNull(textDocument, "textDocument");
   }
   
   /**
@@ -83,10 +80,7 @@ public class RenameParams {
    * The position at which this request was send.
    */
   public void setPosition(@NonNull final Position position) {
-    if (position == null) {
-      throw new IllegalArgumentException("Property must not be null: position");
-    }
-    this.position = position;
+    this.position = Preconditions.checkNotNull(position, "position");
   }
   
   /**
@@ -104,10 +98,7 @@ public class RenameParams {
    * ResponseError with an appropriate message set.
    */
   public void setNewName(@NonNull final String newName) {
-    if (newName == null) {
-      throw new IllegalArgumentException("Property must not be null: newName");
-    }
-    this.newName = newName;
+    this.newName = Preconditions.checkNotNull(newName, "newName");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ResolveTypeHierarchyItemParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ResolveTypeHierarchyItemParams.java
@@ -64,10 +64,7 @@ public class ResolveTypeHierarchyItemParams {
    * The hierarchy item to resolve.
    */
   public void setItem(@NonNull final TypeHierarchyItem item) {
-    if (item == null) {
-      throw new IllegalArgumentException("Property must not be null: item");
-    }
-    this.item = item;
+    this.item = Preconditions.checkNotNull(item, "item");
   }
   
   /**
@@ -98,10 +95,7 @@ public class ResolveTypeHierarchyItemParams {
    * The direction of the type hierarchy resolution.
    */
   public void setDirection(@NonNull final TypeHierarchyDirection direction) {
-    if (direction == null) {
-      throw new IllegalArgumentException("Property must not be null: direction");
-    }
-    this.direction = direction;
+    this.direction = Preconditions.checkNotNull(direction, "direction");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ResourceOperation.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ResourceOperation.java
@@ -38,10 +38,7 @@ public abstract class ResourceOperation {
   }
   
   public void setKind(@NonNull final String kind) {
-    if (kind == null) {
-      throw new IllegalArgumentException("Property must not be null: kind");
-    }
-    this.kind = kind;
+    this.kind = Preconditions.checkNotNull(kind, "kind");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SelectionRange.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SelectionRange.java
@@ -57,10 +57,7 @@ public class SelectionRange {
    * The [range](#Range) of this selection range.
    */
   public void setRange(@NonNull final Range range) {
-    if (range == null) {
-      throw new IllegalArgumentException("Property must not be null: range");
-    }
-    this.range = range;
+    this.range = Preconditions.checkNotNull(range, "range");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SelectionRangeParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SelectionRangeParams.java
@@ -59,10 +59,7 @@ public class SelectionRangeParams {
    * The text document.
    */
   public void setTextDocument(@NonNull final TextDocumentIdentifier textDocument) {
-    if (textDocument == null) {
-      throw new IllegalArgumentException("Property must not be null: textDocument");
-    }
-    this.textDocument = textDocument;
+    this.textDocument = Preconditions.checkNotNull(textDocument, "textDocument");
   }
   
   /**
@@ -78,10 +75,7 @@ public class SelectionRangeParams {
    * The positions inside the text document.
    */
   public void setPositions(@NonNull final List<Position> positions) {
-    if (positions == null) {
-      throw new IllegalArgumentException("Property must not be null: positions");
-    }
-    this.positions = positions;
+    this.positions = Preconditions.checkNotNull(positions, "positions");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SemanticHighlightingParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SemanticHighlightingParams.java
@@ -59,10 +59,7 @@ public class SemanticHighlightingParams {
    * The text document that has to be decorated with the semantic highlighting information.
    */
   public void setTextDocument(@NonNull final VersionedTextDocumentIdentifier textDocument) {
-    if (textDocument == null) {
-      throw new IllegalArgumentException("Property must not be null: textDocument");
-    }
-    this.textDocument = textDocument;
+    this.textDocument = Preconditions.checkNotNull(textDocument, "textDocument");
   }
   
   /**
@@ -78,10 +75,7 @@ public class SemanticHighlightingParams {
    * An array of semantic highlighting information.
    */
   public void setLines(@NonNull final List<SemanticHighlightingInformation> lines) {
-    if (lines == null) {
-      throw new IllegalArgumentException("Property must not be null: lines");
-    }
-    this.lines = lines;
+    this.lines = Preconditions.checkNotNull(lines, "lines");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureHelp.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureHelp.java
@@ -77,10 +77,7 @@ public class SignatureHelp {
    * One or more signatures.
    */
   public void setSignatures(@NonNull final List<SignatureInformation> signatures) {
-    if (signatures == null) {
-      throw new IllegalArgumentException("Property must not be null: signatures");
-    }
-    this.signatures = signatures;
+    this.signatures = Preconditions.checkNotNull(signatures, "signatures");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureInformation.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureInformation.java
@@ -74,10 +74,7 @@ public class SignatureInformation {
    * The label of this signature. Will be shown in the UI.
    */
   public void setLabel(@NonNull final String label) {
-    if (label == null) {
-      throw new IllegalArgumentException("Property must not be null: label");
-    }
-    this.label = label;
+    this.label = Preconditions.checkNotNull(label, "label");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SymbolInformation.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SymbolInformation.java
@@ -92,10 +92,7 @@ public class SymbolInformation {
    * The name of this symbol.
    */
   public void setName(@NonNull final String name) {
-    if (name == null) {
-      throw new IllegalArgumentException("Property must not be null: name");
-    }
-    this.name = name;
+    this.name = Preconditions.checkNotNull(name, "name");
   }
   
   /**
@@ -111,10 +108,7 @@ public class SymbolInformation {
    * The kind of this symbol.
    */
   public void setKind(@NonNull final SymbolKind kind) {
-    if (kind == null) {
-      throw new IllegalArgumentException("Property must not be null: kind");
-    }
-    this.kind = kind;
+    this.kind = Preconditions.checkNotNull(kind, "kind");
   }
   
   /**
@@ -161,10 +155,7 @@ public class SymbolInformation {
    * the symbols.
    */
   public void setLocation(@NonNull final Location location) {
-    if (location == null) {
-      throw new IllegalArgumentException("Property must not be null: location");
-    }
-    this.location = location;
+    this.location = Preconditions.checkNotNull(location, "location");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentChangeRegistrationOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentChangeRegistrationOptions.java
@@ -52,10 +52,7 @@ public class TextDocumentChangeRegistrationOptions extends TextDocumentRegistrat
    * and TextDocumentSyncKind.Incremental.
    */
   public void setSyncKind(@NonNull final TextDocumentSyncKind syncKind) {
-    if (syncKind == null) {
-      throw new IllegalArgumentException("Property must not be null: syncKind");
-    }
-    this.syncKind = syncKind;
+    this.syncKind = Preconditions.checkNotNull(syncKind, "syncKind");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentContentChangeEvent.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentContentChangeEvent.java
@@ -95,10 +95,7 @@ public class TextDocumentContentChangeEvent {
    * The new text of the range/document.
    */
   public void setText(@NonNull final String text) {
-    if (text == null) {
-      throw new IllegalArgumentException("Property must not be null: text");
-    }
-    this.text = text;
+    this.text = Preconditions.checkNotNull(text, "text");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentEdit.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentEdit.java
@@ -59,10 +59,7 @@ public class TextDocumentEdit {
    * The text document to change.
    */
   public void setTextDocument(@NonNull final VersionedTextDocumentIdentifier textDocument) {
-    if (textDocument == null) {
-      throw new IllegalArgumentException("Property must not be null: textDocument");
-    }
-    this.textDocument = textDocument;
+    this.textDocument = Preconditions.checkNotNull(textDocument, "textDocument");
   }
   
   /**
@@ -78,10 +75,7 @@ public class TextDocumentEdit {
    * The edits to be applied
    */
   public void setEdits(@NonNull final List<TextEdit> edits) {
-    if (edits == null) {
-      throw new IllegalArgumentException("Property must not be null: edits");
-    }
-    this.edits = edits;
+    this.edits = Preconditions.checkNotNull(edits, "edits");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentIdentifier.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentIdentifier.java
@@ -47,10 +47,7 @@ public class TextDocumentIdentifier {
    * The text document's uri.
    */
   public void setUri(@NonNull final String uri) {
-    if (uri == null) {
-      throw new IllegalArgumentException("Property must not be null: uri");
-    }
-    this.uri = uri;
+    this.uri = Preconditions.checkNotNull(uri, "uri");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentItem.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentItem.java
@@ -67,10 +67,7 @@ public class TextDocumentItem {
    * The text document's uri.
    */
   public void setUri(@NonNull final String uri) {
-    if (uri == null) {
-      throw new IllegalArgumentException("Property must not be null: uri");
-    }
-    this.uri = uri;
+    this.uri = Preconditions.checkNotNull(uri, "uri");
   }
   
   /**
@@ -86,10 +83,7 @@ public class TextDocumentItem {
    * The text document's language identifier
    */
   public void setLanguageId(@NonNull final String languageId) {
-    if (languageId == null) {
-      throw new IllegalArgumentException("Property must not be null: languageId");
-    }
-    this.languageId = languageId;
+    this.languageId = Preconditions.checkNotNull(languageId, "languageId");
   }
   
   /**
@@ -120,10 +114,7 @@ public class TextDocumentItem {
    * The content of the opened  text document.
    */
   public void setText(@NonNull final String text) {
-    if (text == null) {
-      throw new IllegalArgumentException("Property must not be null: text");
-    }
-    this.text = text;
+    this.text = Preconditions.checkNotNull(text, "text");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentPositionParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentPositionParams.java
@@ -69,10 +69,7 @@ public class TextDocumentPositionParams {
    * The text document.
    */
   public void setTextDocument(@NonNull final TextDocumentIdentifier textDocument) {
-    if (textDocument == null) {
-      throw new IllegalArgumentException("Property must not be null: textDocument");
-    }
-    this.textDocument = textDocument;
+    this.textDocument = Preconditions.checkNotNull(textDocument, "textDocument");
   }
   
   /**
@@ -105,10 +102,7 @@ public class TextDocumentPositionParams {
    * The position inside the text document.
    */
   public void setPosition(@NonNull final Position position) {
-    if (position == null) {
-      throw new IllegalArgumentException("Property must not be null: position");
-    }
-    this.position = position;
+    this.position = Preconditions.checkNotNull(position, "position");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextEdit.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextEdit.java
@@ -55,10 +55,7 @@ public class TextEdit {
    * The range of the text document to be manipulated. To insert text into a document create a range where start === end.
    */
   public void setRange(@NonNull final Range range) {
-    if (range == null) {
-      throw new IllegalArgumentException("Property must not be null: range");
-    }
-    this.range = range;
+    this.range = Preconditions.checkNotNull(range, "range");
   }
   
   /**
@@ -74,10 +71,7 @@ public class TextEdit {
    * The string to be inserted. For delete operations use an empty string.
    */
   public void setNewText(@NonNull final String newText) {
-    if (newText == null) {
-      throw new IllegalArgumentException("Property must not be null: newText");
-    }
-    this.newText = newText;
+    this.newText = Preconditions.checkNotNull(newText, "newText");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TypeHierarchyItem.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TypeHierarchyItem.java
@@ -17,6 +17,7 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -103,10 +104,7 @@ public class TypeHierarchyItem {
    * The human readable name of the hierarchy item.
    */
   public void setName(@NonNull final String name) {
-    if (name == null) {
-      throw new IllegalArgumentException("Property must not be null: name");
-    }
-    this.name = name;
+    this.name = Preconditions.checkNotNull(name, "name");
   }
   
   /**
@@ -137,10 +135,7 @@ public class TypeHierarchyItem {
    * The kind of the hierarchy item. For instance, class or interface.
    */
   public void setKind(@NonNull final SymbolKind kind) {
-    if (kind == null) {
-      throw new IllegalArgumentException("Property must not be null: kind");
-    }
-    this.kind = kind;
+    this.kind = Preconditions.checkNotNull(kind, "kind");
   }
   
   /**
@@ -171,10 +166,7 @@ public class TypeHierarchyItem {
    * The URI of the text document where this type hierarchy item belongs to.
    */
   public void setUri(@NonNull final String uri) {
-    if (uri == null) {
-      throw new IllegalArgumentException("Property must not be null: uri");
-    }
-    this.uri = uri;
+    this.uri = Preconditions.checkNotNull(uri, "uri");
   }
   
   /**
@@ -198,10 +190,7 @@ public class TypeHierarchyItem {
    * @see TypeHierarchyItem#selectionRange
    */
   public void setRange(@NonNull final Range range) {
-    if (range == null) {
-      throw new IllegalArgumentException("Property must not be null: range");
-    }
-    this.range = range;
+    this.range = Preconditions.checkNotNull(range, "range");
   }
   
   /**
@@ -223,10 +212,7 @@ public class TypeHierarchyItem {
    * @see TypeHierarchyItem#range
    */
   public void setSelectionRange(@NonNull final Range selectionRange) {
-    if (selectionRange == null) {
-      throw new IllegalArgumentException("Property must not be null: selectionRange");
-    }
-    this.selectionRange = selectionRange;
+    this.selectionRange = Preconditions.checkNotNull(selectionRange, "selectionRange");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Unregistration.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Unregistration.java
@@ -57,10 +57,7 @@ public class Unregistration {
    * provided during the register request.
    */
   public void setId(@NonNull final String id) {
-    if (id == null) {
-      throw new IllegalArgumentException("Property must not be null: id");
-    }
-    this.id = id;
+    this.id = Preconditions.checkNotNull(id, "id");
   }
   
   /**
@@ -76,10 +73,7 @@ public class Unregistration {
    * The method / capability to unregister for.
    */
   public void setMethod(@NonNull final String method) {
-    if (method == null) {
-      throw new IllegalArgumentException("Property must not be null: method");
-    }
-    this.method = method;
+    this.method = Preconditions.checkNotNull(method, "method");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/UnregistrationParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/UnregistrationParams.java
@@ -43,10 +43,7 @@ public class UnregistrationParams {
   }
   
   public void setUnregisterations(@NonNull final List<Unregistration> unregisterations) {
-    if (unregisterations == null) {
-      throw new IllegalArgumentException("Property must not be null: unregisterations");
-    }
-    this.unregisterations = unregisterations;
+    this.unregisterations = Preconditions.checkNotNull(unregisterations, "unregisterations");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/WillSaveTextDocumentParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/WillSaveTextDocumentParams.java
@@ -53,10 +53,7 @@ public class WillSaveTextDocumentParams {
    * The document that will be saved.
    */
   public void setTextDocument(@NonNull final TextDocumentIdentifier textDocument) {
-    if (textDocument == null) {
-      throw new IllegalArgumentException("Property must not be null: textDocument");
-    }
-    this.textDocument = textDocument;
+    this.textDocument = Preconditions.checkNotNull(textDocument, "textDocument");
   }
   
   /**
@@ -72,10 +69,7 @@ public class WillSaveTextDocumentParams {
    * A reason why a text document is saved.
    */
   public void setReason(@NonNull final TextDocumentSaveReason reason) {
-    if (reason == null) {
-      throw new IllegalArgumentException("Property must not be null: reason");
-    }
-    this.reason = reason;
+    this.reason = Preconditions.checkNotNull(reason, "reason");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/WorkspaceFolder.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/WorkspaceFolder.java
@@ -60,10 +60,7 @@ public class WorkspaceFolder {
    * The associated URI for this workspace folder.
    */
   public void setUri(@NonNull final String uri) {
-    if (uri == null) {
-      throw new IllegalArgumentException("Property must not be null: uri");
-    }
-    this.uri = uri;
+    this.uri = Preconditions.checkNotNull(uri, "uri");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/WorkspaceFoldersChangeEvent.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/WorkspaceFoldersChangeEvent.java
@@ -57,10 +57,7 @@ public class WorkspaceFoldersChangeEvent {
    * The array of added workspace folders
    */
   public void setAdded(@NonNull final List<WorkspaceFolder> added) {
-    if (added == null) {
-      throw new IllegalArgumentException("Property must not be null: added");
-    }
-    this.added = added;
+    this.added = Preconditions.checkNotNull(added, "added");
   }
   
   /**
@@ -76,10 +73,7 @@ public class WorkspaceFoldersChangeEvent {
    * The array of the removed workspace folders
    */
   public void setRemoved(@NonNull final List<WorkspaceFolder> removed) {
-    if (removed == null) {
-      throw new IllegalArgumentException("Property must not be null: removed");
-    }
-    this.removed = removed;
+    this.removed = Preconditions.checkNotNull(removed, "removed");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/WorkspaceSymbolParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/WorkspaceSymbolParams.java
@@ -47,10 +47,7 @@ public class WorkspaceSymbolParams {
    * A non-empty query string
    */
   public void setQuery(@NonNull final String query) {
-    if (query == null) {
-      throw new IllegalArgumentException("Property must not be null: query");
-    }
-    this.query = query;
+    this.query = Preconditions.checkNotNull(query, "query");
   }
   
   @Override


### PR DESCRIPTION
Follow-up of #305. This allows to globally disable the null-checks in applications where they cause more trouble than they actually help. See the discussion:
https://github.com/eclipse/xtext-core/pull/1060/files/853bfb6536c406f26ca53f17eef9189e649beb2e#pullrequestreview-210108691

@kittaakos @cdietrich would this change improve the situation?