### PR TITLE
Updated significant portion for LSP 3.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
  * Implemented DAP version 1.36.0
  * Implemented DAP version 1.37.0 (except CancelRequest)
+ * Implemented LSP version 3.15.0 (except Progress)
 
 Fixed issues: https://github.com/eclipse/lsp4j/milestone/15?closed=1
 
@@ -25,6 +26,10 @@ Breaking API changes:
 
  * The DebugProtocol's `EvaluateResponse`'s field `memoryReference` was previously incorrectly
    declared as `Long`, it is now correctly declared as `String`
+
+ * `CodeActionKindCapabilities.valueSet` marked with `@NonNull`
+
+ * Parameter of `textDocument/signatureHelp` changed from `TextDocumentPositionParams position` to `SignatureHelpParams params`
 
 ### v0.8.1 (Sep. 2019)
 

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/CompletionItemTag.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/CompletionItemTag.java
@@ -1,6 +1,6 @@
 /******************************************************************************
- * Copyright (c) 2019 Microsoft.
- *
+ * Copyright (c) 2016-2018 TypeFox and others.
+ * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
  * http://www.eclipse.org/legal/epl-2.0,
@@ -13,30 +13,21 @@
 package org.eclipse.lsp4j;
 
 /**
- * The diagnostic tags.
+ * Completion item tags are extra annotations that tweak the rendering of a completion
+ * item.
  * 
  * Since 3.15.0
  */
