### PR TITLE
Add missing restart flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Also, you can get them directly from the TypeFox Jenkins server:
 
 ### Supported DAP Versions
 
+ * LSP4J 0.8.x &rarr; DAP 1.32.0
  * LSP4J 0.5.x &rarr; DAP 1.31.0
  * LSP4J 0.4.x &rarr; DAP 1.25.0
  * LSP4J before 0.4.x did not support DAP

--- a/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/DebugProtocol.xtend
+++ b/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/DebugProtocol.xtend
@@ -26,7 +26,7 @@ class DebugProtcol {
 	/**
 	 * Version of Debug Protocol
 	 */
-	public static final String SCHEMA_VERSION = "1.31.0";
+	public static final String SCHEMA_VERSION = "1.32.0";
 }
 
 /**

--- a/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/DebugProtocol.xtend
+++ b/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/DebugProtocol.xtend
@@ -618,6 +618,10 @@ class DisconnectArguments {
  */
 @JsonRpcData
 class TerminateArguments {
+  /**
+   * A value of true indicates that this 'terminate' request is part of a restart sequence.
+   */
+   Boolean restart;
 }
 
 /**

--- a/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/DebugProtocol.xtend
+++ b/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/DebugProtocol.xtend
@@ -595,6 +595,11 @@ class RestartArguments {
  */
 @JsonRpcData
 class DisconnectArguments {
+    /**
+     * A value of true indicates that this 'disconnect' request is part of a restart sequence.
+     */
+    Boolean restart;
+
 	/**
 	 * Indicates whether the debuggee should be terminated when the debugger is disconnected.
 	 * <p>

--- a/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/services/IDebugProtocolClient.java
+++ b/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/services/IDebugProtocolClient.java
@@ -34,7 +34,7 @@ public interface IDebugProtocolClient {
 	/**
 	 * Version of Debug Protocol
 	 */
-	public static final String SCHEMA_VERSION = "1.31.0";
+	public static final String SCHEMA_VERSION = "1.32.0";
 
 	/**
 	 * This event indicates that the debug adapter is ready to accept configuration

--- a/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/services/IDebugProtocolServer.java
+++ b/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/services/IDebugProtocolServer.java
@@ -77,7 +77,7 @@ public interface IDebugProtocolServer {
 	/**
 	 * Version of Debug Protocol
 	 */
-	public static final String SCHEMA_VERSION = "1.31.0";
+	public static final String SCHEMA_VERSION = "1.32.0";
 
 	/**
 	 * This request is sent from the debug adapter to the client to run a command in

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/DebugProtcol.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/DebugProtcol.java
@@ -20,5 +20,5 @@ public class DebugProtcol {
   /**
    * Version of Debug Protocol
    */
-  public static final String SCHEMA_VERSION = "1.31.0";
+  public static final String SCHEMA_VERSION = "1.32.0";
 }

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/DisconnectArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/DisconnectArguments.java
@@ -20,6 +20,11 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 @SuppressWarnings("all")
 public class DisconnectArguments {
   /**
+   * A value of true indicates that this 'disconnect' request is part of a restart sequence.
+   */
+  private Boolean restart;
+  
+  /**
    * Indicates whether the debuggee should be terminated when the debugger is disconnected.
    * <p>
    * If unspecified, the debug adapter is free to do whatever it thinks is best.
@@ -30,6 +35,21 @@ public class DisconnectArguments {
    * This is an optional property.
    */
   private Boolean terminateDebuggee;
+  
+  /**
+   * A value of true indicates that this 'disconnect' request is part of a restart sequence.
+   */
+  @Pure
+  public Boolean getRestart() {
+    return this.restart;
+  }
+  
+  /**
+   * A value of true indicates that this 'disconnect' request is part of a restart sequence.
+   */
+  public void setRestart(final Boolean restart) {
+    this.restart = restart;
+  }
   
   /**
    * Indicates whether the debuggee should be terminated when the debugger is disconnected.
@@ -64,6 +84,7 @@ public class DisconnectArguments {
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
+    b.add("restart", this.restart);
     b.add("terminateDebuggee", this.terminateDebuggee);
     return b.toString();
   }
@@ -78,6 +99,11 @@ public class DisconnectArguments {
     if (getClass() != obj.getClass())
       return false;
     DisconnectArguments other = (DisconnectArguments) obj;
+    if (this.restart == null) {
+      if (other.restart != null)
+        return false;
+    } else if (!this.restart.equals(other.restart))
+      return false;
     if (this.terminateDebuggee == null) {
       if (other.terminateDebuggee != null)
         return false;
@@ -89,6 +115,9 @@ public class DisconnectArguments {
   @Override
   @Pure
   public int hashCode() {
-    return 31 * 1 + ((this.terminateDebuggee== null) ? 0 : this.terminateDebuggee.hashCode());
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.restart== null) ? 0 : this.restart.hashCode());
+    return prime * result + ((this.terminateDebuggee== null) ? 0 : this.terminateDebuggee.hashCode());
   }
 }

--- a/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/TerminateArguments.java
+++ b/org.eclipse.lsp4j.debug/src/main/xtend-gen/org/eclipse/lsp4j/debug/TerminateArguments.java
@@ -19,10 +19,31 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
  */
 @SuppressWarnings("all")
 public class TerminateArguments {
+  /**
+   * A value of true indicates that this 'terminate' request is part of a restart sequence.
+   */
+  private Boolean restart;
+  
+  /**
+   * A value of true indicates that this 'terminate' request is part of a restart sequence.
+   */
+  @Pure
+  public Boolean getRestart() {
+    return this.restart;
+  }
+  
+  /**
+   * A value of true indicates that this 'terminate' request is part of a restart sequence.
+   */
+  public void setRestart(final Boolean restart) {
+    this.restart = restart;
+  }
+  
   @Override
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
+    b.add("restart", this.restart);
     return b.toString();
   }
   
@@ -35,12 +56,18 @@ public class TerminateArguments {
       return false;
     if (getClass() != obj.getClass())
       return false;
+    TerminateArguments other = (TerminateArguments) obj;
+    if (this.restart == null) {
+      if (other.restart != null)
+        return false;
+    } else if (!this.restart.equals(other.restart))
+      return false;
     return true;
   }
   
   @Override
   @Pure
   public int hashCode() {
-    return 1;
+    return 31 * 1 + ((this.restart== null) ? 0 : this.restart.hashCode());
   }
 }


### PR DESCRIPTION
This adds `restart` flags to both [DisconnectArguments](https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Disconnect) and [TerminateArguments](https://microsoft.github.io/debug-adapter-protocol/specification#Requests_Terminate).