### PR TITLE
Deprecate deprecated

### DIFF
--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionItem.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionItem.java
@@ -64,7 +64,10 @@ public class CompletionItem {
   
   /**
    * Indicates if this item is deprecated.
+   *
+   * @deprecated Use `tags` instead if supported.
    */
+  @Deprecated
   private Boolean deprecated;
   
   /**


### PR DESCRIPTION
According to https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_completion the `deprecated` field in `CompletionItem` should be deprecated in favor of using `tags`.