### PR TITLE
Fix tests regarding os specific line endings

### DIFF
--- a/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/RemoteEndpointTest.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/RemoteEndpointTest.java
@@ -213,7 +213,7 @@ public class RemoteEndpointTest {
 			assertEquals(ResponseErrorCode.InternalError.getValue(), response.getError().getCode());
 			String exception = (String) response.getError().getData();
 			String expected = "java.lang.RuntimeException: BAAZ\n\tat org.eclipse.lsp4j.jsonrpc.test.RemoteEndpointTest";
-			assertEquals(expected, exception.substring(0, expected.length()));
+			assertEquals(expected, exception.replaceAll("\\r", "").substring(0, expected.length()));
 		} finally {
 			logMessages.unregister();
 		}

--- a/org.eclipse.lsp4j/src/test/java/org/eclipse/lsp4j/test/LSPEndpointTest.xtend
+++ b/org.eclipse.lsp4j/src/test/java/org/eclipse/lsp4j/test/LSPEndpointTest.xtend
@@ -72,7 +72,7 @@ class LSPEndpointTest {
 			assertEquals('''
 				Lists must not contain null references. Path: $.result.contents[0]
 				Lists must not contain null references. Path: $.result.contents[1]
-			'''.toString.trim, exception.cause.message)
+			'''.toString.replaceAll("\\r", "").trim, exception.cause.message)
 			assertFalse(future.isDone)
 		} finally {
 			in.close()


### PR DESCRIPTION
On Windows two tests fail because additional
\r chars are being used for new lines.
To fix this issue those chars are being
removed from exception texts.