### PR TITLE
Remove @Beta from selectionRangeProvider

### DIFF
--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -855,6 +855,8 @@ class RenameCapabilities extends DynamicRegistrationCapabilities {
 	/**
 	 * Client supports testing for validity of rename operations
 	 * before execution.
+	 * 
+	 * Since 3.12.0
 	 */
 	Boolean prepareSupport
 
@@ -1016,6 +1018,8 @@ class CallHierarchyCapabilities extends DynamicRegistrationCapabilities {
 
 /**
  * Capabilities specific to `textDocument/selectionRange` requests
+ * 
+ * Since 3.15.0
  */
 @JsonRpcData
 class SelectionRangeCapabilities extends DynamicRegistrationCapabilities {
@@ -1168,8 +1172,10 @@ class TextDocumentClientCapabilities {
 	
 	/**
 	 * Capabilities specific to `textDocument/selectionRange` requests
+	 * 
+	 * Since 3.15.0
 	 */
-	SelectionRangeCapabilities  selectionRange
+	SelectionRangeCapabilities selectionRange
 }
 
 /**
@@ -1682,6 +1688,8 @@ class Diagnostic {
 
 	/**
 	 * Additional metadata about the diagnostic.
+	 * 
+	 * Since 3.15.0
 	 */
 	 List<DiagnosticTag> tags;
 
@@ -3372,8 +3380,9 @@ class ServerCapabilities {
 	
 	/**
 	 * The server provides selection range support.
+	 *
+	 * Since 3.15.0
 	 */
-	@Beta
 	Either<Boolean, StaticRegistrationOptions> selectionRangeProvider
 
 	/**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Diagnostic.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Diagnostic.java
@@ -56,6 +56,8 @@ public class Diagnostic {
   
   /**
    * Additional metadata about the diagnostic.
+   * 
+   * Since 3.15.0
    */
   private List<DiagnosticTag> tags;
   
@@ -167,6 +169,8 @@ public class Diagnostic {
   
   /**
    * Additional metadata about the diagnostic.
+   * 
+   * Since 3.15.0
    */
   @Pure
   public List<DiagnosticTag> getTags() {
@@ -175,6 +179,8 @@ public class Diagnostic {
   
   /**
    * Additional metadata about the diagnostic.
+   * 
+   * Since 3.15.0
    */
   public void setTags(final List<DiagnosticTag> tags) {
     this.tags = tags;

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/RenameCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/RenameCapabilities.java
@@ -23,6 +23,8 @@ public class RenameCapabilities extends DynamicRegistrationCapabilities {
   /**
    * Client supports testing for validity of rename operations
    * before execution.
+   * 
+   * Since 3.12.0
    */
   private Boolean prepareSupport;
   
@@ -41,6 +43,8 @@ public class RenameCapabilities extends DynamicRegistrationCapabilities {
   /**
    * Client supports testing for validity of rename operations
    * before execution.
+   * 
+   * Since 3.12.0
    */
   @Pure
   public Boolean getPrepareSupport() {
@@ -50,6 +54,8 @@ public class RenameCapabilities extends DynamicRegistrationCapabilities {
   /**
    * Client supports testing for validity of rename operations
    * before execution.
+   * 
+   * Since 3.12.0
    */
   public void setPrepareSupport(final Boolean prepareSupport) {
     this.prepareSupport = prepareSupport;

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SelectionRangeCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SelectionRangeCapabilities.java
@@ -17,6 +17,8 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
  * Capabilities specific to `textDocument/selectionRange` requests
+ * 
+ * Since 3.15.0
  */
 @SuppressWarnings("all")
 public class SelectionRangeCapabilities extends DynamicRegistrationCapabilities {

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ServerCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ServerCapabilities.java
@@ -189,8 +189,9 @@ public class ServerCapabilities {
   
   /**
    * The server provides selection range support.
+   * 
+   * Since 3.15.0
    */
-  @Beta
   private Either<Boolean, StaticRegistrationOptions> selectionRangeProvider;
   
   /**
@@ -789,6 +790,8 @@ public class ServerCapabilities {
   
   /**
    * The server provides selection range support.
+   * 
+   * Since 3.15.0
    */
   @Pure
   public Either<Boolean, StaticRegistrationOptions> getSelectionRangeProvider() {
@@ -797,6 +800,8 @@ public class ServerCapabilities {
   
   /**
    * The server provides selection range support.
+   * 
+   * Since 3.15.0
    */
   public void setSelectionRangeProvider(final Either<Boolean, StaticRegistrationOptions> selectionRangeProvider) {
     this.selectionRangeProvider = selectionRangeProvider;

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentClientCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentClientCapabilities.java
@@ -180,6 +180,8 @@ public class TextDocumentClientCapabilities {
   
   /**
    * Capabilities specific to `textDocument/selectionRange` requests
+   * 
+   * Since 3.15.0
    */
   private SelectionRangeCapabilities selectionRange;
   
@@ -565,6 +567,8 @@ public class TextDocumentClientCapabilities {
   
   /**
    * Capabilities specific to `textDocument/selectionRange` requests
+   * 
+   * Since 3.15.0
    */
   @Pure
   public SelectionRangeCapabilities getSelectionRange() {
@@ -573,6 +577,8 @@ public class TextDocumentClientCapabilities {
   
   /**
    * Capabilities specific to `textDocument/selectionRange` requests
+   * 
+   * Since 3.15.0
    */
   public void setSelectionRange(final SelectionRangeCapabilities selectionRange) {
     this.selectionRange = selectionRange;


### PR DESCRIPTION
When I was removing the beta tags for selection range, I seem to have overlooked this one. I also added some missing "Since" doc strings while I was looking over what else might have been missed.