-public enum DiagnosticTag {
+public enum CompletionItemTag {
 
     /**
-     * Unused or unnecessary code.
-     *
-     * Clients are allowed to render diagnostics with this tag faded out instead of having
-     * an error squiggle.
+     * Render a completion as obsolete, usually using a strike-out.
      */
-    Unnecessary(1),
-
-    /**
-     * Deprecated or obsolete code.
-     *
-     * Clients are allowed to rendered diagnostics with this tag strike through.
-     */
-    Deprecated(2);
+    Deprecated(1);
 
     private final int value;
 
-    DiagnosticTag(int value) {
+    CompletionItemTag(int value) {
         this.value = value;
     }
 
@@ -44,8 +35,8 @@ public enum DiagnosticTag {
         return value;
     }
 
-    public static DiagnosticTag forValue(int value) {
-        DiagnosticTag[] allValues = DiagnosticTag.values();
+    public static CompletionItemTag forValue(int value) {
+        CompletionItemTag[] allValues = CompletionItemTag.values();
         if (value < 1 || value > allValues.length)
             throw new IllegalArgumentException("Illegal enum value: " + value);
         return allValues[value - 1];

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -281,11 +281,38 @@ class CompletionItemCapabilities {
 	 */
 	Boolean preselectSupport
 
+	/**
+	 * Client supports the tag property on a completion item. Clients supporting
+	 * tags have to handle unknown tags gracefully. Clients especially need to
+	 * preserve unknown tags when sending a completion item back to the server in
+	 * a resolve call.
+	 * 
+	 * Since 3.15.0
+	 */
+	CompletionItemTagSupportCapabilities tagSupport
+
 	new() {
 	}
 
 	new(Boolean snippetSupport) {
 		this.snippetSupport = snippetSupport
+	}
+}
+
+@JsonRpcData
+class CompletionItemTagSupportCapabilities {
+	/**
+	* The tags supported by the client.
+	*/
+	@NonNull
+	List<CompletionItemTag> valueSet
+
+	new() {
+		this.valueSet = new ArrayList
+	}
+
+	new(@NonNull List<CompletionItemTag> valueSet) {
+		this.valueSet = Preconditions.checkNotNull(valueSet, 'valueSet')
 	}
 }
 
@@ -433,6 +460,16 @@ class SignatureHelpCapabilities extends DynamicRegistrationCapabilities {
 	 * specific properties.
 	 */
 	SignatureInformationCapabilities signatureInformation
+
+	/**
+	 * The client supports to send additional context information for a
+	 * `textDocument/signatureHelp` request. A client that opts into
+	 * contextSupport will also support the `retriggerCharacters` on
+	 * `SignatureHelpOptions`.
+	 * 
+	 * Since 3.15.0
+	 */
+	Boolean contextSupport
 
 	new() {
 	}
@@ -689,13 +726,15 @@ class CodeActionKindCapabilities {
 	 * 
 	 * See {@link CodeActionKind} for allowed values.
 	 */
+	@NonNull
 	List<String> valueSet
 
 	new() {
+		this.valueSet = new ArrayList
 	}
 
-	new(List<String> valueSet) {
-		this.valueSet = valueSet
+	new(@NonNull List<String> valueSet) {
+		this.valueSet = Preconditions.checkNotNull(valueSet, 'valueSet')
 	}
 }
 
@@ -727,6 +766,13 @@ class CodeActionCapabilities extends DynamicRegistrationCapabilities {
 	 */
 	CodeActionLiteralSupportCapabilities codeActionLiteralSupport
 
+	/**
+	 * Whether code action supports the `isPreferred` property.
+	 * 
+	 * Since 3.15.0
+	 */
+	Boolean isPreferredSupport
+
 	new() {
 	}
 
@@ -737,6 +783,11 @@ class CodeActionCapabilities extends DynamicRegistrationCapabilities {
 	new(CodeActionLiteralSupportCapabilities codeActionLiteralSupport, Boolean dynamicRegistration) {
 		super(dynamicRegistration)
 		this.codeActionLiteralSupport = codeActionLiteralSupport
+	}
+
+	new(CodeActionLiteralSupportCapabilities codeActionLiteralSupport, Boolean dynamicRegistration, Boolean isPreferredSupport) {
+		this(codeActionLiteralSupport, dynamicRegistration)
+		this.isPreferredSupport = isPreferredSupport
 	}
 }
 
@@ -758,11 +809,24 @@ class CodeLensCapabilities extends DynamicRegistrationCapabilities {
  */
 @JsonRpcData
 class DocumentLinkCapabilities extends DynamicRegistrationCapabilities {
+
+	/**
+	 * Whether the client supports the `tooltip` property on `DocumentLink`.
+	 * 
+	 * Since 3.15.0
+	 */
+	Boolean tooltipSupport
+
 	new() {
 	}
 
 	new(Boolean dynamicRegistration) {
 		super(dynamicRegistration)
+	}
+
+	new(Boolean dynamicRegistration, Boolean tooltipSupport) {
+		super(dynamicRegistration)
+		this.tooltipSupport = tooltipSupport
 	}
 }
 
@@ -819,10 +883,19 @@ class PublishDiagnosticsCapabilities {
 
 	/**
 	 * Client supports the tag property to provide meta data about a diagnostic.
-	 *
+	 * Clients supporting tags have to handle unknown tags gracefully.
+	 * 
 	 * Since 3.15
 	 */
 	DiagnosticsTagSupport tagSupport
+
+	/**
+	 * Whether the client interprets the version property of the
+	 * `textDocument/publishDiagnostics` notification's parameter.
+	 * 
+	 * Since 3.15.0
+	 */
+	Boolean versionSupport
 
 	new() {
 	}
@@ -832,8 +905,13 @@ class PublishDiagnosticsCapabilities {
 	}
 	
 	new(Boolean relatedInformation, DiagnosticsTagSupport tagSupport) {
-		this.relatedInformation = relatedInformation
+		this(relatedInformation)
 		this.tagSupport = tagSupport
+	}
+
+	new(Boolean relatedInformation, DiagnosticsTagSupport tagSupport, Boolean versionSupport) {
+		this(relatedInformation, tagSupport)
+		this.versionSupport = versionSupport
 	}
 }
 
@@ -842,13 +920,15 @@ class DiagnosticsTagSupport {
 	/**
 	* The tags supported by the client.
 	*/
+	@NonNull
 	List<DiagnosticTag> valueSet
 
 	new() {
+		this.valueSet = new ArrayList
 	}
 
-	new(List<DiagnosticTag> valueSet) {
-		this.valueSet = valueSet
+	new(@NonNull List<DiagnosticTag> valueSet) {
+		this.valueSet = Preconditions.checkNotNull(valueSet, 'valueSet')
 	}
 }
 
@@ -937,7 +1017,6 @@ class CallHierarchyCapabilities extends DynamicRegistrationCapabilities {
 /**
  * Capabilities specific to `textDocument/selectionRange` requests
  */
-@Beta
 @JsonRpcData
 class SelectionRangeCapabilities extends DynamicRegistrationCapabilities {
 	
@@ -1090,7 +1169,6 @@ class TextDocumentClientCapabilities {
 	/**
 	 * Capabilities specific to `textDocument/selectionRange` requests
 	 */
-	@Beta
 	SelectionRangeCapabilities  selectionRange
 }
 
@@ -1162,6 +1240,17 @@ class CodeAction {
 	List<Diagnostic> diagnostics
 
 	/**
+	 * Marks this as a preferred action. Preferred actions are used by the `auto fix` command and can be targeted
+	 * by keybindings.
+	 * 
+	 * A quick fix should be marked preferred if it properly addresses the underlying error.
+	 * A refactoring should be marked preferred if it is the most reasonable choice of actions to take.
+	 * 
+	 * Since 3.15.0
+	 */
+	Boolean isPreferred
+
+	/**
 	 * The workspace edit this code action performs.
 	 */
 	WorkspaceEdit edit
@@ -1218,8 +1307,7 @@ class CodeActionContext {
 
 /**
  * The code action request is sent from the client to the server to compute commands for a given text document and range.
- * The request is triggered when the user moves the cursor into an problem marker in the editor or presses the lightbulb
- * associated with a marker.
+ * These commands are typically code fixes to either fix problems or to beautify/refactor code.
  */
 @JsonRpcData
 class CodeActionParams {
@@ -1406,6 +1494,13 @@ class CompletionItem {
 	CompletionItemKind kind
 
 	/**
+	 * Tags for this completion item.
+	 * 
+	 * Since 3.15.0
+	 */
+	List<CompletionItemTag> tags
+
+	/**
 	 * A human-readable string with additional information about this item, like type or symbol information.
 	 */
 	String detail
@@ -1430,7 +1525,7 @@ class CompletionItem {
 	Boolean preselect
 
 	/**
-	 * A string that shoud be used when comparing this item with other items. When `falsy` the label is used.
+	 * A string that should be used when comparing this item with other items. When `falsy` the label is used.
 	 */
 	String sortText
 
@@ -1829,7 +1924,7 @@ class DidOpenTextDocumentParams {
 }
 
 /**
- * The document save notification is sent from the client to the server when the document for saved in the clinet.
+ * The document save notification is sent from the client to the server when the document was saved in the client.
  */
 @JsonRpcData
 class DidSaveTextDocumentParams {
@@ -1955,6 +2050,17 @@ class DocumentLink {
 	String target
 
 	/**
+	 * The tooltip text when you hover over this link.
+	 * 
+	 * If a tooltip is provided, is will be displayed in a string that includes instructions on how to
+	 * trigger the link, such as `{0} (ctrl + click)`. The specific instructions vary depending on OS,
+	 * user settings, and localization.
+	 * 
+	 * Since 3.15.0
+	 */
+	String tooltip
+
+	/**
 	 * A data entry field that is preserved on a document link between a
 	 * DocumentLinkRequest and a DocumentLinkResolveRequest.
 	 */
@@ -1976,6 +2082,11 @@ class DocumentLink {
 	new(@NonNull Range range, String target, Object data) {
 		this(range, target)
 		this.data = data
+	}
+
+	new(@NonNull Range range, String target, Object data, String tooltip) {
+		this(range, target, data)
+		this.tooltip = tooltip
 	}
 }
 
@@ -2305,6 +2416,9 @@ class FormattingOptions extends LinkedHashMap<String, Either3<String, Number, Bo
 
 	static val TAB_SIZE = 'tabSize'
 	static val INSERT_SPACES = 'insertSpaces'
+	static val TRIM_TRAILING_WHITESPACE = 'trimTrailingWhitespace'
+	static val INSERT_FINAL_NEWLINE = 'insertFinalNewline'
+	static val TRIM_FINAL_NEWLINES = 'trimFinalNewlines'
 
 	new() {
 	}
@@ -2375,6 +2489,57 @@ class FormattingOptions extends LinkedHashMap<String, Either3<String, Number, Bo
 
 	def void setInsertSpaces(boolean insertSpaces) {
 		putBoolean(INSERT_SPACES, insertSpaces)
+	}
+
+	/**
+	 * Trim trailing whitespace on a line.
+	 * 
+	 * Since 3.15.0
+	 */
+	def boolean isTrimTrailingWhitespace() {
+		val value = getBoolean(TRIM_TRAILING_WHITESPACE)
+		if (value !== null)
+			return value
+		else
+			return false
+	}
+
+	def void setTrimTrailingWhitespace(boolean trimTrailingWhitespace) {
+		putBoolean(TRIM_TRAILING_WHITESPACE, trimTrailingWhitespace)
+	}
+
+	/**
+	 * Insert a newline character at the end of the file if one does not exist.
+	 * 
+	 * Since 3.15.0
+	 */
+	def boolean isInsertFinalNewline() {
+		val value = getBoolean(INSERT_FINAL_NEWLINE)
+		if (value !== null)
+			return value
+		else
+			return false
+	}
+
+	def void setInsertFinalNewline(boolean insertFinalNewline) {
+		putBoolean(INSERT_FINAL_NEWLINE, insertFinalNewline)
+	}
+
+	/**
+	 * Trim all newlines after the final newline at the end of the file.
+	 * 
+	 * Since 3.15.0
+	 */
+	def boolean isTrimFinalNewlines() {
+		val value = getBoolean(TRIM_FINAL_NEWLINES)
+		if (value !== null)
+			return value
+		else
+			return false
+	}
+
+	def void setTrimFinalNewlines(boolean trimFinalNewlines) {
+		putBoolean(TRIM_FINAL_NEWLINES, trimFinalNewlines)
 	}
 
 	/**
@@ -2482,7 +2647,7 @@ class Hover {
 /**
  * MarkedString can be used to render human readable text. It is either a markdown string
  * or a code-block that provides a language and a code snippet. The language identifier
- * is sematically equal to the optional language identifier in fenced code blocks in GitHub
+ * is semantically equal to the optional language identifier in fenced code blocks in GitHub
  * issues. See https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting
  * 
  * The pair of a language and a value is an equivalent to markdown:
@@ -2491,8 +2656,11 @@ class Hover {
  * ```
  * 
  * Note that markdown strings will be sanitized - that means html will be escaped.
+ * 
+ * @deprecated Use MarkupContent instead.
  */
 @JsonRpcData
+@Deprecated
 class MarkedString {
 	@NonNull
 	String language
@@ -2555,7 +2723,7 @@ class InitializeParams {
 	/**
 	 * The rootPath of the workspace. Is null if no folder is open.
 	 * 
-	 * @deprecated in favour of rootUri.
+	 * @deprecated Use rootUri instead.
 	 */
 	@Deprecated
 	String rootPath
@@ -2580,9 +2748,18 @@ class InitializeParams {
 	/**
 	 * An optional extension to the protocol.
 	 * To tell the server what client (editor) is talking to it.
+	 * 
+	 * @deprecated Use clientInfo instead.
 	 */
 	@Deprecated
 	String clientName
+
+	/**
+	 * Information about the client
+	 * 
+	 * Since 3.15.0
+	 */
+	ClientInfo clientInfo
 
 	/**
 	 * The initial trace setting. If omitted trace is disabled ('off').
@@ -2610,16 +2787,90 @@ class InitializeResult {
 	@NonNull
 	ServerCapabilities capabilities
 
+	/**
+	 * Information about the server.
+	 * 
+	 * Since 3.15.0
+	 */
+	ServerInfo serverInfo
+
 	new() {
 	}
 
 	new(@NonNull ServerCapabilities capabilities) {
 		this.capabilities = Preconditions.checkNotNull(capabilities, 'capabilities')
 	}
+
+	new(@NonNull ServerCapabilities capabilities, ServerInfo serverInfo) {
+		this(capabilities)
+		this.serverInfo = serverInfo
+	}
 }
 
 @JsonRpcData
 class InitializedParams {
+}
+
+/**
+ * Information about the client
+ * 
+ * Since 3.15.0
+ */
+@JsonRpcData
+class ClientInfo {
+	/**
+	 * The name of the client as defined by the client.
+	 */
+	@NonNull
+	String name
+
+	/**
+	 * The client's version as defined by the client.
+	 */
+	String version
+
+	new() {
+	}
+
+	new(@NonNull String name) {
+		this.name = Preconditions.checkNotNull(name, 'name')
+	}
+
+	new(@NonNull String name, String version) {
+		this(name)
+		this.version = version
+	}
+}
+
+/**
+ * Information about the server.
+ * 
+ * Since 3.15.0
+ */
+@JsonRpcData
+class ServerInfo {
+	/**
+	 * The name of the server as defined by the server.
+	 */
+	@NonNull
+	String name
+
+	/**
+	 * The server's version as defined by the server.
+	 */
+	String version
+
+	new() {
+	}
+
+	new(@NonNull String name) {
+		this.name = Preconditions.checkNotNull(name, 'name')
+	}
+
+	new(@NonNull String name, String version) {
+		this(name)
+		this.version = version
+	}
 }
 
 /**
@@ -2826,9 +3077,9 @@ class PublishDiagnosticsParams {
 	/**
 	 * Optional the version number of the document the diagnostics are published for.
 	 *
-	 * @since 3.15.0
+	 * Since 3.15.0
 	 */
-	int version
+	Integer version
 
 	new() {
 		this.diagnostics = new ArrayList
@@ -2837,6 +3088,11 @@ class PublishDiagnosticsParams {
 	new(@NonNull String uri, @NonNull List<Diagnostic> diagnostics) {
 		this.uri = Preconditions.checkNotNull(uri, 'uri')
 		this.diagnostics = Preconditions.checkNotNull(diagnostics, 'diagnostics')
+	}
+
+	new(@NonNull String uri, @NonNull List<Diagnostic> diagnostics, Integer version) {
+		this(uri, diagnostics)
+		this.version = version
 	}
 }
 
@@ -3198,6 +3454,77 @@ class ShowMessageRequestParams extends MessageParams {
 }
 
 /**
+ * The signature help request is sent from the client to the server to request signature information at a given cursor position.
+ */
+@JsonRpcData
+class SignatureHelpParams extends TextDocumentPositionParams {
+	/**
+	 * The signature help context. This is only available if the client specifies
+	 * to send this using the client capability  `textDocument.signatureHelp.contextSupport === true`
+	 * 
+	 * Since 3.15.0
+	 */
+	SignatureHelpContext context
+
+	new() {
+	}
+
+	new(@NonNull TextDocumentIdentifier textDocument, @NonNull Position position) {
+		super(textDocument, position)
+	}
+
+	new(@NonNull TextDocumentIdentifier textDocument, @NonNull Position position, SignatureHelpContext context) {
+		super(textDocument, position)
+		this.context = context
+	}
+}
+
+/**
+ * Additional information about the context in which a signature help request was triggered.
+ * 
+ * Since 3.15.0
+ */
+@JsonRpcData
+class SignatureHelpContext {
+	/**
+	 * Action that caused signature help to be triggered.
+	 */
+	@NonNull
+	SignatureHelpTriggerKind triggerKind
+
+	/**
+	 * Character that caused signature help to be triggered.
+	 * 
+	 * This is undefined when `triggerKind !== SignatureHelpTriggerKind.TriggerCharacter`
+	 */
+	String triggerCharacter
+
+	/**
+	 * `true` if signature help was already showing when it was triggered.
+	 * 
+	 * Retriggers occur when the signature help is already active and can be caused by actions such as
+	 * typing a trigger character, a cursor move, or document content changes.
+	 */
+	boolean isRetrigger
+
+	/**
+	 * The currently active `SignatureHelp`.
+	 * 
+	 * The `activeSignatureHelp` has its `SignatureHelp.activeSignature` field updated based on
+	 * the user navigating through available signatures.
+	 */
+	SignatureHelp activeSignatureHelp
+
+	new() {
+	}
+
+	new(@NonNull SignatureHelpTriggerKind triggerKind, boolean isRetrigger) {
+		this.triggerKind = triggerKind
+		this.isRetrigger = isRetrigger
+	}
+}
+
+/**
  * Signature help represents the signature of something callable. There can be multiple signature but only one
  * active and only one active parameter.
  */
@@ -3212,21 +3539,21 @@ class SignatureHelp {
 	/**
 	 * The active signature. If omitted or the value lies outside the
 	 * range of `signatures` the value defaults to zero or is ignored if
-	 * `signatures.length === 0`. Whenever possible implementors should 
-	 * make an active decision about the active signature and shouldn't 
+	 * `signatures.length === 0`. Whenever possible implementors should
+	 * make an active decision about the active signature and shouldn't
 	 * rely on a default value.
 	 * In future version of the protocol this property might become
-	 * mandantory to better express this.
+	 * mandatory to better express this.
 	 */
 	Integer activeSignature
 
 	/**
 	 * The active parameter of the active signature. If omitted or the value
-	 * lies outside the range of `signatures[activeSignature].parameters` 
-	 * defaults to 0 if the active signature has parameters. If 
-	 * the active signature has no parameters it is ignored. 
+	 * lies outside the range of `signatures[activeSignature].parameters`
+	 * defaults to 0 if the active signature has parameters. If
+	 * the active signature has no parameters it is ignored.
 	 * In future version of the protocol this property might become
-	 * mandantory to better express the active parameter if the
+	 * mandatory to better express the active parameter if the
 	 * active signature does have any.
 	 */
 	Integer activeParameter
@@ -3252,11 +3579,26 @@ class SignatureHelpOptions {
 	 */
 	List<String> triggerCharacters
 
+	/**
+	 * List of characters that re-trigger signature help.
+	 * 
+	 * These trigger characters are only active when signature help is already showing. All trigger characters
+	 * are also counted as re-trigger characters.
+	 * 
+	 * Since 3.15.0
+	 */
+	List<String> retriggerCharacters
+
 	new() {
 	}
 
 	new(List<String> triggerCharacters) {
 		this.triggerCharacters = triggerCharacters
+	}
+
+	new(List<String> triggerCharacters, List<String> retriggerCharacters) {
+		this(triggerCharacters)
+		this.retriggerCharacters = retriggerCharacters
 	}
 }
 
@@ -3523,7 +3865,10 @@ class TextDocumentContentChangeEvent {
 
 	/**
 	 * The length of the range that got replaced.
+	 * 
+	 * @deprecated Use range instead.
 	 */
+	 @Deprecated
 	Integer rangeLength
 
 	/**
@@ -4047,7 +4392,8 @@ class WorkspaceEdit {
 @JsonRpcData
 class WorkspaceSymbolParams {
 	/**
-	 * A non-empty query string
+	 * A query string to filter symbols by. Clients may send an empty
+	 * string here to request all symbols.
 	 */
 	@NonNull
 	String query
@@ -4202,6 +4548,7 @@ class Unregistration {
  */
 @JsonRpcData
 class UnregistrationParams {
+	// This is a known misspelling in the spec and is intended to be fixed in LSP 4.x
 	@NonNull
 	List<Unregistration> unregisterations
 
@@ -4460,7 +4807,7 @@ class WorkspaceFoldersOptions {
 	 * change notifications.
 	 * 
 	 * If a string is provided, the string is treated as an ID
-	 * under which the notification is registed on the client
+	 * under which the notification is registered on the client
 	 * side. The ID can be used to unregister for these events
 	 * using the `client/unregisterCapability` request.
 	 */
@@ -4596,7 +4943,7 @@ class ConfigurationItem {
 }
 
 /**
- * The document color request is sent from the client to the server to list all color refereces
+ * The document color request is sent from the client to the server to list all color references
  * found in a given text document. Along with the range, a color value in RGB is returned.
  * 
  * Since 3.6.0
@@ -4620,7 +4967,7 @@ class DocumentColorParams {
 @JsonRpcData
 class ColorInformation {
 	/**
-	 * The range in the document where this color appers.
+	 * The range in the document where this color appears.
 	 */
 	@NonNull
 	Range range
@@ -5028,7 +5375,6 @@ class CallHierarchyItem {
 /**
  * A parameter literal used in selection range requests.
  */
-@Beta
 @JsonRpcData
 class SelectionRangeParams {
 	
@@ -5044,7 +5390,6 @@ class SelectionRangeParams {
 	@NonNull
 	List<Position> positions
 	
-	
 	new() {
 	}
 
@@ -5058,7 +5403,6 @@ class SelectionRangeParams {
  * A selection range represents a part of a selection hierarchy. A selection range
  * may have a parent selection range that contains it.
  */
-@Beta
 @JsonRpcData
 class SelectionRange {
 	
@@ -5072,8 +5416,6 @@ class SelectionRange {
 	 * The parent selection range containing this range. Therefore `parent.range` must contain `this.range`.
 	 */
 	SelectionRange parent
-	
-	
 	
 	new() {
 	}

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/SignatureHelpTriggerKind.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/SignatureHelpTriggerKind.java
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2016 TypeFox and others.
+ * Copyright (c) 2016-2018 TypeFox and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -12,63 +12,30 @@
 package org.eclipse.lsp4j;
 
 /**
- * The kind of a completion entry.
+ * How a signature help was triggered.
+ * 
+ * Since 3.15.0
  */
-public enum CompletionItemKind {
+public enum SignatureHelpTriggerKind {
 	
-	Text(1),
+	/**
+	 * Signature help was invoked manually by the user or by a command.
+	 */
+	Invoked(1),
 	
-	Method(2),
+	/**
+	 * Signature help was triggered by a trigger character.
+	 */
+	TriggerCharacter(2),
 	
-	Function(3),
-	
-	Constructor(4),
-	
-	Field(5),
-	
-	Variable(6),
-	
-	Class(7),
-	
-	Interface(8),
-	
-	Module(9),
-	
-	Property(10),
-	
-	Unit(11),
-	
-	Value(12),
-	
-	Enum(13),
-	
-	Keyword(14),
-	
-	Snippet(15),
-	
-	Color(16),
-	
-	File(17),
-	
-	Reference(18),
-	
-	Folder(19),
-	
-	EnumMember(20),
-	
-	Constant(21),
-	
-	Struct(22),
-	
-	Event(23),
-	
-	Operator(24),
-	
-	TypeParameter(25);
+	/**
+	 * Signature help was triggered by the cursor moving or by the document content changing.
+	 */
+	ContentChange(3);
 	
 	private final int value;
 	
-	CompletionItemKind(int value) {
+	SignatureHelpTriggerKind(int value) {
 		this.value = value;
 	}
 	
@@ -76,8 +43,8 @@ public enum CompletionItemKind {
 		return value;
 	}
 	
-	public static CompletionItemKind forValue(int value) {
-		CompletionItemKind[] allValues = CompletionItemKind.values();
+	public static SignatureHelpTriggerKind forValue(int value) {
+		SignatureHelpTriggerKind[] allValues = SignatureHelpTriggerKind.values();
 		if (value < 1 || value > allValues.length)
 			throw new IllegalArgumentException("Illegal enum value: " + value);
 		return allValues[value - 1];

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/TextDocumentService.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/TextDocumentService.java
@@ -58,6 +58,7 @@ import org.eclipse.lsp4j.ResolveTypeHierarchyItemParams;
 import org.eclipse.lsp4j.SelectionRange;
 import org.eclipse.lsp4j.SelectionRangeParams;
 import org.eclipse.lsp4j.SignatureHelp;
+import org.eclipse.lsp4j.SignatureHelpParams;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.TextDocumentPositionParams;
 import org.eclipse.lsp4j.TextDocumentRegistrationOptions;
@@ -123,7 +124,7 @@ public interface TextDocumentService {
 	 * Registration Options: SignatureHelpRegistrationOptions
 	 */
 	@JsonRequest
-	default CompletableFuture<SignatureHelp> signatureHelp(TextDocumentPositionParams position) {
+	default CompletableFuture<SignatureHelp> signatureHelp(SignatureHelpParams params) {
 		throw new UnsupportedOperationException();
 	}
 	
@@ -509,7 +510,6 @@ public interface TextDocumentService {
 	 * suggested selection ranges at an array of given positions. A selection range is a range around
 	 * the cursor position which the user might be interested in selecting.
 	 */
-	@Beta
 	@JsonRequest
 	default CompletableFuture<List<SelectionRange>> selectionRange(SelectionRangeParams params) {
 		throw new UnsupportedOperationException();

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ClientInfo.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ClientInfo.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2016-2018 TypeFox and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.lsp4j;
+
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+/**
+ * Information about the client
+ * 
+ * Since 3.15.0
+ */
+@SuppressWarnings("all")
+public class ClientInfo {
+  /**
+   * The name of the client as defined by the client.
+   */
+  @NonNull
+  private String name;
+  
+  /**
+   * The client's version as defined by the client.
+   */
+  private String version;
+  
+  public ClientInfo() {
+  }
+  
+  public ClientInfo(@NonNull final String name) {
+    this.name = Preconditions.<String>checkNotNull(name, "name");
+  }
+  
+  public ClientInfo(@NonNull final String name, final String version) {
+    this(name);
+    this.version = version;
+  }
+  
+  /**
+   * The name of the client as defined by the client.
+   */
+  @Pure
+  @NonNull
+  public String getName() {
+    return this.name;
+  }
+  
+  /**
+   * The name of the client as defined by the client.
+   */
+  public void setName(@NonNull final String name) {
+    this.name = Preconditions.checkNotNull(name, "name");
+  }
+  
+  /**
+   * The client's version as defined by the client.
+   */
+  @Pure
+  public String getVersion() {
+    return this.version;
+  }
+  
+  /**
+   * The client's version as defined by the client.
+   */
+  public void setVersion(final String version) {
+    this.version = version;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("name", this.name);
+    b.add("version", this.version);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    ClientInfo other = (ClientInfo) obj;
+    if (this.name == null) {
+      if (other.name != null)
+        return false;
+    } else if (!this.name.equals(other.name))
+      return false;
+    if (this.version == null) {
+      if (other.version != null)
+        return false;
+    } else if (!this.version.equals(other.version))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.name== null) ? 0 : this.name.hashCode());
+    return prime * result + ((this.version== null) ? 0 : this.version.hashCode());
+  }
+}

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeAction.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeAction.java
@@ -47,6 +47,17 @@ public class CodeAction {
   private List<Diagnostic> diagnostics;
   
   /**
+   * Marks this as a preferred action. Preferred actions are used by the `auto fix` command and can be targeted
+   * by keybindings.
+   * 
+   * A quick fix should be marked preferred if it properly addresses the underlying error.
+   * A refactoring should be marked preferred if it is the most reasonable choice of actions to take.
+   * 
+   * Since 3.15.0
+   */
+  private Boolean isPreferred;
+  
+  /**
    * The workspace edit this code action performs.
    */
   private WorkspaceEdit edit;
@@ -116,6 +127,33 @@ public class CodeAction {
   }
   
   /**
+   * Marks this as a preferred action. Preferred actions are used by the `auto fix` command and can be targeted
+   * by keybindings.
+   * 
+   * A quick fix should be marked preferred if it properly addresses the underlying error.
+   * A refactoring should be marked preferred if it is the most reasonable choice of actions to take.
+   * 
+   * Since 3.15.0
+   */
+  @Pure
+  public Boolean getIsPreferred() {
+    return this.isPreferred;
+  }
+  
+  /**
+   * Marks this as a preferred action. Preferred actions are used by the `auto fix` command and can be targeted
+   * by keybindings.
+   * 
+   * A quick fix should be marked preferred if it properly addresses the underlying error.
+   * A refactoring should be marked preferred if it is the most reasonable choice of actions to take.
+   * 
+   * Since 3.15.0
+   */
+  public void setIsPreferred(final Boolean isPreferred) {
+    this.isPreferred = isPreferred;
+  }
+  
+  /**
    * The workspace edit this code action performs.
    */
   @Pure
@@ -156,6 +194,7 @@ public class CodeAction {
     b.add("title", this.title);
     b.add("kind", this.kind);
     b.add("diagnostics", this.diagnostics);
+    b.add("isPreferred", this.isPreferred);
     b.add("edit", this.edit);
     b.add("command", this.command);
     return b.toString();
@@ -186,6 +225,11 @@ public class CodeAction {
         return false;
     } else if (!this.diagnostics.equals(other.diagnostics))
       return false;
+    if (this.isPreferred == null) {
+      if (other.isPreferred != null)
+        return false;
+    } else if (!this.isPreferred.equals(other.isPreferred))
+      return false;
     if (this.edit == null) {
       if (other.edit != null)
         return false;
@@ -207,6 +251,7 @@ public class CodeAction {
     result = prime * result + ((this.title== null) ? 0 : this.title.hashCode());
     result = prime * result + ((this.kind== null) ? 0 : this.kind.hashCode());
     result = prime * result + ((this.diagnostics== null) ? 0 : this.diagnostics.hashCode());
+    result = prime * result + ((this.isPreferred== null) ? 0 : this.isPreferred.hashCode());
     result = prime * result + ((this.edit== null) ? 0 : this.edit.hashCode());
     return prime * result + ((this.command== null) ? 0 : this.command.hashCode());
   }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeActionCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeActionCapabilities.java
@@ -27,6 +27,13 @@ public class CodeActionCapabilities extends DynamicRegistrationCapabilities {
    */
   private CodeActionLiteralSupportCapabilities codeActionLiteralSupport;
   
+  /**
+   * Whether code action supports the `isPreferred` property.
+   * 
+   * Since 3.15.0
+   */
+  private Boolean isPreferredSupport;
+  
   public CodeActionCapabilities() {
   }
   
@@ -37,6 +44,11 @@ public class CodeActionCapabilities extends DynamicRegistrationCapabilities {
   public CodeActionCapabilities(final CodeActionLiteralSupportCapabilities codeActionLiteralSupport, final Boolean dynamicRegistration) {
     super(dynamicRegistration);
     this.codeActionLiteralSupport = codeActionLiteralSupport;
+  }
+  
+  public CodeActionCapabilities(final CodeActionLiteralSupportCapabilities codeActionLiteralSupport, final Boolean dynamicRegistration, final Boolean isPreferredSupport) {
+    this(codeActionLiteralSupport, dynamicRegistration);
+    this.isPreferredSupport = isPreferredSupport;
   }
   
   /**
@@ -56,11 +68,31 @@ public class CodeActionCapabilities extends DynamicRegistrationCapabilities {
     this.codeActionLiteralSupport = codeActionLiteralSupport;
   }
   
+  /**
+   * Whether code action supports the `isPreferred` property.
+   * 
+   * Since 3.15.0
+   */
+  @Pure
+  public Boolean getIsPreferredSupport() {
+    return this.isPreferredSupport;
+  }
+  
+  /**
+   * Whether code action supports the `isPreferred` property.
+   * 
+   * Since 3.15.0
+   */
+  public void setIsPreferredSupport(final Boolean isPreferredSupport) {
+    this.isPreferredSupport = isPreferredSupport;
+  }
+  
   @Override
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("codeActionLiteralSupport", this.codeActionLiteralSupport);
+    b.add("isPreferredSupport", this.isPreferredSupport);
     b.add("dynamicRegistration", getDynamicRegistration());
     return b.toString();
   }
@@ -82,12 +114,20 @@ public class CodeActionCapabilities extends DynamicRegistrationCapabilities {
         return false;
     } else if (!this.codeActionLiteralSupport.equals(other.codeActionLiteralSupport))
       return false;
+    if (this.isPreferredSupport == null) {
+      if (other.isPreferredSupport != null)
+        return false;
+    } else if (!this.isPreferredSupport.equals(other.isPreferredSupport))
+      return false;
     return true;
   }
   
   @Override
   @Pure
   public int hashCode() {
-    return 31 * super.hashCode() + ((this.codeActionLiteralSupport== null) ? 0 : this.codeActionLiteralSupport.hashCode());
+    final int prime = 31;
+    int result = super.hashCode();
+    result = prime * result + ((this.codeActionLiteralSupport== null) ? 0 : this.codeActionLiteralSupport.hashCode());
+    return prime * result + ((this.isPreferredSupport== null) ? 0 : this.isPreferredSupport.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeActionKindCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeActionKindCapabilities.java
@@ -11,7 +11,10 @@
  */
 package org.eclipse.lsp4j;
 
+import java.util.ArrayList;
 import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -25,13 +28,16 @@ public class CodeActionKindCapabilities {
    * 
    * See {@link CodeActionKind} for allowed values.
    */
+  @NonNull
   private List<String> valueSet;
   
   public CodeActionKindCapabilities() {
+    ArrayList<String> _arrayList = new ArrayList<String>();
+    this.valueSet = _arrayList;
   }
   
-  public CodeActionKindCapabilities(final List<String> valueSet) {
-    this.valueSet = valueSet;
+  public CodeActionKindCapabilities(@NonNull final List<String> valueSet) {
+    this.valueSet = Preconditions.<List<String>>checkNotNull(valueSet, "valueSet");
   }
   
   /**
@@ -43,6 +49,7 @@ public class CodeActionKindCapabilities {
    * See {@link CodeActionKind} for allowed values.
    */
   @Pure
+  @NonNull
   public List<String> getValueSet() {
     return this.valueSet;
   }
@@ -55,8 +62,8 @@ public class CodeActionKindCapabilities {
    * 
    * See {@link CodeActionKind} for allowed values.
    */
-  public void setValueSet(final List<String> valueSet) {
-    this.valueSet = valueSet;
+  public void setValueSet(@NonNull final List<String> valueSet) {
+    this.valueSet = Preconditions.checkNotNull(valueSet, "valueSet");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeActionParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeActionParams.java
@@ -21,8 +21,7 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
  * The code action request is sent from the client to the server to compute commands for a given text document and range.
- * The request is triggered when the user moves the cursor into an problem marker in the editor or presses the lightbulb
- * associated with a marker.
+ * These commands are typically code fixes to either fix problems or to beautify/refactor code.
  */
 @SuppressWarnings("all")
 public class CodeActionParams {

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ColorInformation.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ColorInformation.java
@@ -21,7 +21,7 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 @SuppressWarnings("all")
 public class ColorInformation {
   /**
-   * The range in the document where this color appers.
+   * The range in the document where this color appears.
    */
   @NonNull
   private Range range;
@@ -41,7 +41,7 @@ public class ColorInformation {
   }
   
   /**
-   * The range in the document where this color appers.
+   * The range in the document where this color appears.
    */
   @Pure
   @NonNull
@@ -50,7 +50,7 @@ public class ColorInformation {
   }
   
   /**
-   * The range in the document where this color appers.
+   * The range in the document where this color appears.
    */
   public void setRange(@NonNull final Range range) {
     this.range = Preconditions.checkNotNull(range, "range");

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionItem.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionItem.java
@@ -15,6 +15,7 @@ import com.google.gson.annotations.JsonAdapter;
 import java.util.List;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.CompletionItemKind;
+import org.eclipse.lsp4j.CompletionItemTag;
 import org.eclipse.lsp4j.InsertTextFormat;
 import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.TextEdit;
@@ -45,6 +46,13 @@ public class CompletionItem {
   private CompletionItemKind kind;
   
   /**
+   * Tags for this completion item.
+   * 
+   * Since 3.15.0
+   */
+  private List<CompletionItemTag> tags;
+  
+  /**
    * A human-readable string with additional information about this item, like type or symbol information.
    */
   private String detail;
@@ -69,7 +77,7 @@ public class CompletionItem {
   private Boolean preselect;
   
   /**
-   * A string that shoud be used when comparing this item with other items. When `falsy` the label is used.
+   * A string that should be used when comparing this item with other items. When `falsy` the label is used.
    */
   private String sortText;
   
@@ -168,6 +176,25 @@ public class CompletionItem {
   }
   
   /**
+   * Tags for this completion item.
+   * 
+   * Since 3.15.0
+   */
+  @Pure
+  public List<CompletionItemTag> getTags() {
+    return this.tags;
+  }
+  
+  /**
+   * Tags for this completion item.
+   * 
+   * Since 3.15.0
+   */
+  public void setTags(final List<CompletionItemTag> tags) {
+    this.tags = tags;
+  }
+  
+  /**
    * A human-readable string with additional information about this item, like type or symbol information.
    */
   @Pure
@@ -252,7 +279,7 @@ public class CompletionItem {
   }
   
   /**
-   * A string that shoud be used when comparing this item with other items. When `falsy` the label is used.
+   * A string that should be used when comparing this item with other items. When `falsy` the label is used.
    */
   @Pure
   public String getSortText() {
@@ -260,7 +287,7 @@ public class CompletionItem {
   }
   
   /**
-   * A string that shoud be used when comparing this item with other items. When `falsy` the label is used.
+   * A string that should be used when comparing this item with other items. When `falsy` the label is used.
    */
   public void setSortText(final String sortText) {
     this.sortText = sortText;
@@ -422,6 +449,7 @@ public class CompletionItem {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("label", this.label);
     b.add("kind", this.kind);
+    b.add("tags", this.tags);
     b.add("detail", this.detail);
     b.add("documentation", this.documentation);
     b.add("deprecated", this.deprecated);
@@ -457,6 +485,11 @@ public class CompletionItem {
       if (other.kind != null)
         return false;
     } else if (!this.kind.equals(other.kind))
+      return false;
+    if (this.tags == null) {
+      if (other.tags != null)
+        return false;
+    } else if (!this.tags.equals(other.tags))
       return false;
     if (this.detail == null) {
       if (other.detail != null)
@@ -533,6 +566,7 @@ public class CompletionItem {
     int result = 1;
     result = prime * result + ((this.label== null) ? 0 : this.label.hashCode());
     result = prime * result + ((this.kind== null) ? 0 : this.kind.hashCode());
+    result = prime * result + ((this.tags== null) ? 0 : this.tags.hashCode());
     result = prime * result + ((this.detail== null) ? 0 : this.detail.hashCode());
     result = prime * result + ((this.documentation== null) ? 0 : this.documentation.hashCode());
     result = prime * result + ((this.deprecated== null) ? 0 : this.deprecated.hashCode());

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionItemCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionItemCapabilities.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j;
 
 import java.util.List;
+import org.eclipse.lsp4j.CompletionItemTagSupportCapabilities;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -50,6 +51,16 @@ public class CompletionItemCapabilities {
    * Client supports the preselect property on a completion item.
    */
   private Boolean preselectSupport;
+  
+  /**
+   * Client supports the tag property on a completion item. Clients supporting
+   * tags have to handle unknown tags gracefully. Clients especially need to
+   * preserve unknown tags when sending a completion item back to the server in
+   * a resolve call.
+   * 
+   * Since 3.15.0
+   */
+  private CompletionItemTagSupportCapabilities tagSupport;
   
   public CompletionItemCapabilities() {
   }
@@ -145,6 +156,31 @@ public class CompletionItemCapabilities {
     this.preselectSupport = preselectSupport;
   }
   
+  /**
+   * Client supports the tag property on a completion item. Clients supporting
+   * tags have to handle unknown tags gracefully. Clients especially need to
+   * preserve unknown tags when sending a completion item back to the server in
+   * a resolve call.
+   * 
+   * Since 3.15.0
+   */
+  @Pure
+  public CompletionItemTagSupportCapabilities getTagSupport() {
+    return this.tagSupport;
+  }
+  
+  /**
+   * Client supports the tag property on a completion item. Clients supporting
+   * tags have to handle unknown tags gracefully. Clients especially need to
+   * preserve unknown tags when sending a completion item back to the server in
+   * a resolve call.
+   * 
+   * Since 3.15.0
+   */
+  public void setTagSupport(final CompletionItemTagSupportCapabilities tagSupport) {
+    this.tagSupport = tagSupport;
+  }
+  
   @Override
   @Pure
   public String toString() {
@@ -154,6 +190,7 @@ public class CompletionItemCapabilities {
     b.add("documentationFormat", this.documentationFormat);
     b.add("deprecatedSupport", this.deprecatedSupport);
     b.add("preselectSupport", this.preselectSupport);
+    b.add("tagSupport", this.tagSupport);
     return b.toString();
   }
   
@@ -192,6 +229,11 @@ public class CompletionItemCapabilities {
         return false;
     } else if (!this.preselectSupport.equals(other.preselectSupport))
       return false;
+    if (this.tagSupport == null) {
+      if (other.tagSupport != null)
+        return false;
+    } else if (!this.tagSupport.equals(other.tagSupport))
+      return false;
     return true;
   }
   
@@ -204,6 +246,7 @@ public class CompletionItemCapabilities {
     result = prime * result + ((this.commitCharactersSupport== null) ? 0 : this.commitCharactersSupport.hashCode());
     result = prime * result + ((this.documentationFormat== null) ? 0 : this.documentationFormat.hashCode());
     result = prime * result + ((this.deprecatedSupport== null) ? 0 : this.deprecatedSupport.hashCode());
-    return prime * result + ((this.preselectSupport== null) ? 0 : this.preselectSupport.hashCode());
+    result = prime * result + ((this.preselectSupport== null) ? 0 : this.preselectSupport.hashCode());
+    return prime * result + ((this.tagSupport== null) ? 0 : this.tagSupport.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionItemTagSupportCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionItemTagSupportCapabilities.java
@@ -11,54 +11,52 @@
  */
 package org.eclipse.lsp4j;
 
-import org.eclipse.lsp4j.TextDocumentIdentifier;
+import java.util.ArrayList;
+import java.util.List;
+import org.eclipse.lsp4j.CompletionItemTag;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
-/**
- * The document color request is sent from the client to the server to list all color references
- * found in a given text document. Along with the range, a color value in RGB is returned.
- * 
- * Since 3.6.0
- */
 @SuppressWarnings("all")
-public class DocumentColorParams {
+public class CompletionItemTagSupportCapabilities {
   /**
-   * The text document.
+   * The tags supported by the client.
    */
   @NonNull
-  private TextDocumentIdentifier textDocument;
+  private List<CompletionItemTag> valueSet;
   
-  public DocumentColorParams() {
+  public CompletionItemTagSupportCapabilities() {
+    ArrayList<CompletionItemTag> _arrayList = new ArrayList<CompletionItemTag>();
+    this.valueSet = _arrayList;
   }
   
-  public DocumentColorParams(@NonNull final TextDocumentIdentifier textDocument) {
-    this.textDocument = Preconditions.<TextDocumentIdentifier>checkNotNull(textDocument, "textDocument");
+  public CompletionItemTagSupportCapabilities(@NonNull final List<CompletionItemTag> valueSet) {
+    this.valueSet = Preconditions.<List<CompletionItemTag>>checkNotNull(valueSet, "valueSet");
   }
   
   /**
-   * The text document.
+   * The tags supported by the client.
    */
   @Pure
   @NonNull
-  public TextDocumentIdentifier getTextDocument() {
-    return this.textDocument;
+  public List<CompletionItemTag> getValueSet() {
+    return this.valueSet;
   }
   
   /**
-   * The text document.
+   * The tags supported by the client.
    */
-  public void setTextDocument(@NonNull final TextDocumentIdentifier textDocument) {
-    this.textDocument = Preconditions.checkNotNull(textDocument, "textDocument");
+  public void setValueSet(@NonNull final List<CompletionItemTag> valueSet) {
+    this.valueSet = Preconditions.checkNotNull(valueSet, "valueSet");
   }
   
   @Override
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
-    b.add("textDocument", this.textDocument);
+    b.add("valueSet", this.valueSet);
     return b.toString();
   }
   
@@ -71,11 +69,11 @@ public class DocumentColorParams {
       return false;
     if (getClass() != obj.getClass())
       return false;
-    DocumentColorParams other = (DocumentColorParams) obj;
-    if (this.textDocument == null) {
-      if (other.textDocument != null)
+    CompletionItemTagSupportCapabilities other = (CompletionItemTagSupportCapabilities) obj;
+    if (this.valueSet == null) {
+      if (other.valueSet != null)
         return false;
-    } else if (!this.textDocument.equals(other.textDocument))
+    } else if (!this.valueSet.equals(other.valueSet))
       return false;
     return true;
   }
@@ -83,6 +81,6 @@ public class DocumentColorParams {
   @Override
   @Pure
   public int hashCode() {
-    return 31 * 1 + ((this.textDocument== null) ? 0 : this.textDocument.hashCode());
+    return 31 * 1 + ((this.valueSet== null) ? 0 : this.valueSet.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DiagnosticsTagSupport.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DiagnosticsTagSupport.java
@@ -11,8 +11,11 @@
  */
 package org.eclipse.lsp4j;
 
+import java.util.ArrayList;
 import java.util.List;
 import org.eclipse.lsp4j.DiagnosticTag;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -21,19 +24,23 @@ public class DiagnosticsTagSupport {
   /**
    * The tags supported by the client.
    */
+  @NonNull
   private List<DiagnosticTag> valueSet;
   
   public DiagnosticsTagSupport() {
+    ArrayList<DiagnosticTag> _arrayList = new ArrayList<DiagnosticTag>();
+    this.valueSet = _arrayList;
   }
   
-  public DiagnosticsTagSupport(final List<DiagnosticTag> valueSet) {
-    this.valueSet = valueSet;
+  public DiagnosticsTagSupport(@NonNull final List<DiagnosticTag> valueSet) {
+    this.valueSet = Preconditions.<List<DiagnosticTag>>checkNotNull(valueSet, "valueSet");
   }
   
   /**
    * The tags supported by the client.
    */
   @Pure
+  @NonNull
   public List<DiagnosticTag> getValueSet() {
     return this.valueSet;
   }
@@ -41,8 +48,8 @@ public class DiagnosticsTagSupport {
   /**
    * The tags supported by the client.
    */
-  public void setValueSet(final List<DiagnosticTag> valueSet) {
-    this.valueSet = valueSet;
+  public void setValueSet(@NonNull final List<DiagnosticTag> valueSet) {
+    this.valueSet = Preconditions.checkNotNull(valueSet, "valueSet");
   }
   
   @Override

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidSaveTextDocumentParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DidSaveTextDocumentParams.java
@@ -18,7 +18,7 @@ import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
- * The document save notification is sent from the client to the server when the document for saved in the clinet.
+ * The document save notification is sent from the client to the server when the document was saved in the client.
  */
 @SuppressWarnings("all")
 public class DidSaveTextDocumentParams {

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentLink.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentLink.java
@@ -37,6 +37,17 @@ public class DocumentLink {
   private String target;
   
   /**
+   * The tooltip text when you hover over this link.
+   * 
+   * If a tooltip is provided, is will be displayed in a string that includes instructions on how to
+   * trigger the link, such as `{0} (ctrl + click)`. The specific instructions vary depending on OS,
+   * user settings, and localization.
+   * 
+   * Since 3.15.0
+   */
+  private String tooltip;
+  
+  /**
    * A data entry field that is preserved on a document link between a
    * DocumentLinkRequest and a DocumentLinkResolveRequest.
    */
@@ -58,6 +69,11 @@ public class DocumentLink {
   public DocumentLink(@NonNull final Range range, final String target, final Object data) {
     this(range, target);
     this.data = data;
+  }
+  
+  public DocumentLink(@NonNull final Range range, final String target, final Object data, final String tooltip) {
+    this(range, target, data);
+    this.tooltip = tooltip;
   }
   
   /**
@@ -92,6 +108,33 @@ public class DocumentLink {
   }
   
   /**
+   * The tooltip text when you hover over this link.
+   * 
+   * If a tooltip is provided, is will be displayed in a string that includes instructions on how to
+   * trigger the link, such as `{0} (ctrl + click)`. The specific instructions vary depending on OS,
+   * user settings, and localization.
+   * 
+   * Since 3.15.0
+   */
+  @Pure
+  public String getTooltip() {
+    return this.tooltip;
+  }
+  
+  /**
+   * The tooltip text when you hover over this link.
+   * 
+   * If a tooltip is provided, is will be displayed in a string that includes instructions on how to
+   * trigger the link, such as `{0} (ctrl + click)`. The specific instructions vary depending on OS,
+   * user settings, and localization.
+   * 
+   * Since 3.15.0
+   */
+  public void setTooltip(final String tooltip) {
+    this.tooltip = tooltip;
+  }
+  
+  /**
    * A data entry field that is preserved on a document link between a
    * DocumentLinkRequest and a DocumentLinkResolveRequest.
    */
@@ -114,6 +157,7 @@ public class DocumentLink {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("range", this.range);
     b.add("target", this.target);
+    b.add("tooltip", this.tooltip);
     b.add("data", this.data);
     return b.toString();
   }
@@ -138,6 +182,11 @@ public class DocumentLink {
         return false;
     } else if (!this.target.equals(other.target))
       return false;
+    if (this.tooltip == null) {
+      if (other.tooltip != null)
+        return false;
+    } else if (!this.tooltip.equals(other.tooltip))
+      return false;
     if (this.data == null) {
       if (other.data != null)
         return false;
@@ -153,6 +202,7 @@ public class DocumentLink {
     int result = 1;
     result = prime * result + ((this.range== null) ? 0 : this.range.hashCode());
     result = prime * result + ((this.target== null) ? 0 : this.target.hashCode());
+    result = prime * result + ((this.tooltip== null) ? 0 : this.tooltip.hashCode());
     return prime * result + ((this.data== null) ? 0 : this.data.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentLinkCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentLinkCapabilities.java
@@ -20,6 +20,13 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
  */
 @SuppressWarnings("all")
 public class DocumentLinkCapabilities extends DynamicRegistrationCapabilities {
+  /**
+   * Whether the client supports the `tooltip` property on `DocumentLink`.
+   * 
+   * Since 3.15.0
+   */
+  private Boolean tooltipSupport;
+  
   public DocumentLinkCapabilities() {
   }
   
@@ -27,10 +34,35 @@ public class DocumentLinkCapabilities extends DynamicRegistrationCapabilities {
     super(dynamicRegistration);
   }
   
+  public DocumentLinkCapabilities(final Boolean dynamicRegistration, final Boolean tooltipSupport) {
+    super(dynamicRegistration);
+    this.tooltipSupport = tooltipSupport;
+  }
+  
+  /**
+   * Whether the client supports the `tooltip` property on `DocumentLink`.
+   * 
+   * Since 3.15.0
+   */
+  @Pure
+  public Boolean getTooltipSupport() {
+    return this.tooltipSupport;
+  }
+  
+  /**
+   * Whether the client supports the `tooltip` property on `DocumentLink`.
+   * 
+   * Since 3.15.0
+   */
+  public void setTooltipSupport(final Boolean tooltipSupport) {
+    this.tooltipSupport = tooltipSupport;
+  }
+  
   @Override
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
+    b.add("tooltipSupport", this.tooltipSupport);
     b.add("dynamicRegistration", getDynamicRegistration());
     return b.toString();
   }
@@ -46,12 +78,18 @@ public class DocumentLinkCapabilities extends DynamicRegistrationCapabilities {
       return false;
     if (!super.equals(obj))
       return false;
+    DocumentLinkCapabilities other = (DocumentLinkCapabilities) obj;
+    if (this.tooltipSupport == null) {
+      if (other.tooltipSupport != null)
+        return false;
+    } else if (!this.tooltipSupport.equals(other.tooltipSupport))
+      return false;
     return true;
   }
   
   @Override
   @Pure
   public int hashCode() {
-    return super.hashCode();
+    return 31 * super.hashCode() + ((this.tooltipSupport== null) ? 0 : this.tooltipSupport.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/FormattingOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/FormattingOptions.java
@@ -28,6 +28,12 @@ public class FormattingOptions extends LinkedHashMap<String, Either3<String, Num
   
   private static final String INSERT_SPACES = "insertSpaces";
   
+  private static final String TRIM_TRAILING_WHITESPACE = "trimTrailingWhitespace";
+  
+  private static final String INSERT_FINAL_NEWLINE = "insertFinalNewline";
+  
+  private static final String TRIM_FINAL_NEWLINES = "trimFinalNewlines";
+  
   public FormattingOptions() {
   }
   
@@ -114,6 +120,60 @@ public class FormattingOptions extends LinkedHashMap<String, Either3<String, Num
   
   public void setInsertSpaces(final boolean insertSpaces) {
     this.putBoolean(FormattingOptions.INSERT_SPACES, Boolean.valueOf(insertSpaces));
+  }
+  
+  /**
+   * Trim trailing whitespace on a line.
+   * 
+   * Since 3.15.0
+   */
+  public boolean isTrimTrailingWhitespace() {
+    final Boolean value = this.getBoolean(FormattingOptions.TRIM_TRAILING_WHITESPACE);
+    if ((value != null)) {
+      return (value).booleanValue();
+    } else {
+      return false;
+    }
+  }
+  
+  public void setTrimTrailingWhitespace(final boolean trimTrailingWhitespace) {
+    this.putBoolean(FormattingOptions.TRIM_TRAILING_WHITESPACE, Boolean.valueOf(trimTrailingWhitespace));
+  }
+  
+  /**
+   * Insert a newline character at the end of the file if one does not exist.
+   * 
+   * Since 3.15.0
+   */
+  public boolean isInsertFinalNewline() {
+    final Boolean value = this.getBoolean(FormattingOptions.INSERT_FINAL_NEWLINE);
+    if ((value != null)) {
+      return (value).booleanValue();
+    } else {
+      return false;
+    }
+  }
+  
+  public void setInsertFinalNewline(final boolean insertFinalNewline) {
+    this.putBoolean(FormattingOptions.INSERT_FINAL_NEWLINE, Boolean.valueOf(insertFinalNewline));
+  }
+  
+  /**
+   * Trim all newlines after the final newline at the end of the file.
+   * 
+   * Since 3.15.0
+   */
+  public boolean isTrimFinalNewlines() {
+    final Boolean value = this.getBoolean(FormattingOptions.TRIM_FINAL_NEWLINES);
+    if ((value != null)) {
+      return (value).booleanValue();
+    } else {
+      return false;
+    }
+  }
+  
+  public void setTrimFinalNewlines(final boolean trimFinalNewlines) {
+    this.putBoolean(FormattingOptions.TRIM_FINAL_NEWLINES, Boolean.valueOf(trimFinalNewlines));
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/InitializeParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/InitializeParams.java
@@ -14,6 +14,7 @@ package org.eclipse.lsp4j;
 import com.google.gson.annotations.JsonAdapter;
 import java.util.List;
 import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.ClientInfo;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.adapters.InitializeParamsTypeAdapter;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
@@ -34,7 +35,7 @@ public class InitializeParams {
   /**
    * The rootPath of the workspace. Is null if no folder is open.
    * 
-   * @deprecated in favour of rootUri.
+   * @deprecated Use rootUri instead.
    */
   @Deprecated
   private String rootPath;
@@ -59,9 +60,18 @@ public class InitializeParams {
   /**
    * An optional extension to the protocol.
    * To tell the server what client (editor) is talking to it.
+   * 
+   * @deprecated Use clientInfo instead.
    */
   @Deprecated
   private String clientName;
+  
+  /**
+   * Information about the client
+   * 
+   * Since 3.15.0
+   */
+  private ClientInfo clientInfo;
   
   /**
    * The initial trace setting. If omitted trace is disabled ('off').
@@ -98,7 +108,7 @@ public class InitializeParams {
   /**
    * The rootPath of the workspace. Is null if no folder is open.
    * 
-   * @deprecated in favour of rootUri.
+   * @deprecated Use rootUri instead.
    */
   @Pure
   @Deprecated
@@ -109,7 +119,7 @@ public class InitializeParams {
   /**
    * The rootPath of the workspace. Is null if no folder is open.
    * 
-   * @deprecated in favour of rootUri.
+   * @deprecated Use rootUri instead.
    */
   @Deprecated
   public void setRootPath(final String rootPath) {
@@ -166,6 +176,8 @@ public class InitializeParams {
   /**
    * An optional extension to the protocol.
    * To tell the server what client (editor) is talking to it.
+   * 
+   * @deprecated Use clientInfo instead.
    */
   @Pure
   @Deprecated
@@ -176,10 +188,31 @@ public class InitializeParams {
   /**
    * An optional extension to the protocol.
    * To tell the server what client (editor) is talking to it.
+   * 
+   * @deprecated Use clientInfo instead.
    */
   @Deprecated
   public void setClientName(final String clientName) {
     this.clientName = clientName;
+  }
+  
+  /**
+   * Information about the client
+   * 
+   * Since 3.15.0
+   */
+  @Pure
+  public ClientInfo getClientInfo() {
+    return this.clientInfo;
+  }
+  
+  /**
+   * Information about the client
+   * 
+   * Since 3.15.0
+   */
+  public void setClientInfo(final ClientInfo clientInfo) {
+    this.clientInfo = clientInfo;
   }
   
   /**
@@ -236,6 +269,7 @@ public class InitializeParams {
     b.add("initializationOptions", this.initializationOptions);
     b.add("capabilities", this.capabilities);
     b.add("clientName", this.clientName);
+    b.add("clientInfo", this.clientInfo);
     b.add("trace", this.trace);
     b.add("workspaceFolders", this.workspaceFolders);
     return b.toString();
@@ -281,6 +315,11 @@ public class InitializeParams {
         return false;
     } else if (!this.clientName.equals(other.clientName))
       return false;
+    if (this.clientInfo == null) {
+      if (other.clientInfo != null)
+        return false;
+    } else if (!this.clientInfo.equals(other.clientInfo))
+      return false;
     if (this.trace == null) {
       if (other.trace != null)
         return false;
@@ -305,6 +344,7 @@ public class InitializeParams {
     result = prime * result + ((this.initializationOptions== null) ? 0 : this.initializationOptions.hashCode());
     result = prime * result + ((this.capabilities== null) ? 0 : this.capabilities.hashCode());
     result = prime * result + ((this.clientName== null) ? 0 : this.clientName.hashCode());
+    result = prime * result + ((this.clientInfo== null) ? 0 : this.clientInfo.hashCode());
     result = prime * result + ((this.trace== null) ? 0 : this.trace.hashCode());
     return prime * result + ((this.workspaceFolders== null) ? 0 : this.workspaceFolders.hashCode());
   }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/InitializeResult.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/InitializeResult.java
@@ -12,6 +12,7 @@
 package org.eclipse.lsp4j;
 
 import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.ServerInfo;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
@@ -25,11 +26,23 @@ public class InitializeResult {
   @NonNull
   private ServerCapabilities capabilities;
   
+  /**
+   * Information about the server.
+   * 
+   * Since 3.15.0
+   */
+  private ServerInfo serverInfo;
+  
   public InitializeResult() {
   }
   
   public InitializeResult(@NonNull final ServerCapabilities capabilities) {
     this.capabilities = Preconditions.<ServerCapabilities>checkNotNull(capabilities, "capabilities");
+  }
+  
+  public InitializeResult(@NonNull final ServerCapabilities capabilities, final ServerInfo serverInfo) {
+    this(capabilities);
+    this.serverInfo = serverInfo;
   }
   
   /**
@@ -48,11 +61,31 @@ public class InitializeResult {
     this.capabilities = Preconditions.checkNotNull(capabilities, "capabilities");
   }
   
+  /**
+   * Information about the server.
+   * 
+   * Since 3.15.0
+   */
+  @Pure
+  public ServerInfo getServerInfo() {
+    return this.serverInfo;
+  }
+  
+  /**
+   * Information about the server.
+   * 
+   * Since 3.15.0
+   */
+  public void setServerInfo(final ServerInfo serverInfo) {
+    this.serverInfo = serverInfo;
+  }
+  
   @Override
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("capabilities", this.capabilities);
+    b.add("serverInfo", this.serverInfo);
     return b.toString();
   }
   
@@ -71,12 +104,20 @@ public class InitializeResult {
         return false;
     } else if (!this.capabilities.equals(other.capabilities))
       return false;
+    if (this.serverInfo == null) {
+      if (other.serverInfo != null)
+        return false;
+    } else if (!this.serverInfo.equals(other.serverInfo))
+      return false;
     return true;
   }
   
   @Override
   @Pure
   public int hashCode() {
-    return 31 * 1 + ((this.capabilities== null) ? 0 : this.capabilities.hashCode());
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.capabilities== null) ? 0 : this.capabilities.hashCode());
+    return prime * result + ((this.serverInfo== null) ? 0 : this.serverInfo.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/MarkedString.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/MarkedString.java
@@ -19,7 +19,7 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 /**
  * MarkedString can be used to render human readable text. It is either a markdown string
  * or a code-block that provides a language and a code snippet. The language identifier
- * is sematically equal to the optional language identifier in fenced code blocks in GitHub
+ * is semantically equal to the optional language identifier in fenced code blocks in GitHub
  * issues. See https://help.github.com/articles/creating-and-highlighting-code-blocks/#syntax-highlighting
  * 
  * The pair of a language and a value is an equivalent to markdown:
@@ -28,7 +28,10 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
  * ```
  * 
  * Note that markdown strings will be sanitized - that means html will be escaped.
+ * 
+ * @deprecated Use MarkupContent instead.
  */
+@Deprecated
 @SuppressWarnings("all")
 public class MarkedString {
   @NonNull

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/PublishDiagnosticsCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/PublishDiagnosticsCapabilities.java
@@ -27,10 +27,19 @@ public class PublishDiagnosticsCapabilities {
   
   /**
    * Client supports the tag property to provide meta data about a diagnostic.
+   * Clients supporting tags have to handle unknown tags gracefully.
    * 
    * Since 3.15
    */
   private DiagnosticsTagSupport tagSupport;
+  
+  /**
+   * Whether the client interprets the version property of the
+   * `textDocument/publishDiagnostics` notification's parameter.
+   * 
+   * Since 3.15.0
+   */
+  private Boolean versionSupport;
   
   public PublishDiagnosticsCapabilities() {
   }
@@ -40,8 +49,13 @@ public class PublishDiagnosticsCapabilities {
   }
   
   public PublishDiagnosticsCapabilities(final Boolean relatedInformation, final DiagnosticsTagSupport tagSupport) {
-    this.relatedInformation = relatedInformation;
+    this(relatedInformation);
     this.tagSupport = tagSupport;
+  }
+  
+  public PublishDiagnosticsCapabilities(final Boolean relatedInformation, final DiagnosticsTagSupport tagSupport, final Boolean versionSupport) {
+    this(relatedInformation, tagSupport);
+    this.versionSupport = versionSupport;
   }
   
   /**
@@ -61,6 +75,7 @@ public class PublishDiagnosticsCapabilities {
   
   /**
    * Client supports the tag property to provide meta data about a diagnostic.
+   * Clients supporting tags have to handle unknown tags gracefully.
    * 
    * Since 3.15
    */
@@ -71,11 +86,33 @@ public class PublishDiagnosticsCapabilities {
   
   /**
    * Client supports the tag property to provide meta data about a diagnostic.
+   * Clients supporting tags have to handle unknown tags gracefully.
    * 
    * Since 3.15
    */
   public void setTagSupport(final DiagnosticsTagSupport tagSupport) {
     this.tagSupport = tagSupport;
+  }
+  
+  /**
+   * Whether the client interprets the version property of the
+   * `textDocument/publishDiagnostics` notification's parameter.
+   * 
+   * Since 3.15.0
+   */
+  @Pure
+  public Boolean getVersionSupport() {
+    return this.versionSupport;
+  }
+  
+  /**
+   * Whether the client interprets the version property of the
+   * `textDocument/publishDiagnostics` notification's parameter.
+   * 
+   * Since 3.15.0
+   */
+  public void setVersionSupport(final Boolean versionSupport) {
+    this.versionSupport = versionSupport;
   }
   
   @Override
@@ -84,6 +121,7 @@ public class PublishDiagnosticsCapabilities {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("relatedInformation", this.relatedInformation);
     b.add("tagSupport", this.tagSupport);
+    b.add("versionSupport", this.versionSupport);
     return b.toString();
   }
   
@@ -107,6 +145,11 @@ public class PublishDiagnosticsCapabilities {
         return false;
     } else if (!this.tagSupport.equals(other.tagSupport))
       return false;
+    if (this.versionSupport == null) {
+      if (other.versionSupport != null)
+        return false;
+    } else if (!this.versionSupport.equals(other.versionSupport))
+      return false;
     return true;
   }
   
@@ -116,6 +159,7 @@ public class PublishDiagnosticsCapabilities {
     final int prime = 31;
     int result = 1;
     result = prime * result + ((this.relatedInformation== null) ? 0 : this.relatedInformation.hashCode());
-    return prime * result + ((this.tagSupport== null) ? 0 : this.tagSupport.hashCode());
+    result = prime * result + ((this.tagSupport== null) ? 0 : this.tagSupport.hashCode());
+    return prime * result + ((this.versionSupport== null) ? 0 : this.versionSupport.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/PublishDiagnosticsParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/PublishDiagnosticsParams.java
@@ -39,9 +39,9 @@ public class PublishDiagnosticsParams {
   /**
    * Optional the version number of the document the diagnostics are published for.
    * 
-   * @since 3.15.0
+   * Since 3.15.0
    */
-  private int version;
+  private Integer version;
   
   public PublishDiagnosticsParams() {
     ArrayList<Diagnostic> _arrayList = new ArrayList<Diagnostic>();
@@ -51,6 +51,11 @@ public class PublishDiagnosticsParams {
   public PublishDiagnosticsParams(@NonNull final String uri, @NonNull final List<Diagnostic> diagnostics) {
     this.uri = Preconditions.<String>checkNotNull(uri, "uri");
     this.diagnostics = Preconditions.<List<Diagnostic>>checkNotNull(diagnostics, "diagnostics");
+  }
+  
+  public PublishDiagnosticsParams(@NonNull final String uri, @NonNull final List<Diagnostic> diagnostics, final Integer version) {
+    this(uri, diagnostics);
+    this.version = version;
   }
   
   /**
@@ -88,19 +93,19 @@ public class PublishDiagnosticsParams {
   /**
    * Optional the version number of the document the diagnostics are published for.
    * 
-   * @since 3.15.0
+   * Since 3.15.0
    */
   @Pure
-  public int getVersion() {
+  public Integer getVersion() {
     return this.version;
   }
   
   /**
    * Optional the version number of the document the diagnostics are published for.
    * 
-   * @since 3.15.0
+   * Since 3.15.0
    */
-  public void setVersion(final int version) {
+  public void setVersion(final Integer version) {
     this.version = version;
   }
   
@@ -134,7 +139,10 @@ public class PublishDiagnosticsParams {
         return false;
     } else if (!this.diagnostics.equals(other.diagnostics))
       return false;
-    if (other.version != this.version)
+    if (this.version == null) {
+      if (other.version != null)
+        return false;
+    } else if (!this.version.equals(other.version))
       return false;
     return true;
   }
@@ -146,6 +154,6 @@ public class PublishDiagnosticsParams {
     int result = 1;
     result = prime * result + ((this.uri== null) ? 0 : this.uri.hashCode());
     result = prime * result + ((this.diagnostics== null) ? 0 : this.diagnostics.hashCode());
-    return prime * result + this.version;
+    return prime * result + ((this.version== null) ? 0 : this.version.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SelectionRange.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SelectionRange.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.lsp4j;
 
-import com.google.common.annotations.Beta;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.lsp4j.util.Preconditions;
@@ -22,7 +21,6 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
  * A selection range represents a part of a selection hierarchy. A selection range
  * may have a parent selection range that contains it.
  */
-@Beta
 @SuppressWarnings("all")
 public class SelectionRange {
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SelectionRangeCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SelectionRangeCapabilities.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.lsp4j;
 
-import com.google.common.annotations.Beta;
 import org.eclipse.lsp4j.DynamicRegistrationCapabilities;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -19,7 +18,6 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 /**
  * Capabilities specific to `textDocument/selectionRange` requests
  */
-@Beta
 @SuppressWarnings("all")
 public class SelectionRangeCapabilities extends DynamicRegistrationCapabilities {
   public SelectionRangeCapabilities() {

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SelectionRangeParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SelectionRangeParams.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.lsp4j;
 
-import com.google.common.annotations.Beta;
 import java.util.List;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
@@ -23,7 +22,6 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 /**
  * A parameter literal used in selection range requests.
  */
-@Beta
 @SuppressWarnings("all")
 public class SelectionRangeParams {
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ServerInfo.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ServerInfo.java
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) 2016-2018 TypeFox and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.lsp4j;
+
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+/**
+ * Information about the server.
+ * 
+ * Since 3.15.0
+ */
+@SuppressWarnings("all")
+public class ServerInfo {
+  /**
+   * The name of the server as defined by the server.
+   */
+  @NonNull
+  private String name;
+  
+  /**
+   * The server's version as defined by the server.
+   */
+  private String version;
+  
+  public ServerInfo() {
+  }
+  
+  public ServerInfo(@NonNull final String name) {
+    this.name = Preconditions.<String>checkNotNull(name, "name");
+  }
+  
+  public ServerInfo(@NonNull final String name, final String version) {
+    this(name);
+    this.version = version;
+  }
+  
+  /**
+   * The name of the server as defined by the server.
+   */
+  @Pure
+  @NonNull
+  public String getName() {
+    return this.name;
+  }
+  
+  /**
+   * The name of the server as defined by the server.
+   */
+  public void setName(@NonNull final String name) {
+    this.name = Preconditions.checkNotNull(name, "name");
+  }
+  
+  /**
+   * The server's version as defined by the server.
+   */
+  @Pure
+  public String getVersion() {
+    return this.version;
+  }
+  
+  /**
+   * The server's version as defined by the server.
+   */
+  public void setVersion(final String version) {
+    this.version = version;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("name", this.name);
+    b.add("version", this.version);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    ServerInfo other = (ServerInfo) obj;
+    if (this.name == null) {
+      if (other.name != null)
+        return false;
+    } else if (!this.name.equals(other.name))
+      return false;
+    if (this.version == null) {
+      if (other.version != null)
+        return false;
+    } else if (!this.version.equals(other.version))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.name== null) ? 0 : this.name.hashCode());
+    return prime * result + ((this.version== null) ? 0 : this.version.hashCode());
+  }
+}

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureHelp.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureHelp.java
@@ -38,7 +38,7 @@ public class SignatureHelp {
    * make an active decision about the active signature and shouldn't
    * rely on a default value.
    * In future version of the protocol this property might become
-   * mandantory to better express this.
+   * mandatory to better express this.
    */
   private Integer activeSignature;
   
@@ -48,7 +48,7 @@ public class SignatureHelp {
    * defaults to 0 if the active signature has parameters. If
    * the active signature has no parameters it is ignored.
    * In future version of the protocol this property might become
-   * mandantory to better express the active parameter if the
+   * mandatory to better express the active parameter if the
    * active signature does have any.
    */
   private Integer activeParameter;
@@ -87,7 +87,7 @@ public class SignatureHelp {
    * make an active decision about the active signature and shouldn't
    * rely on a default value.
    * In future version of the protocol this property might become
-   * mandantory to better express this.
+   * mandatory to better express this.
    */
   @Pure
   public Integer getActiveSignature() {
@@ -101,7 +101,7 @@ public class SignatureHelp {
    * make an active decision about the active signature and shouldn't
    * rely on a default value.
    * In future version of the protocol this property might become
-   * mandantory to better express this.
+   * mandatory to better express this.
    */
   public void setActiveSignature(final Integer activeSignature) {
     this.activeSignature = activeSignature;
@@ -113,7 +113,7 @@ public class SignatureHelp {
    * defaults to 0 if the active signature has parameters. If
    * the active signature has no parameters it is ignored.
    * In future version of the protocol this property might become
-   * mandantory to better express the active parameter if the
+   * mandatory to better express the active parameter if the
    * active signature does have any.
    */
   @Pure
@@ -127,7 +127,7 @@ public class SignatureHelp {
    * defaults to 0 if the active signature has parameters. If
    * the active signature has no parameters it is ignored.
    * In future version of the protocol this property might become
-   * mandantory to better express the active parameter if the
+   * mandatory to better express the active parameter if the
    * active signature does have any.
    */
   public void setActiveParameter(final Integer activeParameter) {

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureHelpCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureHelpCapabilities.java
@@ -27,6 +27,16 @@ public class SignatureHelpCapabilities extends DynamicRegistrationCapabilities {
    */
   private SignatureInformationCapabilities signatureInformation;
   
+  /**
+   * The client supports to send additional context information for a
+   * `textDocument/signatureHelp` request. A client that opts into
+   * contextSupport will also support the `retriggerCharacters` on
+   * `SignatureHelpOptions`.
+   * 
+   * Since 3.15.0
+   */
+  private Boolean contextSupport;
+  
   public SignatureHelpCapabilities() {
   }
   
@@ -56,11 +66,37 @@ public class SignatureHelpCapabilities extends DynamicRegistrationCapabilities {
     this.signatureInformation = signatureInformation;
   }
   
+  /**
+   * The client supports to send additional context information for a
+   * `textDocument/signatureHelp` request. A client that opts into
+   * contextSupport will also support the `retriggerCharacters` on
+   * `SignatureHelpOptions`.
+   * 
+   * Since 3.15.0
+   */
+  @Pure
+  public Boolean getContextSupport() {
+    return this.contextSupport;
+  }
+  
+  /**
+   * The client supports to send additional context information for a
+   * `textDocument/signatureHelp` request. A client that opts into
+   * contextSupport will also support the `retriggerCharacters` on
+   * `SignatureHelpOptions`.
+   * 
+   * Since 3.15.0
+   */
+  public void setContextSupport(final Boolean contextSupport) {
+    this.contextSupport = contextSupport;
+  }
+  
   @Override
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("signatureInformation", this.signatureInformation);
+    b.add("contextSupport", this.contextSupport);
     b.add("dynamicRegistration", getDynamicRegistration());
     return b.toString();
   }
@@ -82,12 +118,20 @@ public class SignatureHelpCapabilities extends DynamicRegistrationCapabilities {
         return false;
     } else if (!this.signatureInformation.equals(other.signatureInformation))
       return false;
+    if (this.contextSupport == null) {
+      if (other.contextSupport != null)
+        return false;
+    } else if (!this.contextSupport.equals(other.contextSupport))
+      return false;
     return true;
   }
   
   @Override
   @Pure
   public int hashCode() {
-    return 31 * super.hashCode() + ((this.signatureInformation== null) ? 0 : this.signatureInformation.hashCode());
+    final int prime = 31;
+    int result = super.hashCode();
+    result = prime * result + ((this.signatureInformation== null) ? 0 : this.signatureInformation.hashCode());
+    return prime * result + ((this.contextSupport== null) ? 0 : this.contextSupport.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureHelpContext.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureHelpContext.java
@@ -1,0 +1,193 @@
+/**
+ * Copyright (c) 2016-2018 TypeFox and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.lsp4j;
+
+import org.eclipse.lsp4j.SignatureHelp;
+import org.eclipse.lsp4j.SignatureHelpTriggerKind;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+/**
+ * Additional information about the context in which a signature help request was triggered.
+ * 
+ * Since 3.15.0
+ */
+@SuppressWarnings("all")
+public class SignatureHelpContext {
+  /**
+   * Action that caused signature help to be triggered.
+   */
+  @NonNull
+  private SignatureHelpTriggerKind triggerKind;
+  
+  /**
+   * Character that caused signature help to be triggered.
+   * 
+   * This is undefined when `triggerKind !== SignatureHelpTriggerKind.TriggerCharacter`
+   */
+  private String triggerCharacter;
+  
+  /**
+   * `true` if signature help was already showing when it was triggered.
+   * 
+   * Retriggers occur when the signature help is already active and can be caused by actions such as
+   * typing a trigger character, a cursor move, or document content changes.
+   */
+  private boolean isRetrigger;
+  
+  /**
+   * The currently active `SignatureHelp`.
+   * 
+   * The `activeSignatureHelp` has its `SignatureHelp.activeSignature` field updated based on
+   * the user navigating through available signatures.
+   */
+  private SignatureHelp activeSignatureHelp;
+  
+  public SignatureHelpContext() {
+  }
+  
+  public SignatureHelpContext(@NonNull final SignatureHelpTriggerKind triggerKind, final boolean isRetrigger) {
+    this.triggerKind = triggerKind;
+    this.isRetrigger = isRetrigger;
+  }
+  
+  /**
+   * Action that caused signature help to be triggered.
+   */
+  @Pure
+  @NonNull
+  public SignatureHelpTriggerKind getTriggerKind() {
+    return this.triggerKind;
+  }
+  
+  /**
+   * Action that caused signature help to be triggered.
+   */
+  public void setTriggerKind(@NonNull final SignatureHelpTriggerKind triggerKind) {
+    this.triggerKind = Preconditions.checkNotNull(triggerKind, "triggerKind");
+  }
+  
+  /**
+   * Character that caused signature help to be triggered.
+   * 
+   * This is undefined when `triggerKind !== SignatureHelpTriggerKind.TriggerCharacter`
+   */
+  @Pure
+  public String getTriggerCharacter() {
+    return this.triggerCharacter;
+  }
+  
+  /**
+   * Character that caused signature help to be triggered.
+   * 
+   * This is undefined when `triggerKind !== SignatureHelpTriggerKind.TriggerCharacter`
+   */
+  public void setTriggerCharacter(final String triggerCharacter) {
+    this.triggerCharacter = triggerCharacter;
+  }
+  
+  /**
+   * `true` if signature help was already showing when it was triggered.
+   * 
+   * Retriggers occur when the signature help is already active and can be caused by actions such as
+   * typing a trigger character, a cursor move, or document content changes.
+   */
+  @Pure
+  public boolean isRetrigger() {
+    return this.isRetrigger;
+  }
+  
+  /**
+   * `true` if signature help was already showing when it was triggered.
+   * 
+   * Retriggers occur when the signature help is already active and can be caused by actions such as
+   * typing a trigger character, a cursor move, or document content changes.
+   */
+  public void setIsRetrigger(final boolean isRetrigger) {
+    this.isRetrigger = isRetrigger;
+  }
+  
+  /**
+   * The currently active `SignatureHelp`.
+   * 
+   * The `activeSignatureHelp` has its `SignatureHelp.activeSignature` field updated based on
+   * the user navigating through available signatures.
+   */
+  @Pure
+  public SignatureHelp getActiveSignatureHelp() {
+    return this.activeSignatureHelp;
+  }
+  
+  /**
+   * The currently active `SignatureHelp`.
+   * 
+   * The `activeSignatureHelp` has its `SignatureHelp.activeSignature` field updated based on
+   * the user navigating through available signatures.
+   */
+  public void setActiveSignatureHelp(final SignatureHelp activeSignatureHelp) {
+    this.activeSignatureHelp = activeSignatureHelp;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("triggerKind", this.triggerKind);
+    b.add("triggerCharacter", this.triggerCharacter);
+    b.add("isRetrigger", this.isRetrigger);
+    b.add("activeSignatureHelp", this.activeSignatureHelp);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    SignatureHelpContext other = (SignatureHelpContext) obj;
+    if (this.triggerKind == null) {
+      if (other.triggerKind != null)
+        return false;
+    } else if (!this.triggerKind.equals(other.triggerKind))
+      return false;
+    if (this.triggerCharacter == null) {
+      if (other.triggerCharacter != null)
+        return false;
+    } else if (!this.triggerCharacter.equals(other.triggerCharacter))
+      return false;
+    if (other.isRetrigger != this.isRetrigger)
+      return false;
+    if (this.activeSignatureHelp == null) {
+      if (other.activeSignatureHelp != null)
+        return false;
+    } else if (!this.activeSignatureHelp.equals(other.activeSignatureHelp))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.triggerKind== null) ? 0 : this.triggerKind.hashCode());
+    result = prime * result + ((this.triggerCharacter== null) ? 0 : this.triggerCharacter.hashCode());
+    result = prime * result + (this.isRetrigger ? 1231 : 1237);
+    return prime * result + ((this.activeSignatureHelp== null) ? 0 : this.activeSignatureHelp.hashCode());
+  }
+}

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureHelpOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureHelpOptions.java
@@ -25,11 +25,26 @@ public class SignatureHelpOptions {
    */
   private List<String> triggerCharacters;
   
+  /**
+   * List of characters that re-trigger signature help.
+   * 
+   * These trigger characters are only active when signature help is already showing. All trigger characters
+   * are also counted as re-trigger characters.
+   * 
+   * Since 3.15.0
+   */
+  private List<String> retriggerCharacters;
+  
   public SignatureHelpOptions() {
   }
   
   public SignatureHelpOptions(final List<String> triggerCharacters) {
     this.triggerCharacters = triggerCharacters;
+  }
+  
+  public SignatureHelpOptions(final List<String> triggerCharacters, final List<String> retriggerCharacters) {
+    this(triggerCharacters);
+    this.retriggerCharacters = retriggerCharacters;
   }
   
   /**
@@ -47,11 +62,37 @@ public class SignatureHelpOptions {
     this.triggerCharacters = triggerCharacters;
   }
   
+  /**
+   * List of characters that re-trigger signature help.
+   * 
+   * These trigger characters are only active when signature help is already showing. All trigger characters
+   * are also counted as re-trigger characters.
+   * 
+   * Since 3.15.0
+   */
+  @Pure
+  public List<String> getRetriggerCharacters() {
+    return this.retriggerCharacters;
+  }
+  
+  /**
+   * List of characters that re-trigger signature help.
+   * 
+   * These trigger characters are only active when signature help is already showing. All trigger characters
+   * are also counted as re-trigger characters.
+   * 
+   * Since 3.15.0
+   */
+  public void setRetriggerCharacters(final List<String> retriggerCharacters) {
+    this.retriggerCharacters = retriggerCharacters;
+  }
+  
   @Override
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("triggerCharacters", this.triggerCharacters);
+    b.add("retriggerCharacters", this.retriggerCharacters);
     return b.toString();
   }
   
@@ -70,12 +111,20 @@ public class SignatureHelpOptions {
         return false;
     } else if (!this.triggerCharacters.equals(other.triggerCharacters))
       return false;
+    if (this.retriggerCharacters == null) {
+      if (other.retriggerCharacters != null)
+        return false;
+    } else if (!this.retriggerCharacters.equals(other.retriggerCharacters))
+      return false;
     return true;
   }
   
   @Override
   @Pure
   public int hashCode() {
-    return 31 * 1 + ((this.triggerCharacters== null) ? 0 : this.triggerCharacters.hashCode());
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((this.triggerCharacters== null) ? 0 : this.triggerCharacters.hashCode());
+    return prime * result + ((this.retriggerCharacters== null) ? 0 : this.retriggerCharacters.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureHelpParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureHelpParams.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2016-2018 TypeFox and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.lsp4j;
+
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.SignatureHelpContext;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextDocumentPositionParams;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+/**
+ * The signature help request is sent from the client to the server to request signature information at a given cursor position.
+ */
+@SuppressWarnings("all")
+public class SignatureHelpParams extends TextDocumentPositionParams {
+  /**
+   * The signature help context. This is only available if the client specifies
+   * to send this using the client capability  `textDocument.signatureHelp.contextSupport === true`
+   * 
+   * Since 3.15.0
+   */
+  private SignatureHelpContext context;
+  
+  public SignatureHelpParams() {
+  }
+  
+  public SignatureHelpParams(@NonNull final TextDocumentIdentifier textDocument, @NonNull final Position position) {
+    super(textDocument, position);
+  }
+  
+  public SignatureHelpParams(@NonNull final TextDocumentIdentifier textDocument, @NonNull final Position position, final SignatureHelpContext context) {
+    super(textDocument, position);
+    this.context = context;
+  }
+  
+  /**
+   * The signature help context. This is only available if the client specifies
+   * to send this using the client capability  `textDocument.signatureHelp.contextSupport === true`
+   * 
+   * Since 3.15.0
+   */
+  @Pure
+  public SignatureHelpContext getContext() {
+    return this.context;
+  }
+  
+  /**
+   * The signature help context. This is only available if the client specifies
+   * to send this using the client capability  `textDocument.signatureHelp.contextSupport === true`
+   * 
+   * Since 3.15.0
+   */
+  public void setContext(final SignatureHelpContext context) {
+    this.context = context;
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("context", this.context);
+    b.add("textDocument", getTextDocument());
+    b.add("uri", getUri());
+    b.add("position", getPosition());
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    if (!super.equals(obj))
+      return false;
+    SignatureHelpParams other = (SignatureHelpParams) obj;
+    if (this.context == null) {
+      if (other.context != null)
+        return false;
+    } else if (!this.context.equals(other.context))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * super.hashCode() + ((this.context== null) ? 0 : this.context.hashCode());
+  }
+}

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentClientCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentClientCapabilities.java
@@ -181,7 +181,6 @@ public class TextDocumentClientCapabilities {
   /**
    * Capabilities specific to `textDocument/selectionRange` requests
    */
-  @Beta
   private SelectionRangeCapabilities selectionRange;
   
   @Pure

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentContentChangeEvent.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentContentChangeEvent.java
@@ -30,7 +30,10 @@ public class TextDocumentContentChangeEvent {
   
   /**
    * The length of the range that got replaced.
+   * 
+   * @deprecated Use range instead.
    */
+  @Deprecated
   private Integer rangeLength;
   
   /**
@@ -69,15 +72,21 @@ public class TextDocumentContentChangeEvent {
   
   /**
    * The length of the range that got replaced.
+   * 
+   * @deprecated Use range instead.
    */
   @Pure
+  @Deprecated
   public Integer getRangeLength() {
     return this.rangeLength;
   }
   
   /**
    * The length of the range that got replaced.
+   * 
+   * @deprecated Use range instead.
    */
+  @Deprecated
   public void setRangeLength(final Integer rangeLength) {
     this.rangeLength = rangeLength;
   }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/WorkspaceFoldersOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/WorkspaceFoldersOptions.java
@@ -32,7 +32,7 @@ public class WorkspaceFoldersOptions {
    * change notifications.
    * 
    * If a string is provided, the string is treated as an ID
-   * under which the notification is registed on the client
+   * under which the notification is registered on the client
    * side. The ID can be used to unregister for these events
    * using the `client/unregisterCapability` request.
    */
@@ -58,7 +58,7 @@ public class WorkspaceFoldersOptions {
    * change notifications.
    * 
    * If a string is provided, the string is treated as an ID
-   * under which the notification is registed on the client
+   * under which the notification is registered on the client
    * side. The ID can be used to unregister for these events
    * using the `client/unregisterCapability` request.
    */
@@ -72,7 +72,7 @@ public class WorkspaceFoldersOptions {
    * change notifications.
    * 
    * If a string is provided, the string is treated as an ID
-   * under which the notification is registed on the client
+   * under which the notification is registered on the client
    * side. The ID can be used to unregister for these events
    * using the `client/unregisterCapability` request.
    */

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/WorkspaceSymbolParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/WorkspaceSymbolParams.java
@@ -22,7 +22,8 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 @SuppressWarnings("all")
 public class WorkspaceSymbolParams {
   /**
-   * A non-empty query string
+   * A query string to filter symbols by. Clients may send an empty
+   * string here to request all symbols.
    */
   @NonNull
   private String query;
@@ -35,7 +36,8 @@ public class WorkspaceSymbolParams {
   }
   
   /**
-   * A non-empty query string
+   * A query string to filter symbols by. Clients may send an empty
+   * string here to request all symbols.
    */
   @Pure
   @NonNull
@@ -44,7 +46,8 @@ public class WorkspaceSymbolParams {
   }
   
   /**
-   * A non-empty query string
+   * A query string to filter symbols by. Clients may send an empty
+   * string here to request all symbols.
    */
   public void setQuery(@NonNull final String query) {
     this.query = Preconditions.checkNotNull(query, "query");

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/adapters/InitializeParamsTypeAdapter.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/adapters/InitializeParamsTypeAdapter.java
@@ -22,6 +22,7 @@ import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
 import java.util.List;
 import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.ClientInfo;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.generator.TypeAdapterImpl;
@@ -104,6 +105,9 @@ public class InitializeParamsTypeAdapter extends TypeAdapter<InitializeParams> {
     	case "clientName":
     		result.setClientName(readClientName(in));
     		break;
+    	case "clientInfo":
+    		result.setClientInfo(readClientInfo(in));
+    		break;
     	case "trace":
     		result.setTrace(readTrace(in));
     		break;
@@ -138,6 +142,10 @@ public class InitializeParamsTypeAdapter extends TypeAdapter<InitializeParams> {
     return gson.fromJson(in, String.class);
   }
   
+  protected ClientInfo readClientInfo(final JsonReader in) throws IOException {
+    return gson.fromJson(in, ClientInfo.class);
+  }
+  
   protected String readTrace(final JsonReader in) throws IOException {
     return gson.fromJson(in, String.class);
   }
@@ -165,6 +173,8 @@ public class InitializeParamsTypeAdapter extends TypeAdapter<InitializeParams> {
     writeCapabilities(out, value.getCapabilities());
     out.name("clientName");
     writeClientName(out, value.getClientName());
+    out.name("clientInfo");
+    writeClientInfo(out, value.getClientInfo());
     out.name("trace");
     writeTrace(out, value.getTrace());
     out.name("workspaceFolders");
@@ -189,6 +199,10 @@ public class InitializeParamsTypeAdapter extends TypeAdapter<InitializeParams> {
   
   protected void writeClientName(final JsonWriter out, final String value) throws IOException {
     out.value(value);
+  }
+  
+  protected void writeClientInfo(final JsonWriter out, final ClientInfo value) throws IOException {
+    gson.toJson(value, ClientInfo.class, out);
   }
   
   protected void writeTrace(final JsonWriter out, final String value) throws IOException {


### PR DESCRIPTION
I went through most of the [LSP 3.15](https://microsoft.github.io/language-server-protocol/specifications/specification-3-15/) changes and below is the summary of my changes:

* Removed `@Beta`from `textDocument/selectionRange` items
* Add support for server and client information.
* Add signature help context.
* Fixed `version` on `PublishDiagnosticsParams`  (see below) and added missing client capability.
* Add CodeAction#isPreferred support.
* Add CompletionItem#tag support.
* Add DocumentLink#tooltip support.
* Add trimTrailingWhitespace, insertFinalNewline and trimFinalNewlines to FormattingOptions.
* Clarified WorkspaceSymbolParams#query parameter.
* Deprecated `MarkedString`
* Deprecated `rangeLength` in `TextDocumentContentChangeEvent`
* Misc. spelling/grammar fixes

Breaking API changes (stable):
 * `valueSet` of `CodeActionKindCapabilities` set to `@NonNull`
 * Signature of `textDocument/signatureHelp` changed from `signatureHelp(TextDocumentPositionParams position)` to `signatureHelp(SignatureHelpParams params)`

Breaking API changes (preview):
 * `valueSet` of `DiagnosticTagSupport` set to `@NonNull`
 * `version` of `PublishDiagnosticsParams` changed from `int` to `Integer`

Still missing for complete 3.15:
 * [General Progress Support](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#progress)
 * [Work Done Progress](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workDoneProgress)
 * [Partial Result Progress](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#partialResults)