### PR TITLE
Added partial message support for WebSocketMessageHandler

### DIFF
--- a/org.eclipse.lsp4j.websocket/src/test/java/org/eclipse/lsp4j/websocket/test/MockConnectionTest.java
+++ b/org.eclipse.lsp4j.websocket/src/test/java/org/eclipse/lsp4j/websocket/test/MockConnectionTest.java
@@ -52,6 +52,22 @@ public class MockConnectionTest {
 	}
 	
 	@Test
+	public void testChunkedClientRequest() throws Exception {
+		StringBuilder messageBuilder = new StringBuilder();
+		Random random = new Random(1);
+		for (int i = 0; i < 3 * MockSession.MAX_CHUNK_SIZE; i++) {
+			messageBuilder.append((char) ('a' + random.nextInt('z' - 'a' + 1)));
+		}
+		String message = messageBuilder.toString();
+		String expectedResult = messageBuilder.append("bar").toString();
+	
+		CompletableFuture<String> future = client.server.request(message);
+		String result = future.get(TIMEOUT, TimeUnit.MILLISECONDS);
+
+		Assert.assertEquals(expectedResult, result);
+	}
+
+	@Test
 	public void testNotifications() throws Exception {
 		server.client.notify("12");
 		await(() -> client.result.length() == 2);


### PR DESCRIPTION
I'm using your great `WebSocketLauncherBuilder` to serve my language server and some additonal endpoints. On large payloads (> 8kB) I'm running into trouble:

> The decoded text message was too big for the output buffer and the endpoint does not support partial messages

To fix that, I changed the class `WebSocketMessageHandler` to support partial messages.

If your not happy with that, it would be great, if you provide some other 'official' way to support larger payloads. 

Thank you.

---

**Note**: The `dispatch` method of the `MockSession` makes things very smart since handlers implementing `MessageHandler.Whole` finally getting active - even on fragmented messages. In reason of that, the unit test I added, would not break using the old `MessageHandler.Whole` handler. It seems, that some implementations like Tomcat are less smart. They will only call `MessageHandler.Partial` handlers - and never `MessageHandler.Whole` handlers - for fragmented messages. See [here](https://github.com/apache/tomcat/blob/master/java/org/apache/tomcat/websocket/WsFrameBase.java), specialy the places where `"wsFrame.textMessageTooBig"` - the key to get the error message above - is used. 
 