### PR TITLE
Update diagnostics tag for lsp4j

### DIFF
--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -822,7 +822,7 @@ class PublishDiagnosticsCapabilities {
 	 *
 	 * Since 3.15
 	 */
-	Boolean tagSupport
+	DiagnosticsTagSupport tagSupport
 
 	new() {
 	}
@@ -831,9 +831,24 @@ class PublishDiagnosticsCapabilities {
 		this.relatedInformation = relatedInformation
 	}
 	
-	new(Boolean relatedInformation, Boolean tagSupport) {
+	new(Boolean relatedInformation, DiagnosticsTagSupport tagSupport) {
 		this.relatedInformation = relatedInformation
 		this.tagSupport = tagSupport
+	}
+}
+
+@JsonRpcData
+class DiagnosticsTagSupport {
+	/**
+	* The tags supported by the client.
+	*/
+	List<DiagnosticTag> valueSet
+
+	new() {
+	}
+
+	new(List<DiagnosticTag> valueSet) {
+		this.valueSet = valueSet
 	}
 }
 
@@ -2807,6 +2822,13 @@ class PublishDiagnosticsParams {
 	 */
 	@NonNull
 	List<Diagnostic> diagnostics
+
+	/**
+	 * Optional the version number of the document the diagnostics are published for.
+	 *
+	 * @since 3.15.0
+	 */
+	int version
 
 	new() {
 		this.diagnostics = new ArrayList

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DiagnosticsTagSupport.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DiagnosticsTagSupport.java
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) 2016-2018 TypeFox and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.lsp4j;
+
+import java.util.List;
+import org.eclipse.lsp4j.DiagnosticTag;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+@SuppressWarnings("all")
+public class DiagnosticsTagSupport {
+  /**
+   * The tags supported by the client.
+   */
+  private List<DiagnosticTag> valueSet;
+  
+  public DiagnosticsTagSupport() {
+  }
+  
+  public DiagnosticsTagSupport(final List<DiagnosticTag> valueSet) {
+    this.valueSet = valueSet;
+  }
+  
+  /**
+   * The tags supported by the client.
+   */
+  @Pure
+  public List<DiagnosticTag> getValueSet() {
+    return this.valueSet;
+  }
+  
+  /**
+   * The tags supported by the client.
+   */
+  public void setValueSet(final List<DiagnosticTag> valueSet) {
+    this.valueSet = valueSet;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("valueSet", this.valueSet);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    DiagnosticsTagSupport other = (DiagnosticsTagSupport) obj;
+    if (this.valueSet == null) {
+      if (other.valueSet != null)
+        return false;
+    } else if (!this.valueSet.equals(other.valueSet))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.valueSet== null) ? 0 : this.valueSet.hashCode());
+  }
+}

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/PublishDiagnosticsCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/PublishDiagnosticsCapabilities.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j;
 
