### PR TITLE
Params updates

### DIFF
--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -1473,7 +1473,6 @@ class CodeActionContext {
  */
 @JsonRpcData
 class CodeActionParams extends WorkDoneProgressAndPartialResultParams {
-
 	/**
 	 * The document in which the command was invoked.
 	 */
@@ -1586,7 +1585,6 @@ class CodeLensOptions extends AbstractWorkDoneProgressOptions {
  */
 @JsonRpcData
 class CodeLensParams extends WorkDoneProgressAndPartialResultParams {
-
 	/**
 	 * The document to request code lens for.
 	 */
@@ -2150,8 +2148,12 @@ class WillSaveTextDocumentParams {
  * The document formatting request is sent from the server to the client to format a whole document.
  */
 @JsonRpcData
-class DocumentFormattingParams {
-	
+class DocumentFormattingParams implements WorkDoneProgressParams {
+	/**
+	 * An optional token that a server can use to report work done progress.
+	 */
+	Either<String, Number> workDoneToken
+
 	/**
 	 * The document to format.
 	 */
@@ -2266,7 +2268,6 @@ class DocumentLink {
  */
 @JsonRpcData
 class DocumentLinkParams extends WorkDoneProgressAndPartialResultParams {
-	
 	/**
 	 * The document to provide document links for.
 	 */
@@ -2440,13 +2441,12 @@ class DocumentOnTypeFormattingOptions {
  * The document on type formatting request is sent from the client to the server to format parts of the document during typing.
  */
 @JsonRpcData
-class DocumentOnTypeFormattingParams extends DocumentFormattingParams {
-	
+class DocumentOnTypeFormattingParams extends TextDocumentPositionParams {
 	/**
-	 * The position at which this request was send.
+	 * The format options
 	 */
 	@NonNull
-	Position position
+	FormattingOptions options
 
 	/**
 	 * The character that has been typed.
@@ -2458,14 +2458,14 @@ class DocumentOnTypeFormattingParams extends DocumentFormattingParams {
 	}
 
 	new(@NonNull TextDocumentIdentifier textDocument, @NonNull FormattingOptions options, @NonNull Position position, @NonNull String ch) {
-		super(textDocument, options)
-		this.position = Preconditions.checkNotNull(position, 'position')
+		super(textDocument, position)
+		this.options = Preconditions.checkNotNull(options, 'options')
 		this.ch = Preconditions.checkNotNull(ch, 'ch')
 	}
 
 	@Deprecated
 	new(@NonNull Position position, @NonNull String ch) {
-		this.position = Preconditions.checkNotNull(position, 'position')
+		super.setPosition(position)
 		this.ch = Preconditions.checkNotNull(ch, 'ch')
 	}
 }
@@ -2474,10 +2474,24 @@ class DocumentOnTypeFormattingParams extends DocumentFormattingParams {
  * The document range formatting request is sent from the client to the server to format a given range in a document.
  */
 @JsonRpcData
-class DocumentRangeFormattingParams extends DocumentFormattingParams implements WorkDoneProgressParams {
-	
+class DocumentRangeFormattingParams implements WorkDoneProgressParams {
+	/**
+	 * An optional token that a server can use to report work done progress.
+	 */
 	Either<String, Number> workDoneToken
-	
+
+	/**
+	 * The document to format.
+	 */
+	@NonNull
+	TextDocumentIdentifier textDocument
+
+	/**
+	 * The format options
+	 */
+	@NonNull
+	FormattingOptions options
+
 	/**
 	 * The range to format
 	 */
@@ -2488,7 +2502,8 @@ class DocumentRangeFormattingParams extends DocumentFormattingParams implements 
 	}
 
 	new(@NonNull TextDocumentIdentifier textDocument, @NonNull FormattingOptions options, @NonNull Range range) {
-		super(textDocument, options)
+		this.textDocument = Preconditions.checkNotNull(textDocument, 'textDocument')
+		this.options = Preconditions.checkNotNull(options, 'options')
 		this.range = Preconditions.checkNotNull(range, 'range')
 	}
 
@@ -2503,9 +2518,9 @@ class DocumentRangeFormattingParams extends DocumentFormattingParams implements 
  * a give cursor location in the text document. The request would also allow to specify if the item should be resolved
  * and whether sub- or supertypes are to be resolved.
  */
+@Beta
 @JsonRpcData
 class TypeHierarchyParams extends TextDocumentPositionParams {
-
 	/**
 	 * The number of hierarchy levels to resolve. {@code 0} indicates no hierarchy level. It defaults to {@code 0}.
 	 */
@@ -2515,7 +2530,6 @@ class TypeHierarchyParams extends TextDocumentPositionParams {
 	 * The direction of the type hierarchy resolution. If not defined, defaults to {@link TypeHierarchyDirection#Children Children}.
 	 */
 	TypeHierarchyDirection direction
-
 }
 
 /**
@@ -2523,9 +2537,9 @@ class TypeHierarchyParams extends TextDocumentPositionParams {
  * {@link TypeHierarchyItem#getParents parents} or the {@link TypeHierarchyItem#getChildren children} is not
  * defined. If resolved and no {@code parents} or {@code children} are available then an empty list is returned.
  */
+@Beta
 @JsonRpcData
 class ResolveTypeHierarchyItemParams {
-
 	/**
 	 * The hierarchy item to resolve.
 	 */
@@ -2551,7 +2565,6 @@ class ResolveTypeHierarchyItemParams {
 		this.resolve = resolve
 		this.direction = Preconditions.checkNotNull(direction, 'direction')
 	}
-
 }
 
 @JsonRpcData
@@ -2567,7 +2580,6 @@ class DocumentSymbolRegistrationOptions extends AbstractTextDocumentRegistration
  */
 @JsonRpcData
 class DocumentSymbolParams extends WorkDoneProgressAndPartialResultParams {
-
 	/**
 	 * The text document.
 	 */
@@ -3008,19 +3020,24 @@ class WorkDoneProgressEnd implements WorkDoneProgressNotification {
 }
 
 /**
- * The base protocol offers also support to report progress in a generic fashion. 
- * This mechanism can be used to report any kind of progress including work done progress 
- * (usually used to report progress in the user interface using a progress bar) 
- * and partial result progress to support streaming of results. 
+ * The base protocol offers also support to report progress in a generic fashion.
+ * This mechanism can be used to report any kind of progress including work done progress
+ * (usually used to report progress in the user interface using a progress bar)
+ * and partial result progress to support streaming of results.
  * A progress notification has the following properties:
- * 
+ *
  * Since 3.15.0
  */
 @JsonRpcData
 class ProgressParams {
-
+	/**
+	 * The progress token provided by the client or server.
+	 */
 	Either<String, Number> token
 
+	/**
+	 * The progress data.
+	 */
 	@JsonAdapter(WorkDoneProgressNotificationAdapter.Factory)
 	WorkDoneProgressNotification value;
 
@@ -3031,13 +3048,12 @@ class ProgressParams {
 		this.token = token
 		this.value = value
 	}
-
 }
 
 
 /**
  * A parameter literal used to pass a work done progress token.
- * 
+ *
  * Since 3.15.0
  */
 interface WorkDoneProgressParams {
@@ -3045,9 +3061,11 @@ interface WorkDoneProgressParams {
 	 * An optional token that a server can use to report work done progress.
 	 */
 	def Either<String, Number> getWorkDoneToken()
-	
+
+	/**
+	 * An optional token that a server can use to report work done progress.
+	 */
 	def void setWorkDoneToken(Either<String, Number> token)
-	
 }
 
 /**
@@ -3094,7 +3112,7 @@ abstract class AbstractTextDocumentRegistrationAndWorkDoneProgressOptions extend
 
 /**
  * A parameter literal used to pass a partial result token.
- * 
+ *
  * Since 3.15.0
  */
 interface PartialResultParams {
@@ -3103,34 +3121,45 @@ interface PartialResultParams {
 	 * the client.
 	 */
 	def Either<String, Number> getPartialResultToken()
-	
+
+	/**
+	 * An optional token that a server can use to report partial results (e.g. streaming) to
+	 * the client.
+	 */
 	def void setPartialResultToken(Either<String, Number> token)
 }
 
 /**
  * Abstract class which implements work done progress and partial result request parameter.
  * It is not present in protocol specification, so it's just "dry" class.
- * 
+ *
  * Since 3.15.0
  */
 @JsonRpcData
 abstract class WorkDoneProgressAndPartialResultParams implements WorkDoneProgressParams, PartialResultParams {
-	
+	/**
+	 * An optional token that a server can use to report work done progress.
+	 */
 	Either<String, Number> workDoneToken
-	
+
+	/**
+	 * An optional token that a server can use to report partial results (e.g. streaming) to
+	 * the client.
+	 */
 	Either<String, Number> partialResultToken
-	
 }
 
 /**
  * Abstract class which extends TextDocumentPosition and implements work done progress request parameter.
  * It is not present in protocol specification, so it's just "dry" class.
- * 
+ *
  * Since 3.15.0
  */
 @JsonRpcData
 abstract class TextDocumentPositionAndWorkDoneProgressParams extends TextDocumentPositionParams implements WorkDoneProgressParams {
-
+	/**
+	 * An optional token that a server can use to report work done progress.
+	 */
 	Either<String, Number> workDoneToken
 
 	new() {
@@ -3138,35 +3167,28 @@ abstract class TextDocumentPositionAndWorkDoneProgressParams extends TextDocumen
 
 	new(@NonNull TextDocumentIdentifier textDocument, @NonNull Position position) {
 		super(textDocument, position)
-	}
-
-	@Deprecated
-	new(@NonNull TextDocumentIdentifier textDocument, String uri, @NonNull Position position) {
-		super(textDocument, uri, position)
 	}
 }
 
 /**
  * Abstract class which extends TextDocumentPosition and implements work done progress and partial result request parameter.
  * It is not present in protocol specification, so it's just "dry" class.
- * 
+ *
  * Since 3.15.0
  */
 @JsonRpcData
 abstract class TextDocumentPositionAndWorkDoneProgressAndPartialResultParams extends TextDocumentPositionAndWorkDoneProgressParams implements PartialResultParams {
-
+	/**
+	 * An optional token that a server can use to report partial results (e.g. streaming) to
+	 * the client.
+	 */
 	Either<String, Number> partialResultToken
-	
+
 	new() {
 	}
 
 	new(@NonNull TextDocumentIdentifier textDocument, @NonNull Position position) {
 		super(textDocument, position)
-	}
-
-	@Deprecated
-	new(@NonNull TextDocumentIdentifier textDocument, String uri, @NonNull Position position) {
-		super(textDocument, uri, position)
 	}
 }
 
@@ -3208,9 +3230,11 @@ interface InitializeErrorCode {
 @JsonRpcData
 @JsonAdapter(InitializeParamsTypeAdapter.Factory)
 class InitializeParams implements WorkDoneProgressParams {
-	
+	/**
+	 * An optional token that a server can use to report work done progress.
+	 */
 	Either<String, Number> workDoneToken
-	
+
 	/**
 	 * The process Id of the parent process that started the server.
 	 */
@@ -3273,7 +3297,6 @@ class InitializeParams implements WorkDoneProgressParams {
 	 * Since 3.6.0
 	 */
 	List<WorkspaceFolder> workspaceFolders
-
 }
 
 @JsonRpcData
@@ -3652,7 +3675,6 @@ class ReferenceRegistrationOptions extends AbstractTextDocumentRegistrationAndWo
  */
 @JsonRpcData
 class ReferenceParams extends TextDocumentPositionAndWorkDoneProgressAndPartialResultParams {
-	
 	@NonNull
 	ReferenceContext context
 
@@ -3698,7 +3720,6 @@ class PrepareRenameResult {
  */
 @JsonRpcData
 class RenameParams extends TextDocumentPositionAndWorkDoneProgressParams {
-
 	/**
 	 * The new name of the symbol. If the given name is not valid the request must return a
 	 * ResponseError with an appropriate message set.
@@ -4072,7 +4093,6 @@ class ShowMessageRequestParams extends MessageParams {
  */
 @JsonRpcData
 class SignatureHelpParams extends TextDocumentPositionAndWorkDoneProgressParams {
-
 	/**
 	 * The signature help context. This is only available if the client specifies
 	 * to send this using the client capability  `textDocument.signatureHelp.contextSupport === true`
@@ -4089,18 +4109,19 @@ class SignatureHelpParams extends TextDocumentPositionAndWorkDoneProgressParams 
 	}
 
 	new(@NonNull TextDocumentIdentifier textDocument, @NonNull Position position, SignatureHelpContext context) {
-		super(textDocument, position)
+		this(textDocument, position)
 		this.context = context
 	}
 }
 
 /**
- * @since 3.16.0
+ * The request is sent from the client to the server to resolve semantic tokens for a given whole file.
+ *
+ * Since 3.16.0
  */
 @Beta
 @JsonRpcData
 class SemanticTokensParams extends WorkDoneProgressAndPartialResultParams {
-
 	/**
 	 * The text document.
 	 */
@@ -4159,12 +4180,13 @@ class SemanticTokensPartialResult {
 }
 
 /**
- * @since 3.16.0
+ * The request is sent from the client to the server to resolve semantic token deltas for a given whole file.
+ *
+ * Since 3.16.0
  */
 @Beta
 @JsonRpcData
 class SemanticTokensDeltaParams extends WorkDoneProgressAndPartialResultParams {
-
 	/**
 	 * The text document.
 	 */
@@ -4173,7 +4195,7 @@ class SemanticTokensDeltaParams extends WorkDoneProgressAndPartialResultParams {
 
 	/**
 	 * The result id of a previous response. The result Id can either point to a full response
-	 * or a delta response depending on what was recevied last.
+	 * or a delta response depending on what was received last.
 	 */
 	@NonNull
 	String previousResultId
@@ -4182,7 +4204,6 @@ class SemanticTokensDeltaParams extends WorkDoneProgressAndPartialResultParams {
 		this.textDocument = Preconditions.checkNotNull(textDocument, 'textDocument')
 		this.previousResultId = Preconditions.checkNotNull(previousResultId, 'previousResultId')
 	}
-
 }
 
 /**
@@ -4255,12 +4276,13 @@ class SemanticTokensDeltaPartialResult {
 }
 
 /**
- * @since 3.16.0
+ * The request is sent from the client to the server to resolve semantic tokens for a range in a given file.
+ *
+ * Since 3.16.0
  */
 @Beta
 @JsonRpcData
 class SemanticTokensRangeParams extends WorkDoneProgressAndPartialResultParams {
-
 	/**
 	 * The text document.
 	 */
@@ -4448,6 +4470,7 @@ class SignatureInformation {
 /**
  * Representation of an item that carries type information (such as class, interface, enumeration, etc) with additional parentage details.
  */
+@Beta
 @JsonRpcData
 class TypeHierarchyItem {
 
@@ -4755,7 +4778,6 @@ class TextDocumentItem {
  */
 @JsonRpcData
 class TextDocumentPositionParams {
-	
 	/**
 	 * The text document.
 	 */
@@ -4791,9 +4813,11 @@ class TextDocumentPositionParams {
 }
 
 
+/**
+ * The Completion request is sent from the client to the server to compute completion items at a given cursor position.
+ */
 @JsonRpcData
 class CompletionParams extends TextDocumentPositionAndWorkDoneProgressAndPartialResultParams {
-	
 	/**
 	 * The completion context. This is only available it the client specifies
 	 * to send this using `ClientCapabilities.textDocument.completion.contextSupport === true`
@@ -4808,7 +4832,7 @@ class CompletionParams extends TextDocumentPositionAndWorkDoneProgressAndPartial
 	}
 
 	new(@NonNull TextDocumentIdentifier textDocument, @NonNull Position position, CompletionContext context) {
-		super(textDocument, position)
+		this(textDocument, position)
 		this.context = context
 	}
 }
@@ -5212,7 +5236,6 @@ class WorkspaceSymbolRegistrationOptions extends WorkspaceSymbolOptions {
  */
 @JsonRpcData
 class WorkspaceSymbolParams extends WorkDoneProgressAndPartialResultParams {
-
 	/**
 	 * A query string to filter symbols by. Clients may send an empty
 	 * string here to request all symbols.
@@ -5525,9 +5548,11 @@ class DocumentOnTypeFormattingRegistrationOptions extends TextDocumentRegistrati
  */
 @JsonRpcData
 class ExecuteCommandParams implements WorkDoneProgressParams {
-	
+	/**
+	 * An optional token that a server can use to report work done progress.
+	 */
 	Either<String, Number> workDoneToken
-	
+
 	/**
 	 * The identifier of the actual command handler.
 	 */
@@ -5548,10 +5573,9 @@ class ExecuteCommandParams implements WorkDoneProgressParams {
 		this.command = Preconditions.checkNotNull(command, 'command')
 		this.arguments = arguments
 	}
-	
+
 	new(@NonNull String command, List<Object> arguments, Either<String, Number> workDoneToken) {
-		this.command = Preconditions.checkNotNull(command, 'command')
-		this.arguments = arguments
+		this(command, arguments)
 		this.workDoneToken = workDoneToken
 	}
 }
@@ -5770,7 +5794,6 @@ class ConfigurationItem {
  */
 @JsonRpcData
 class DocumentColorParams extends WorkDoneProgressAndPartialResultParams {
-
 	/**
 	 * The text document.
 	 */
@@ -5852,7 +5875,6 @@ class Color {
  */
 @JsonRpcData
 class ColorPresentationParams extends WorkDoneProgressAndPartialResultParams {
-
 	/**
 	 * The text document.
 	 */
@@ -5928,7 +5950,6 @@ class ColorPresentation {
  */
 @JsonRpcData
 class FoldingRangeRequestParams extends WorkDoneProgressAndPartialResultParams {
-
 	/**
 	 * The text document.
 	 */
@@ -6200,7 +6221,6 @@ class CallHierarchyItem {
  */
 @JsonRpcData
 class SelectionRangeParams extends WorkDoneProgressAndPartialResultParams {
-
 	/**
 	 * The text document.
 	 */
@@ -6269,7 +6289,6 @@ class HoverRegistrationOptions extends AbstractTextDocumentRegistrationAndWorkDo
  */
 @JsonRpcData
 class HoverParams extends TextDocumentPositionAndWorkDoneProgressParams {
-	
 	new() {
 	}
 
@@ -6292,7 +6311,6 @@ class DeclarationRegistrationOptions extends AbstractTextDocumentRegistrationAnd
  */
 @JsonRpcData
 class DeclarationParams extends TextDocumentPositionAndWorkDoneProgressAndPartialResultParams {
-	
 	new() {
 	}
 
@@ -6311,11 +6329,10 @@ class DefinitionRegistrationOptions extends AbstractTextDocumentRegistrationAndW
 
 /**
  * The go to definition request is sent from the client to the server to resolve the definition
- *  location of a symbol at a given text document position.
+ * location of a symbol at a given text document position.
  */
 @JsonRpcData
 class DefinitionParams extends TextDocumentPositionAndWorkDoneProgressAndPartialResultParams {
-	
 	new() {
 	}
 
@@ -6338,7 +6355,6 @@ class TypeDefinitionRegistrationOptions extends AbstractTextDocumentRegistration
  */
 @JsonRpcData
 class TypeDefinitionParams extends TextDocumentPositionAndWorkDoneProgressAndPartialResultParams {
-	
 	new() {
 	}
 
@@ -6361,7 +6377,6 @@ class ImplementationRegistrationOptions extends AbstractTextDocumentRegistration
  */
 @JsonRpcData
 class ImplementationParams extends TextDocumentPositionAndWorkDoneProgressAndPartialResultParams {
-	
 	new() {
 	}
 
@@ -6384,7 +6399,6 @@ class DocumentHighlightRegistrationOptions extends AbstractTextDocumentRegistrat
  */
 @JsonRpcData
 class DocumentHighlightParams extends TextDocumentPositionAndWorkDoneProgressAndPartialResultParams {
-	
 	new() {
 	}
 
@@ -6428,7 +6442,7 @@ class WorkDoneProgressCancelParams {
 	* The token to be used to report progress.
 	*/
 	Either<String, Number> token
-	
+
 	new() {
 	}
 

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionParams.java
@@ -19,6 +19,9 @@ import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
+/**
+ * The Completion request is sent from the client to the server to compute completion items at a given cursor position.
+ */
 @SuppressWarnings("all")
 public class CompletionParams extends TextDocumentPositionAndWorkDoneProgressAndPartialResultParams {
   /**
@@ -35,7 +38,7 @@ public class CompletionParams extends TextDocumentPositionAndWorkDoneProgressAnd
   }
   
   public CompletionParams(@NonNull final TextDocumentIdentifier textDocument, @NonNull final Position position, final CompletionContext context) {
-    super(textDocument, position);
+    this(textDocument, position);
     this.context = context;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DefinitionParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DefinitionParams.java
@@ -20,7 +20,7 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
  * The go to definition request is sent from the client to the server to resolve the definition
- *  location of a symbol at a given text document position.
+ * location of a symbol at a given text document position.
  */
 @SuppressWarnings("all")
 public class DefinitionParams extends TextDocumentPositionAndWorkDoneProgressAndPartialResultParams {

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentFormattingParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentFormattingParams.java
@@ -13,6 +13,8 @@ package org.eclipse.lsp4j;
 
 import org.eclipse.lsp4j.FormattingOptions;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.WorkDoneProgressParams;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
@@ -22,7 +24,12 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
  * The document formatting request is sent from the server to the client to format a whole document.
  */
 @SuppressWarnings("all")
-public class DocumentFormattingParams {
+public class DocumentFormattingParams implements WorkDoneProgressParams {
+  /**
+   * An optional token that a server can use to report work done progress.
+   */
+  private Either<String, Number> workDoneToken;
+  
   /**
    * The document to format.
    */
@@ -41,6 +48,37 @@ public class DocumentFormattingParams {
   public DocumentFormattingParams(@NonNull final TextDocumentIdentifier textDocument, @NonNull final FormattingOptions options) {
     this.textDocument = Preconditions.<TextDocumentIdentifier>checkNotNull(textDocument, "textDocument");
     this.options = Preconditions.<FormattingOptions>checkNotNull(options, "options");
+  }
+  
+  /**
+   * An optional token that a server can use to report work done progress.
+   */
+  @Pure
+  public Either<String, Number> getWorkDoneToken() {
+    return this.workDoneToken;
+  }
+  
+  /**
+   * An optional token that a server can use to report work done progress.
+   */
+  public void setWorkDoneToken(final Either<String, Number> workDoneToken) {
+    this.workDoneToken = workDoneToken;
+  }
+  
+  public void setWorkDoneToken(final String workDoneToken) {
+    if (workDoneToken == null) {
+      this.workDoneToken = null;
+      return;
+    }
+    this.workDoneToken = Either.forLeft(workDoneToken);
+  }
+  
+  public void setWorkDoneToken(final Number workDoneToken) {
+    if (workDoneToken == null) {
+      this.workDoneToken = null;
+      return;
+    }
+    this.workDoneToken = Either.forRight(workDoneToken);
   }
   
   /**
@@ -79,6 +117,7 @@ public class DocumentFormattingParams {
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
+    b.add("workDoneToken", this.workDoneToken);
     b.add("textDocument", this.textDocument);
     b.add("options", this.options);
     return b.toString();
@@ -94,6 +133,11 @@ public class DocumentFormattingParams {
     if (getClass() != obj.getClass())
       return false;
     DocumentFormattingParams other = (DocumentFormattingParams) obj;
+    if (this.workDoneToken == null) {
+      if (other.workDoneToken != null)
+        return false;
+    } else if (!this.workDoneToken.equals(other.workDoneToken))
+      return false;
     if (this.textDocument == null) {
       if (other.textDocument != null)
         return false;
@@ -112,6 +156,7 @@ public class DocumentFormattingParams {
   public int hashCode() {
     final int prime = 31;
     int result = 1;
+    result = prime * result + ((this.workDoneToken== null) ? 0 : this.workDoneToken.hashCode());
     result = prime * result + ((this.textDocument== null) ? 0 : this.textDocument.hashCode());
     return prime * result + ((this.options== null) ? 0 : this.options.hashCode());
   }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentOnTypeFormattingParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentOnTypeFormattingParams.java
@@ -11,10 +11,10 @@
  */
 package org.eclipse.lsp4j;
 
-import org.eclipse.lsp4j.DocumentFormattingParams;
 import org.eclipse.lsp4j.FormattingOptions;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextDocumentPositionParams;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
@@ -24,12 +24,12 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
  * The document on type formatting request is sent from the client to the server to format parts of the document during typing.
  */
 @SuppressWarnings("all")
-public class DocumentOnTypeFormattingParams extends DocumentFormattingParams {
+public class DocumentOnTypeFormattingParams extends TextDocumentPositionParams {
   /**
-   * The position at which this request was send.
+   * The format options
    */
   @NonNull
-  private Position position;
+  private FormattingOptions options;
   
   /**
    * The character that has been typed.
@@ -41,31 +41,31 @@ public class DocumentOnTypeFormattingParams extends DocumentFormattingParams {
   }
   
   public DocumentOnTypeFormattingParams(@NonNull final TextDocumentIdentifier textDocument, @NonNull final FormattingOptions options, @NonNull final Position position, @NonNull final String ch) {
-    super(textDocument, options);
-    this.position = Preconditions.<Position>checkNotNull(position, "position");
+    super(textDocument, position);
+    this.options = Preconditions.<FormattingOptions>checkNotNull(options, "options");
     this.ch = Preconditions.<String>checkNotNull(ch, "ch");
   }
   
   @Deprecated
   public DocumentOnTypeFormattingParams(@NonNull final Position position, @NonNull final String ch) {
-    this.position = Preconditions.<Position>checkNotNull(position, "position");
+    super.setPosition(position);
     this.ch = Preconditions.<String>checkNotNull(ch, "ch");
   }
   
   /**
-   * The position at which this request was send.
+   * The format options
    */
   @Pure
   @NonNull
-  public Position getPosition() {
-    return this.position;
+  public FormattingOptions getOptions() {
+    return this.options;
   }
   
   /**
-   * The position at which this request was send.
+   * The format options
    */
-  public void setPosition(@NonNull final Position position) {
-    this.position = Preconditions.checkNotNull(position, "position");
+  public void setOptions(@NonNull final FormattingOptions options) {
+    this.options = Preconditions.checkNotNull(options, "options");
   }
   
   /**
@@ -88,10 +88,11 @@ public class DocumentOnTypeFormattingParams extends DocumentFormattingParams {
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
-    b.add("position", this.position);
+    b.add("options", this.options);
     b.add("ch", this.ch);
     b.add("textDocument", getTextDocument());
-    b.add("options", getOptions());
+    b.add("uri", getUri());
+    b.add("position", getPosition());
     return b.toString();
   }
   
@@ -107,10 +108,10 @@ public class DocumentOnTypeFormattingParams extends DocumentFormattingParams {
     if (!super.equals(obj))
       return false;
     DocumentOnTypeFormattingParams other = (DocumentOnTypeFormattingParams) obj;
-    if (this.position == null) {
-      if (other.position != null)
+    if (this.options == null) {
+      if (other.options != null)
         return false;
-    } else if (!this.position.equals(other.position))
+    } else if (!this.options.equals(other.options))
       return false;
     if (this.ch == null) {
       if (other.ch != null)
@@ -125,7 +126,7 @@ public class DocumentOnTypeFormattingParams extends DocumentFormattingParams {
   public int hashCode() {
     final int prime = 31;
     int result = super.hashCode();
-    result = prime * result + ((this.position== null) ? 0 : this.position.hashCode());
+    result = prime * result + ((this.options== null) ? 0 : this.options.hashCode());
     return prime * result + ((this.ch== null) ? 0 : this.ch.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentRangeFormattingParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentRangeFormattingParams.java
@@ -11,7 +11,6 @@
  */
 package org.eclipse.lsp4j;
 
-import org.eclipse.lsp4j.DocumentFormattingParams;
 import org.eclipse.lsp4j.FormattingOptions;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
@@ -26,8 +25,23 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
  * The document range formatting request is sent from the client to the server to format a given range in a document.
  */
 @SuppressWarnings("all")
-public class DocumentRangeFormattingParams extends DocumentFormattingParams implements WorkDoneProgressParams {
+public class DocumentRangeFormattingParams implements WorkDoneProgressParams {
+  /**
+   * An optional token that a server can use to report work done progress.
+   */
   private Either<String, Number> workDoneToken;
+  
+  /**
+   * The document to format.
+   */
+  @NonNull
+  private TextDocumentIdentifier textDocument;
+  
+  /**
+   * The format options
+   */
+  @NonNull
+  private FormattingOptions options;
   
   /**
    * The range to format
@@ -39,7 +53,8 @@ public class DocumentRangeFormattingParams extends DocumentFormattingParams impl
   }
   
   public DocumentRangeFormattingParams(@NonNull final TextDocumentIdentifier textDocument, @NonNull final FormattingOptions options, @NonNull final Range range) {
-    super(textDocument, options);
+    this.textDocument = Preconditions.<TextDocumentIdentifier>checkNotNull(textDocument, "textDocument");
+    this.options = Preconditions.<FormattingOptions>checkNotNull(options, "options");
     this.range = Preconditions.<Range>checkNotNull(range, "range");
   }
   
@@ -48,11 +63,17 @@ public class DocumentRangeFormattingParams extends DocumentFormattingParams impl
     this.range = Preconditions.<Range>checkNotNull(range, "range");
   }
   
+  /**
+   * An optional token that a server can use to report work done progress.
+   */
   @Pure
   public Either<String, Number> getWorkDoneToken() {
     return this.workDoneToken;
   }
   
+  /**
+   * An optional token that a server can use to report work done progress.
+   */
   public void setWorkDoneToken(final Either<String, Number> workDoneToken) {
     this.workDoneToken = workDoneToken;
   }
@@ -71,6 +92,38 @@ public class DocumentRangeFormattingParams extends DocumentFormattingParams impl
       return;
     }
     this.workDoneToken = Either.forRight(workDoneToken);
+  }
+  
+  /**
+   * The document to format.
+   */
+  @Pure
+  @NonNull
+  public TextDocumentIdentifier getTextDocument() {
+    return this.textDocument;
+  }
+  
+  /**
+   * The document to format.
+   */
+  public void setTextDocument(@NonNull final TextDocumentIdentifier textDocument) {
+    this.textDocument = Preconditions.checkNotNull(textDocument, "textDocument");
+  }
+  
+  /**
+   * The format options
+   */
+  @Pure
+  @NonNull
+  public FormattingOptions getOptions() {
+    return this.options;
+  }
+  
+  /**
+   * The format options
+   */
+  public void setOptions(@NonNull final FormattingOptions options) {
+    this.options = Preconditions.checkNotNull(options, "options");
   }
   
   /**
@@ -94,9 +147,9 @@ public class DocumentRangeFormattingParams extends DocumentFormattingParams impl
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("workDoneToken", this.workDoneToken);
+    b.add("textDocument", this.textDocument);
+    b.add("options", this.options);
     b.add("range", this.range);
-    b.add("textDocument", getTextDocument());
-    b.add("options", getOptions());
     return b.toString();
   }
   
@@ -109,13 +162,21 @@ public class DocumentRangeFormattingParams extends DocumentFormattingParams impl
       return false;
     if (getClass() != obj.getClass())
       return false;
-    if (!super.equals(obj))
-      return false;
     DocumentRangeFormattingParams other = (DocumentRangeFormattingParams) obj;
     if (this.workDoneToken == null) {
       if (other.workDoneToken != null)
         return false;
     } else if (!this.workDoneToken.equals(other.workDoneToken))
+      return false;
+    if (this.textDocument == null) {
+      if (other.textDocument != null)
+        return false;
+    } else if (!this.textDocument.equals(other.textDocument))
+      return false;
+    if (this.options == null) {
+      if (other.options != null)
+        return false;
+    } else if (!this.options.equals(other.options))
       return false;
     if (this.range == null) {
       if (other.range != null)
@@ -129,8 +190,10 @@ public class DocumentRangeFormattingParams extends DocumentFormattingParams impl
   @Pure
   public int hashCode() {
     final int prime = 31;
-    int result = super.hashCode();
+    int result = 1;
     result = prime * result + ((this.workDoneToken== null) ? 0 : this.workDoneToken.hashCode());
+    result = prime * result + ((this.textDocument== null) ? 0 : this.textDocument.hashCode());
+    result = prime * result + ((this.options== null) ? 0 : this.options.hashCode());
     return prime * result + ((this.range== null) ? 0 : this.range.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ExecuteCommandParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ExecuteCommandParams.java
@@ -27,6 +27,9 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
  */
 @SuppressWarnings("all")
 public class ExecuteCommandParams implements WorkDoneProgressParams {
+  /**
+   * An optional token that a server can use to report work done progress.
+   */
   private Either<String, Number> workDoneToken;
   
   /**
@@ -51,16 +54,21 @@ public class ExecuteCommandParams implements WorkDoneProgressParams {
   }
   
   public ExecuteCommandParams(@NonNull final String command, final List<Object> arguments, final Either<String, Number> workDoneToken) {
-    this.command = Preconditions.<String>checkNotNull(command, "command");
-    this.arguments = arguments;
+    this(command, arguments);
     this.workDoneToken = workDoneToken;
   }
   
+  /**
+   * An optional token that a server can use to report work done progress.
+   */
   @Pure
   public Either<String, Number> getWorkDoneToken() {
     return this.workDoneToken;
   }
   
+  /**
+   * An optional token that a server can use to report work done progress.
+   */
   public void setWorkDoneToken(final Either<String, Number> workDoneToken) {
     this.workDoneToken = workDoneToken;
   }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/InitializeParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/InitializeParams.java
@@ -29,6 +29,9 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 @JsonAdapter(InitializeParamsTypeAdapter.Factory.class)
 @SuppressWarnings("all")
 public class InitializeParams implements WorkDoneProgressParams {
+  /**
+   * An optional token that a server can use to report work done progress.
+   */
   private Either<String, Number> workDoneToken;
   
   /**
@@ -94,11 +97,17 @@ public class InitializeParams implements WorkDoneProgressParams {
    */
   private List<WorkspaceFolder> workspaceFolders;
   
+  /**
+   * An optional token that a server can use to report work done progress.
+   */
   @Pure
   public Either<String, Number> getWorkDoneToken() {
     return this.workDoneToken;
   }
   
+  /**
+   * An optional token that a server can use to report work done progress.
+   */
   public void setWorkDoneToken(final Either<String, Number> workDoneToken) {
     this.workDoneToken = workDoneToken;
   }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/PartialResultParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/PartialResultParams.java
@@ -26,5 +26,9 @@ public interface PartialResultParams {
    */
   public abstract Either<String, Number> getPartialResultToken();
   
+  /**
+   * An optional token that a server can use to report partial results (e.g. streaming) to
+   * the client.
+   */
   public abstract void setPartialResultToken(final Either<String, Number> token);
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ProgressParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ProgressParams.java
@@ -30,8 +30,14 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
  */
 @SuppressWarnings("all")
 public class ProgressParams {
+  /**
+   * The progress token provided by the client or server.
+   */
   private Either<String, Number> token;
   
+  /**
+   * The progress data.
+   */
   @JsonAdapter(WorkDoneProgressNotificationAdapter.Factory.class)
   private WorkDoneProgressNotification value;
   
@@ -43,11 +49,17 @@ public class ProgressParams {
     this.value = value;
   }
   
+  /**
+   * The progress token provided by the client or server.
+   */
   @Pure
   public Either<String, Number> getToken() {
     return this.token;
   }
   
+  /**
+   * The progress token provided by the client or server.
+   */
   public void setToken(final Either<String, Number> token) {
     this.token = token;
   }
@@ -68,11 +80,17 @@ public class ProgressParams {
     this.token = Either.forRight(token);
   }
   
+  /**
+   * The progress data.
+   */
   @Pure
   public WorkDoneProgressNotification getValue() {
     return this.value;
   }
   
+  /**
+   * The progress data.
+   */
   public void setValue(final WorkDoneProgressNotification value) {
     this.value = value;
   }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ResolveTypeHierarchyItemParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ResolveTypeHierarchyItemParams.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j;
 
+import com.google.common.annotations.Beta;
 import org.eclipse.lsp4j.TypeHierarchyDirection;
 import org.eclipse.lsp4j.TypeHierarchyItem;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
@@ -23,6 +24,7 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
  * {@link TypeHierarchyItem#getParents parents} or the {@link TypeHierarchyItem#getChildren children} is not
  * defined. If resolved and no {@code parents} or {@code children} are available then an empty list is returned.
  */
+@Beta
 @SuppressWarnings("all")
 public class ResolveTypeHierarchyItemParams {
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SemanticTokensDeltaParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SemanticTokensDeltaParams.java
@@ -20,7 +20,9 @@ import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
- * @since 3.16.0
+ * The request is sent from the client to the server to resolve semantic token deltas for a given whole file.
+ * 
+ * Since 3.16.0
  */
 @Beta
 @SuppressWarnings("all")
@@ -33,7 +35,7 @@ public class SemanticTokensDeltaParams extends WorkDoneProgressAndPartialResultP
   
   /**
    * The result id of a previous response. The result Id can either point to a full response
-   * or a delta response depending on what was recevied last.
+   * or a delta response depending on what was received last.
    */
   @NonNull
   private String previousResultId;
@@ -61,7 +63,7 @@ public class SemanticTokensDeltaParams extends WorkDoneProgressAndPartialResultP
   
   /**
    * The result id of a previous response. The result Id can either point to a full response
-   * or a delta response depending on what was recevied last.
+   * or a delta response depending on what was received last.
    */
   @Pure
   @NonNull
@@ -71,7 +73,7 @@ public class SemanticTokensDeltaParams extends WorkDoneProgressAndPartialResultP
   
   /**
    * The result id of a previous response. The result Id can either point to a full response
-   * or a delta response depending on what was recevied last.
+   * or a delta response depending on what was received last.
    */
   public void setPreviousResultId(@NonNull final String previousResultId) {
     this.previousResultId = Preconditions.checkNotNull(previousResultId, "previousResultId");

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SemanticTokensParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SemanticTokensParams.java
@@ -20,7 +20,9 @@ import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
- * @since 3.16.0
+ * The request is sent from the client to the server to resolve semantic tokens for a given whole file.
+ * 
+ * Since 3.16.0
  */
 @Beta
 @SuppressWarnings("all")

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SemanticTokensRangeParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SemanticTokensRangeParams.java
@@ -21,7 +21,9 @@ import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
- * @since 3.16.0
+ * The request is sent from the client to the server to resolve semantic tokens for a range in a given file.
+ * 
+ * Since 3.16.0
  */
 @Beta
 @SuppressWarnings("all")

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureHelpParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureHelpParams.java
@@ -40,7 +40,7 @@ public class SignatureHelpParams extends TextDocumentPositionAndWorkDoneProgress
   }
   
   public SignatureHelpParams(@NonNull final TextDocumentIdentifier textDocument, @NonNull final Position position, final SignatureHelpContext context) {
-    super(textDocument, position);
+    this(textDocument, position);
     this.context = context;
   }
   

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentPositionAndWorkDoneProgressAndPartialResultParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentPositionAndWorkDoneProgressAndPartialResultParams.java
@@ -28,6 +28,10 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
  */
 @SuppressWarnings("all")
 public abstract class TextDocumentPositionAndWorkDoneProgressAndPartialResultParams extends TextDocumentPositionAndWorkDoneProgressParams implements PartialResultParams {
+  /**
+   * An optional token that a server can use to report partial results (e.g. streaming) to
+   * the client.
+   */
   private Either<String, Number> partialResultToken;
   
   public TextDocumentPositionAndWorkDoneProgressAndPartialResultParams() {
@@ -37,16 +41,19 @@ public abstract class TextDocumentPositionAndWorkDoneProgressAndPartialResultPar
     super(textDocument, position);
   }
   
-  @Deprecated
-  public TextDocumentPositionAndWorkDoneProgressAndPartialResultParams(@NonNull final TextDocumentIdentifier textDocument, final String uri, @NonNull final Position position) {
-    super(textDocument, uri, position);
-  }
-  
+  /**
+   * An optional token that a server can use to report partial results (e.g. streaming) to
+   * the client.
+   */
   @Pure
   public Either<String, Number> getPartialResultToken() {
     return this.partialResultToken;
   }
   
+  /**
+   * An optional token that a server can use to report partial results (e.g. streaming) to
+   * the client.
+   */
   public void setPartialResultToken(final Either<String, Number> partialResultToken) {
     this.partialResultToken = partialResultToken;
   }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentPositionAndWorkDoneProgressParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentPositionAndWorkDoneProgressParams.java
@@ -28,6 +28,9 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
  */
 @SuppressWarnings("all")
 public abstract class TextDocumentPositionAndWorkDoneProgressParams extends TextDocumentPositionParams implements WorkDoneProgressParams {
+  /**
+   * An optional token that a server can use to report work done progress.
+   */
   private Either<String, Number> workDoneToken;
   
   public TextDocumentPositionAndWorkDoneProgressParams() {
@@ -37,16 +40,17 @@ public abstract class TextDocumentPositionAndWorkDoneProgressParams extends Text
     super(textDocument, position);
   }
   
-  @Deprecated
-  public TextDocumentPositionAndWorkDoneProgressParams(@NonNull final TextDocumentIdentifier textDocument, final String uri, @NonNull final Position position) {
-    super(textDocument, uri, position);
-  }
-  
+  /**
+   * An optional token that a server can use to report work done progress.
+   */
   @Pure
   public Either<String, Number> getWorkDoneToken() {
     return this.workDoneToken;
   }
   
+  /**
+   * An optional token that a server can use to report work done progress.
+   */
   public void setWorkDoneToken(final Either<String, Number> workDoneToken) {
     this.workDoneToken = workDoneToken;
   }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TypeHierarchyItem.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TypeHierarchyItem.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j;
 
+import com.google.common.annotations.Beta;
 import com.google.gson.annotations.JsonAdapter;
 import java.util.List;
 import org.eclipse.lsp4j.Range;
@@ -24,6 +25,7 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 /**
  * Representation of an item that carries type information (such as class, interface, enumeration, etc) with additional parentage details.
  */
+@Beta
 @SuppressWarnings("all")
 public class TypeHierarchyItem {
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TypeHierarchyParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TypeHierarchyParams.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j;
 
+import com.google.common.annotations.Beta;
 import org.eclipse.lsp4j.TextDocumentPositionParams;
 import org.eclipse.lsp4j.TypeHierarchyDirection;
 import org.eclipse.xtext.xbase.lib.Pure;
@@ -21,6 +22,7 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
  * a give cursor location in the text document. The request would also allow to specify if the item should be resolved
  * and whether sub- or supertypes are to be resolved.
  */
+@Beta
 @SuppressWarnings("all")
 public class TypeHierarchyParams extends TextDocumentPositionParams {
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/WorkDoneProgressAndPartialResultParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/WorkDoneProgressAndPartialResultParams.java
@@ -25,15 +25,28 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
  */
 @SuppressWarnings("all")
 public abstract class WorkDoneProgressAndPartialResultParams implements WorkDoneProgressParams, PartialResultParams {
+  /**
+   * An optional token that a server can use to report work done progress.
+   */
   private Either<String, Number> workDoneToken;
   
+  /**
+   * An optional token that a server can use to report partial results (e.g. streaming) to
+   * the client.
+   */
   private Either<String, Number> partialResultToken;
   
+  /**
+   * An optional token that a server can use to report work done progress.
+   */
   @Pure
   public Either<String, Number> getWorkDoneToken() {
     return this.workDoneToken;
   }
   
+  /**
+   * An optional token that a server can use to report work done progress.
+   */
   public void setWorkDoneToken(final Either<String, Number> workDoneToken) {
     this.workDoneToken = workDoneToken;
   }
@@ -54,11 +67,19 @@ public abstract class WorkDoneProgressAndPartialResultParams implements WorkDone
     this.workDoneToken = Either.forRight(workDoneToken);
   }
   
+  /**
+   * An optional token that a server can use to report partial results (e.g. streaming) to
+   * the client.
+   */
   @Pure
   public Either<String, Number> getPartialResultToken() {
     return this.partialResultToken;
   }
   
+  /**
+   * An optional token that a server can use to report partial results (e.g. streaming) to
+   * the client.
+   */
   public void setPartialResultToken(final Either<String, Number> partialResultToken) {
     this.partialResultToken = partialResultToken;
   }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/WorkDoneProgressParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/WorkDoneProgressParams.java
@@ -25,5 +25,8 @@ public interface WorkDoneProgressParams {
    */
   public abstract Either<String, Number> getWorkDoneToken();
   
+  /**
+   * An optional token that a server can use to report work done progress.
+   */
   public abstract void setWorkDoneToken(final Either<String, Number> token);
 }


### PR DESCRIPTION
Went through all of the Params and made some updates.

- Updated `DocumentFormattingParams` and `DocumentRangeFormattingParams` to support progress. `DocumentOnTypeFormattingParams` now extends `TextDocumentPositionParams` instead of `DocumentFormattingParams` because it does not support progress and better matches the spec. It's possible this may have compatibility issues, but seems unlikely. `DocumentRangeFormattingParams` also no longer extends `DocumentFormattingParams` to better match the spec and prevent future compatibility issues.
- Added `@Beta` to  some `TypeHierarchy` classes that were missing it
- Removed deprecated constructors for new classes just added in #442 since they shouldn't be used
- Added and fixed some comments
- Made spacing more consistent
- Skipped `CallHierarchy` Params to prevent conflict with #449