### PR TITLE
#344: Make the build and contribution guides easier to find.

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -2,7 +2,7 @@
 
 The project is build with Gradle and written in Java 8.
 
-To start working on it simply clone and run `./gradlew build`.
+To start working on it simply clone and run `./gradlew build`. See the section [below](#Eclipse) on building and editing with Eclipse for step-by-step instructions.
 
 # ECA
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Also, you can get them directly from the TypeFox Jenkins server:
  * LSP4J 0.4.x &rarr; DAP 1.25.0
  * LSP4J before 0.4.x did not support DAP
 
+### Building and Contributing
+
+To build and contribute to LSP4J please consult the [Contribution Guide](https://github.com/eclipse/lsp4j/blob/master/Contributing.md).
+
 ### Licenses
 
 LSP4J is published under two licenses:


### PR DESCRIPTION
I have also added a sentance to https://projects.eclipse.org/projects/technology.lsp4j/developer:

"The lsp4j source code is hosted on GitHub. Please see the Readme and Contribution guide located in the repo." (readme and contribution are links)