+import org.eclipse.lsp4j.DiagnosticsTagSupport;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -29,7 +30,7 @@ public class PublishDiagnosticsCapabilities {
    * 
    * Since 3.15
    */
-  private Boolean tagSupport;
+  private DiagnosticsTagSupport tagSupport;
   
   public PublishDiagnosticsCapabilities() {
   }
@@ -38,7 +39,7 @@ public class PublishDiagnosticsCapabilities {
     this.relatedInformation = relatedInformation;
   }
   
-  public PublishDiagnosticsCapabilities(final Boolean relatedInformation, final Boolean tagSupport) {
+  public PublishDiagnosticsCapabilities(final Boolean relatedInformation, final DiagnosticsTagSupport tagSupport) {
     this.relatedInformation = relatedInformation;
     this.tagSupport = tagSupport;
   }
@@ -64,7 +65,7 @@ public class PublishDiagnosticsCapabilities {
    * Since 3.15
    */
   @Pure
-  public Boolean getTagSupport() {
+  public DiagnosticsTagSupport getTagSupport() {
     return this.tagSupport;
   }
   
@@ -73,7 +74,7 @@ public class PublishDiagnosticsCapabilities {
    * 
    * Since 3.15
    */
-  public void setTagSupport(final Boolean tagSupport) {
+  public void setTagSupport(final DiagnosticsTagSupport tagSupport) {
     this.tagSupport = tagSupport;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/PublishDiagnosticsParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/PublishDiagnosticsParams.java
@@ -36,6 +36,13 @@ public class PublishDiagnosticsParams {
   @NonNull
   private List<Diagnostic> diagnostics;
   
+  /**
+   * Optional the version number of the document the diagnostics are published for.
+   * 
+   * @since 3.15.0
+   */
+  private int version;
+  
   public PublishDiagnosticsParams() {
     ArrayList<Diagnostic> _arrayList = new ArrayList<Diagnostic>();
     this.diagnostics = _arrayList;
@@ -78,12 +85,32 @@ public class PublishDiagnosticsParams {
     this.diagnostics = Preconditions.checkNotNull(diagnostics, "diagnostics");
   }
   
+  /**
+   * Optional the version number of the document the diagnostics are published for.
+   * 
+   * @since 3.15.0
+   */
+  @Pure
+  public int getVersion() {
+    return this.version;
+  }
+  
+  /**
+   * Optional the version number of the document the diagnostics are published for.
+   * 
+   * @since 3.15.0
+   */
+  public void setVersion(final int version) {
+    this.version = version;
+  }
+  
   @Override
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("uri", this.uri);
     b.add("diagnostics", this.diagnostics);
+    b.add("version", this.version);
     return b.toString();
   }
   
@@ -107,6 +134,8 @@ public class PublishDiagnosticsParams {
         return false;
     } else if (!this.diagnostics.equals(other.diagnostics))
       return false;
+    if (other.version != this.version)
+      return false;
     return true;
   }
   
@@ -116,6 +145,7 @@ public class PublishDiagnosticsParams {
     final int prime = 31;
     int result = 1;
     result = prime * result + ((this.uri== null) ? 0 : this.uri.hashCode());
-    return prime * result + ((this.diagnostics== null) ? 0 : this.diagnostics.hashCode());
+    result = prime * result + ((this.diagnostics== null) ? 0 : this.diagnostics.hashCode());
+    return prime * result + this.version;
   }
 }

--- a/org.eclipse.lsp4j/src/test/java/org/eclipse/lsp4j/test/services/JsonParseTest.xtend
+++ b/org.eclipse.lsp4j/src/test/java/org/eclipse/lsp4j/test/services/JsonParseTest.xtend
@@ -260,7 +260,8 @@ class JsonParseTest {
 							},
 							"severity": 1
 						}
-					]
+					],
+					version: 1
 				}
 			}
 		'''.assertParse(new NotificationMessage => [
@@ -278,6 +279,7 @@ class JsonParseTest {
 						message = "Couldn't resolve reference to State 'bar'."
 					])
 				]
+				version = 1
 			]
 		])
 	}

--- a/org.eclipse.lsp4j/src/test/java/org/eclipse/lsp4j/test/services/JsonSerializeTest.xtend
+++ b/org.eclipse.lsp4j/src/test/java/org/eclipse/lsp4j/test/services/JsonSerializeTest.xtend
@@ -434,6 +434,7 @@ class JsonSerializeTest {
 						message = "Couldn't resolve reference to State 'bar'."
 					])
 				]
+				version = 1
 			]
 		]
 		message.assertSerialize('''
@@ -457,7 +458,8 @@ class JsonSerializeTest {
 			        "severity": 1,
 			        "message": "Couldn\u0027t resolve reference to State \u0027bar\u0027."
 			      }
-			    ]
+			    ],
+			    "version": 1
 			  }
 			}
 		''')


### PR DESCRIPTION
In the latest LSP definition, the client will pass the supported diagnostics tags array in the PublishDiagnosticsClientCapabilities , See https://github.com/microsoft/vscode-languageserver-node/blob/master/protocol/src/protocol.ts#L1382

```typescript
/**
 * The publish diagnostic client capabilities.
 */
export interface PublishDiagnosticsClientCapabilities {
	/**
	 * Whether the clients accepts diagnostics with related information.
	 */
	relatedInformation?: boolean;

	/**
	 * Client supports the tag property to provide meta data about a diagnostic.
	 * Clients supporting tags have to handle unknown tags gracefully.
	 *
	 * @since 3.15.0
	 */
	tagSupport?: {
		/**
		 * The tags supported by the client.
		 */
		valueSet: DiagnosticTag[];
	};
}
```


Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>