### PR TITLE
The spec allows the Diagnostic code to be a string or a number.

### DIFF
--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -1557,7 +1557,7 @@ class Diagnostic {
 	/**
 	 * The diagnostic's code. Can be omitted.
 	 */
-	String code
+	Either<String, Number> code
 
 	/**
 	 * A human-readable string describing the source of this diagnostic, e.g. 'typescript' or 'super lint'.


### PR DESCRIPTION
But currently, the Diagnostic.getCode() only returns a String. This may show up when the Diagnostic is sent back to the server via codeActions, where the server may refuse to work on Diagnostic which has  a String-based code, while the server only sent a number-based code.

This is an attempt to allow that in the code as well, but making Diagnostic.getCode() return Either<String, Number> instead of just String. This is unfortunately an incompatible change, but unclear to me if there's a way around that. Also, not completely clear if "Number" should be used, or "Integer" (or "Long"), but "Number" seems safer for cases where the value would not fit into int/long.
