### PR TITLE
Add proposed LSP 3.16 changes

### DIFF
--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -74,7 +74,7 @@ class WorkspaceEditCapabilities {
 	 *
 	 * See {@link ResourceOperationKind} for allowed values.
 	 */
-	List<String> resourceOperations;
+	List<String> resourceOperations
 
 	/**
 	 * The failure handling strategy of a client if applying the workspace edit
@@ -82,7 +82,7 @@ class WorkspaceEditCapabilities {
 	 *
 	 * See {@link FailureHandlingKind} for allowed values.
 	 */
-	String failureHandling;
+	String failureHandling
 
 	new() {
 	}
@@ -121,6 +121,7 @@ class DidChangeWatchedFilesCapabilities extends DynamicRegistrationCapabilities 
 
 /**
  * Capabilities specific to the `workspace/symbol` request.
+ * Referred to in the spec as WorkspaceSymbolClientCapabilities.
  */
 @JsonRpcData
 class SymbolCapabilities extends DynamicRegistrationCapabilities {
@@ -129,6 +130,15 @@ class SymbolCapabilities extends DynamicRegistrationCapabilities {
 	 * Specific capabilities for the `SymbolKind` in the `workspace/symbol` request.
 	 */
 	SymbolKindCapabilities symbolKind
+
+	/**
+	 * The client supports tags on `SymbolInformation`.
+	 * Clients supporting tags have to handle unknown tags gracefully.
+	 *
+	 * Since 3.16.0
+	 */
+	@Beta
+	SymbolTagSupportCapabilities tagSupport
 
 	new() {
 	}
@@ -293,6 +303,25 @@ class CompletionItemCapabilities {
 	 */
 	CompletionItemTagSupportCapabilities tagSupport
 
+	/**
+	 * Client support insert replace edit to control different behavior if a
+	 * completion item is inserted in the text or should replace text.
+	 *
+	 * Since 3.16.0
+	 */
+	@Beta
+	Boolean insertReplaceSupport
+
+	/**
+	 * Indicates which properties a client can resolve lazily on a completion
+	 * item. Before version 3.16.0 only the predefined properties `documentation`
+	 * and `details` could be resolved lazily.
+	 *
+	 * Since 3.16.0
+	 */
+	@Beta
+	CompletionItemResolveSupportCapabilities resolveSupport
+
 	new() {
 	}
 
@@ -301,6 +330,14 @@ class CompletionItemCapabilities {
 	}
 }
 
+/**
+ * Client supports the tag property on a completion item. Clients supporting
+ * tags have to handle unknown tags gracefully. Clients especially need to
+ * preserve unknown tags when sending a completion item back to the server in
+ * a resolve call.
+ *
+ * Since 3.15.0
+ */
 @JsonRpcData
 class CompletionItemTagSupportCapabilities {
 	/**
@@ -318,6 +355,35 @@ class CompletionItemTagSupportCapabilities {
 	}
 }
 
+/**
+ * Indicates which properties a client can resolve lazily on a completion
+ * item. Before version 3.16.0 only the predefined properties `documentation`
+ * and `details` could be resolved lazily.
+ *
+ * Since 3.16.0
+ */
+@Beta
+@JsonRpcData
+class CompletionItemResolveSupportCapabilities {
+	/**
+	 * The properties that a client can resolve lazily.
+	 */
+	@NonNull
+	List<String> properties
+
+	new() {
+		this.properties = new ArrayList
+	}
+
+	new(@NonNull List<String> properties) {
+		this.properties = Preconditions.checkNotNull(properties, 'properties')
+	}
+}
+
+/**
+ * The client supports the following `CompletionItemKind` specific
+ * capabilities.
+ */
 @JsonRpcData
 class CompletionItemKindCapabilities {
 	/**
@@ -422,6 +488,15 @@ class SignatureInformationCapabilities {
 	 * Client capabilities specific to parameter information.
 	 */
 	ParameterInformationCapabilities parameterInformation
+
+	/**
+	 * The client supports the `activeParameter` property on `SignatureInformation`
+	 * literal.
+	 *
+	 * Since 3.16.0
+	 */
+	@Beta
+	Boolean activeParameterSupport
 
 	new() {
 	}
@@ -538,6 +613,27 @@ class SymbolKindCapabilities {
 }
 
 /**
+ * Specific capabilities for the `SymbolTag`.
+ */
+@Beta
+@JsonRpcData
+class SymbolTagSupportCapabilities {
+	/**
+	 * The tags supported by the client.
+	 */
+	@NonNull
+	List<SymbolTag> valueSet
+
+	new() {
+		this.valueSet = new ArrayList
+	}
+
+	new(@NonNull List<SymbolTag> valueSet) {
+		this.valueSet = Preconditions.checkNotNull(valueSet, 'valueSet')
+	}
+}
+
+/**
  * Capabilities specific to the `textDocument/documentSymbol`
  */
 @JsonRpcData
@@ -551,6 +647,25 @@ class DocumentSymbolCapabilities extends DynamicRegistrationCapabilities {
 	 * The client support hierarchical document symbols.
 	 */
 	Boolean hierarchicalDocumentSymbolSupport
+
+	/**
+	 * The client supports tags on `SymbolInformation`. Tags are supported on
+	 * `DocumentSymbol` if `hierarchicalDocumentSymbolSupport` is set to true.
+	 * Clients supporting tags have to handle unknown tags gracefully.
+	 *
+	 * Since 3.16.0
+	 */
+	@Beta
+	SymbolTagSupportCapabilities tagSupport
+
+	/**
+	 * The client supports an additional label presented in the UI when
+	 * registering a document symbol provider.
+	 *
+	 * Since 3.16.0
+	 */
+	@Beta
+	Boolean labelSupport
 
 	new() {
 	}
@@ -752,7 +867,31 @@ class CodeActionLiteralSupportCapabilities {
 	}
 
 	new(CodeActionKindCapabilities codeActionKind) {
-		this.codeActionKind = codeActionKind;
+		this.codeActionKind = codeActionKind
+	}
+}
+
+/**
+ * Whether the client supports resolving additional code action
+ * properties via a separate `codeAction/resolve` request.
+ *
+ * Since 3.16.0
+ */
+@Beta
+@JsonRpcData
+class CodeActionResolveSupportCapabilities {
+	/**
+	 * The properties that a client can resolve lazily.
+	 */
+	@NonNull
+	List<String> properties
+
+	new() {
+		this.properties = new ArrayList
+	}
+
+	new(@NonNull List<String> properties) {
+		this.properties = Preconditions.checkNotNull(properties, 'properties')
 	}
 }
 
@@ -774,6 +913,33 @@ class CodeActionCapabilities extends DynamicRegistrationCapabilities {
 	 * Since 3.15.0
 	 */
 	Boolean isPreferredSupport
+
+	/**
+	 * Whether code action supports the `disabled` property.
+	 *
+	 * Since 3.16.0
+	 */
+	@Beta
+	Boolean disabledSupport
+
+	/**
+	 * Whether code action supports the `data` property which is
+	 * preserved between a `textDocument/codeAction` and a
+	 * `codeAction/resolve` request.
+	 *
+	 * Since 3.16.0
+	 */
+	@Beta
+	Boolean dataSupport
+
+	/**
+	 * Whether the client supports resolving additional code action
+	 * properties via a separate `codeAction/resolve` request.
+	 *
+	 * Since 3.16.0
+	 */
+	@Beta
+	CodeActionResolveSupportCapabilities resolveSupport
 
 	new() {
 	}
@@ -862,6 +1028,13 @@ class RenameCapabilities extends DynamicRegistrationCapabilities {
 	 */
 	Boolean prepareSupport
 
+	/**
+	 * Client supports the default behavior result (`{ defaultBehavior: boolean }`).
+	 *
+	 * Since 3.16.0
+	 */
+	Boolean prepareSupportDefaultBehavior
+
 	new() {
 	}
 
@@ -905,6 +1078,24 @@ class PublishDiagnosticsCapabilities {
 	 * Since 3.15.0
 	 */
 	Boolean versionSupport
+
+	/**
+	 * Client supports a codeDescription property
+	 *
+	 * Since 3.16.0
+	 */
+	@Beta
+	Boolean codeDescriptionSupport
+
+	/**
+	 * Whether code action supports the `data` property which is
+	 * preserved between a `textDocument/publishDiagnostics` and
+	 * `textDocument/codeAction` request.
+	 *
+	 * Since 3.16.0
+	 */
+	@Beta
+	Boolean dataSupport
 
 	new() {
 	}
@@ -1008,7 +1199,7 @@ class TypeHierarchyCapabilities extends DynamicRegistrationCapabilities {
 }
 
 /**
- * Capabilities specific to the {@code textDocument/callHierarchy}.
+ * Capabilities specific to the {@code textDocument/prepareCallHierarchy}.
  */
 @Beta
 @JsonRpcData
@@ -1118,13 +1309,13 @@ class SemanticTokensCapabilities extends DynamicRegistrationCapabilities {
 	 * The token types that the client supports.
 	 */
 	@NonNull
-	List<String> tokenTypes;
+	List<String> tokenTypes
 
 	/**
 	 * The token modifiers that the client supports.
 	 */
 	@NonNull
-	List<String> tokenModifiers;
+	List<String> tokenModifiers
 
 	/**
 	 * The tokens the client supports.
@@ -1132,7 +1323,7 @@ class SemanticTokensCapabilities extends DynamicRegistrationCapabilities {
 	 * See {@link TokenFormat} for allowed values.
 	 */
 	@NonNull
-	List<String> formats;
+	List<String> formats
 
 	new(Boolean dynamicRegistration) {
 		super(dynamicRegistration)
@@ -1289,7 +1480,7 @@ class TextDocumentClientCapabilities {
 	TypeHierarchyCapabilities typeHierarchyCapabilities
 
 	/**
-	 * Capabilities specific to {@code textDocument/callHierarchy}.
+	 * Capabilities specific to {@code textDocument/prepareCallHierarchy}.
 	 */
 	@Beta
 	CallHierarchyCapabilities callHierarchy
@@ -1321,7 +1512,7 @@ class WindowClientCapabilities {
 	 *
 	 * Since 3.15.0
 	 */
-	Boolean workDoneProgress;
+	Boolean workDoneProgress
 }
 
 /**
@@ -1368,7 +1559,7 @@ class ClientCapabilities {
 		this.textDocument = textDocument
 		this.experimental = experimental
 	}
-	
+
 	new(WorkspaceClientCapabilities workspace, TextDocumentClientCapabilities textDocument, WindowClientCapabilities window, Object experimental) {
 		this.workspace = workspace
 		this.textDocument = textDocument
@@ -1415,6 +1606,26 @@ class CodeAction {
 	Boolean isPreferred
 
 	/**
+	 * Marks that the code action cannot currently be applied.
+	 *
+	 * Clients should follow the following guidelines regarding disabled code actions:
+	 *
+	 *   - Disabled code actions are not shown in automatic [lightbulb](https://code.visualstudio.com/docs/editor/editingevolved#_code-action)
+	 *     code action menu.
+	 *
+	 *   - Disabled actions are shown as faded out in the code action menu when the user request a more specific type
+	 *     of code action, such as refactorings.
+	 *
+	 *   - If the user has a [keybinding](https://code.visualstudio.com/docs/editor/refactoring#_keybindings-for-code-actions)
+	 *     that auto applies a code action and only a disabled code actions are returned, the client should show the user an
+	 *     error message with `reason` in the editor.
+	 *
+	 * Since 3.16.0
+	 */
+	@Beta
+	CodeActionDisabled disabled
+
+	/**
 	 * The workspace edit this code action performs.
 	 */
 	WorkspaceEdit edit
@@ -1426,13 +1637,58 @@ class CodeAction {
 	 */
 	Command command
 
+	/**
+	 * A data entry field that is preserved on a code action between
+	 * a `textDocument/codeAction` and a `codeAction/resolve` request.
+	 *
+	 * Since 3.16.0
+	 */
+	@Beta
+	@JsonAdapter(JsonElementTypeAdapter.Factory)
+	Object data
+
 	new() {
 	}
 
 	new(@NonNull String title) {
 		this.title = Preconditions.checkNotNull(title, 'title')
 	}
+}
 
+/**
+ * Marks that the code action cannot currently be applied.
+ *
+ * Clients should follow the following guidelines regarding disabled code actions:
+ *
+ *   - Disabled code actions are not shown in automatic [lightbulb](https://code.visualstudio.com/docs/editor/editingevolved#_code-action)
+ *     code action menu.
+ *
+ *   - Disabled actions are shown as faded out in the code action menu when the user request a more specific type
+ *     of code action, such as refactorings.
+ *
+ *   - If the user has a [keybinding](https://code.visualstudio.com/docs/editor/refactoring#_keybindings-for-code-actions)
+ *     that auto applies a code action and only a disabled code actions are returned, the client should show the user an
+ *     error message with `reason` in the editor.
+ *
+ * Since 3.16.0
+ */
+@Beta
+@JsonRpcData
+class CodeActionDisabled {
+	/**
+	 * Human readable description of why the code action is currently disabled.
+	 *
+	 * This is displayed in the code actions UI.
+	 */
+	@NonNull
+	String reason
+
+	new() {
+	}
+
+	new(@NonNull String reason) {
+		this.reason = Preconditions.checkNotNull(reason, 'reason')
+	}
 }
 
 /**
@@ -1524,7 +1780,7 @@ class CodeLens {
 	Command command
 
 	/**
-	 * An data entry field that is preserved on a code lens item between a code lens and a code lens resolve request.
+	 * A data entry field that is preserved on a code lens item between a code lens and a code lens resolve request.
 	 */
 	@JsonAdapter(JsonElementTypeAdapter.Factory)
 	Object data
@@ -1555,6 +1811,15 @@ class CodeActionOptions extends AbstractWorkDoneProgressOptions {
 	 * may list out every specific kind they provide.
 	 */
 	List<String> codeActionKinds
+
+	/**
+	 * The server provides support to resolve additional
+	 * information for a code action.
+	 *
+	 * Since 3.16.0
+	 */
+	@Beta
+	Boolean resolveProvider
 
 	new() {
 	}
@@ -1747,7 +2012,7 @@ class CompletionItem {
 	Command command
 
 	/**
-	 * An data entry field that is preserved on a completion item between a completion and a completion resolve request.
+	 * A data entry field that is preserved on a completion item between a completion and a completion resolve request.
 	 */
 	@JsonAdapter(JsonElementTypeAdapter.Factory)
 	Object data
@@ -1838,6 +2103,14 @@ class Diagnostic {
 	Either<String, Number> code
 
 	/**
+	 * An optional property to describe the error code.
+	 *
+	 * Since 3.16.0
+	 */
+	@Beta
+	DiagnosticCodeDescription codeDescription
+
+	/**
 	 * A human-readable string describing the source of this diagnostic, e.g. 'typescript' or 'super lint'.
 	 */
 	String source
@@ -1853,7 +2126,7 @@ class Diagnostic {
 	 *
 	 * Since 3.15.0
 	 */
-	 List<DiagnosticTag> tags;
+	 List<DiagnosticTag> tags
 
 	/**
 	 * An array of related diagnostic information, e.g. when symbol-names within a scope collide
@@ -1862,6 +2135,16 @@ class Diagnostic {
 	 * Since 3.7.0
 	 */
 	List<DiagnosticRelatedInformation> relatedInformation
+
+	/**
+	 * A data entry field that is preserved between a `textDocument/publishDiagnostics`
+	 * notification and `textDocument/codeAction` request.
+	 *
+	 * Since 3.16.0
+	 */
+	@Beta
+	@JsonAdapter(JsonElementTypeAdapter.Factory)
+	Object data
 
 	new() {
 	}
@@ -1910,6 +2193,28 @@ class DiagnosticRelatedInformation {
 	new(@NonNull Location location, @NonNull String message) {
 		this.location = Preconditions.checkNotNull(location, 'location')
 		this.message = Preconditions.checkNotNull(message, 'message')
+	}
+}
+
+/**
+ * Structure to capture a description for an error code.
+ *
+ * Since 3.16.0
+ */
+@Beta
+@JsonRpcData
+class DiagnosticCodeDescription {
+	/**
+	 * A URI to open with more information about the diagnostic error.
+	 */
+	@NonNull
+	String href
+
+	new() {
+	}
+
+	new(@NonNull String href) {
+		this.href = Preconditions.checkNotNull(href, 'href')
 	}
 }
 
@@ -2349,7 +2654,7 @@ class RenameOptions extends StaticRegistrationOptions {
 	/**
 	 * Renames should be checked and tested before being executed.
 	 */
-	Boolean prepareProvider;
+	Boolean prepareProvider
 }
 
 /**
@@ -2571,6 +2876,22 @@ class ResolveTypeHierarchyItemParams {
 
 @JsonRpcData
 class DocumentSymbolOptions extends AbstractWorkDoneProgressOptions {
+	/**
+	 * A human-readable string that is shown when multiple outlines trees
+	 * are shown for the same document.
+	 *
+	 * Since 3.16.0
+	 */
+	@Beta
+	String label
+
+	new() {
+	}
+
+	@Beta
+	new(String label) {
+		this.label = label
+	}
 }
 
 @JsonRpcData
@@ -2902,7 +3223,7 @@ class MarkedString {
 interface WorkDoneProgressNotification {
 	def WorkDoneProgressKind getKind()
 }
- 
+
 /**
  * The $/progress notification payload to start progress reporting.
  *
@@ -2951,7 +3272,7 @@ class WorkDoneProgressBegin implements WorkDoneProgressNotification {
 	 * The value should be steadily rising. Clients are free to ignore values
 	 * that are not following this rule.
 	 */
-	Integer percentage;
+	Integer percentage
 }
 
 /**
@@ -2995,13 +3316,13 @@ class WorkDoneProgressReport implements WorkDoneProgressNotification {
 	 * The value should be steadily rising. Clients are free to ignore values
 	 * that are not following this rule.
 	 */
-	Integer percentage;
+	Integer percentage
 }
 
 /**
  * The notification payload about progress reporting.
  * Signaling the end of a progress reporting is done using the following payload:
- * 
+ *
  * Since 3.15.0
  */
 @JsonRpcData
@@ -3041,7 +3362,7 @@ class ProgressParams {
 	 * The progress data.
 	 */
 	@JsonAdapter(WorkDoneProgressNotificationAdapter.Factory)
-	WorkDoneProgressNotification value;
+	WorkDoneProgressNotification value
 
 	new() {
 	}
@@ -3072,38 +3393,38 @@ interface WorkDoneProgressParams {
 
 /**
  * Options to signal work done progress support in server capabilities.
- * 
+ *
  * Since 3.15.0
  */
 interface WorkDoneProgressOptions {
-	
+
 	def Boolean getWorkDoneProgress()
-	
+
 	def void setWorkDoneProgress(Boolean workDoneProgress)
-	
+
 }
 
 /**
  * Options to signal work done progress support in server capabilities.
  * It is not present in protocol specification, so it's just "dry" class.
- * 
+ *
  * Since 3.15.0
  */
 @JsonRpcData
 abstract class AbstractWorkDoneProgressOptions implements WorkDoneProgressOptions {
 	Boolean workDoneProgress
-} 
+}
 
 /**
  * Options to signal work done progress support in server capabilities and TextDocumentRegistrationOptions.
  * It is not present in protocol specification, so it's just "dry" class.
- * 
+ *
  * Since 3.15.0
  */
 @JsonRpcData
 abstract class AbstractTextDocumentRegistrationAndWorkDoneProgressOptions extends TextDocumentRegistrationOptions implements WorkDoneProgressOptions {
 	Boolean workDoneProgress
-	
+
 	new() {
 	}
 
@@ -3694,6 +4015,10 @@ class ReferenceParams extends TextDocumentPositionAndWorkDoneProgressAndPartialR
 	}
 }
 
+/**
+ * One of the result types of the `textDocument/prepareRename` request.
+ * Provides the range of the string to rename and a placeholder text of the string content to be renamed.
+ */
 @JsonRpcData
 class PrepareRenameResult {
 	/**
@@ -3746,13 +4071,13 @@ class SemanticTokensLegend {
 	 * The token types that the client supports.
 	 */
 	@NonNull
-	List<String> tokenTypes;
+	List<String> tokenTypes
 
 	/**
 	 * The token modifiers that the client supports.
 	 */
 	@NonNull
-	List<String> tokenModifiers;
+	List<String> tokenModifiers
 
 	new(@NonNull List<String> tokenTypes, @NonNull List<String> tokenModifiers) {
 		this.tokenTypes = Preconditions.checkNotNull(tokenTypes, 'tokenTypes')
@@ -4059,13 +4384,13 @@ class SemanticHighlightingServerCapabilities {
 	 * feature. Otherwise, clients should reuse this "lookup table" when receiving semantic highlighting notifications from
 	 * the server.
 	 */
-	List<List<String>> scopes;
+	List<List<String>> scopes
 
 	new() {
 	}
 
 	new(List<List<String>> scopes) {
-		this.scopes = scopes;
+		this.scopes = scopes
 	}
 
 }
@@ -4223,12 +4548,12 @@ class SemanticTokensEdit {
 	/**
 	 * The count of elements to remove.
 	 */
-	int deleteCount;
+	int deleteCount
 
 	/**
 	 * The elements to insert.
 	 */
-	List<Integer> data;
+	List<Integer> data
 
 	new(int start, int deleteCount, List<Integer> data) {
 		this.start = start
@@ -4295,7 +4620,7 @@ class SemanticTokensRangeParams extends WorkDoneProgressAndPartialResultParams {
 	 * The range the semantic tokens are requested for.
 	 */
 	@NonNull
-	Range range;
+	Range range
 
 	new(@NonNull TextDocumentIdentifier textDocument, @NonNull Range range) {
 		this.textDocument = Preconditions.checkNotNull(textDocument, 'textDocument')
@@ -4449,6 +4774,16 @@ class SignatureInformation {
 	 */
 	List<ParameterInformation> parameters
 
+	/**
+	 * The index of the active parameter.
+	 *
+	 * If provided, this is used in place of `SignatureHelp.activeParameter`.
+	 *
+	 * Since 3.16.0
+	 */
+	@Beta
+	Integer activeParameter
+
 	new() {
 	}
 
@@ -4569,7 +4904,7 @@ class DocumentSymbol {
 	 * inside the symbol to reveal in the symbol in the UI.
 	 */
 	@NonNull
-	Range range;
+	Range range
 
 	/**
 	 * The range that should be selected and revealed when this symbol is being picked, e.g the name of a function.
@@ -4585,8 +4920,19 @@ class DocumentSymbol {
 	String detail
 
 	/**
-	 * Indicates if this symbol is deprecated.
+	 * Tags for this document symbol.
+	 *
+	 * Since 3.16.0
 	 */
+	@Beta
+	List<SymbolTag> tags
+
+	/**
+	 * Indicates if this symbol is deprecated.
+	 *
+	 * @deprecated Use `tags` instead if supported.
+	 */
+	@Deprecated
 	Boolean deprecated
 
 	/**
@@ -4637,8 +4983,19 @@ class SymbolInformation {
 	SymbolKind kind
 
 	/**
-	 * Indicates if this symbol is deprecated.
+	 * Tags for this symbol.
+	 *
+	 * Since 3.16.0
 	 */
+	@Beta
+	List<SymbolTag> tags
+
+	/**
+	 * Indicates if this symbol is deprecated.
+	 *
+	 * @deprecated Use `tags` instead if supported.
+	 */
+	@Deprecated
 	Boolean deprecated
 
 	/**
@@ -4954,7 +5311,7 @@ class TextDocumentEdit {
 abstract class ResourceOperation {
 
 	@NonNull
-	String kind;
+	String kind
 
 	new() {
 	}
@@ -5587,7 +5944,6 @@ class ExecuteCommandParams implements WorkDoneProgressParams {
  */
 @JsonRpcData
 class ExecuteCommandRegistrationOptions extends ExecuteCommandOptions {
-	
 }
 
 /**
@@ -6167,7 +6523,7 @@ class CallHierarchyOutgoingCall {
 }
 
 /**
- * The result of a {@code textDocument/callHierarchy} request.
+ * The result of a {@code textDocument/prepareCallHierarchy} request.
  */
 @Beta
 @JsonRpcData

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -6597,6 +6597,13 @@ class CallHierarchyItem {
 	 */
 	@NonNull
 	Range selectionRange
+
+	/**
+	 * A data entry field that is preserved between a call hierarchy prepare and
+	 * incoming calls or outgoing calls requests.
+	 */
+	@JsonAdapter(JsonElementTypeAdapter.Factory)
+	Object data
 }
 
 /**

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -614,6 +614,8 @@ class SymbolKindCapabilities {
 
 /**
  * Specific capabilities for the `SymbolTag`.
+ *
+ * Since 3.16.0
  */
 @Beta
 @JsonRpcData
@@ -1200,6 +1202,8 @@ class TypeHierarchyCapabilities extends DynamicRegistrationCapabilities {
 
 /**
  * Capabilities specific to the {@code textDocument/prepareCallHierarchy}.
+ *
+ * Since 3.16.0
  */
 @Beta
 @JsonRpcData
@@ -1481,6 +1485,8 @@ class TextDocumentClientCapabilities {
 
 	/**
 	 * Capabilities specific to {@code textDocument/prepareCallHierarchy}.
+	 *
+	 * Since 3.16.0
 	 */
 	@Beta
 	CallHierarchyCapabilities callHierarchy
@@ -1495,7 +1501,7 @@ class TextDocumentClientCapabilities {
 	/**
 	 * Capabilities specific to {@code textDocument/semanticTokens}.
 	 *
-	 * @since 3.16.0
+	 * Since 3.16.0
 	 */
 	@Beta
 	SemanticTokensCapabilities semanticTokens
@@ -4063,6 +4069,11 @@ class RenameParams extends TextDocumentPositionAndWorkDoneProgressParams {
 	}
 }
 
+/**
+ * The legend used by the server
+ *
+ * Since 3.16.0
+ */
 @Beta
 @JsonRpcData
 class SemanticTokensLegend {
@@ -4086,6 +4097,11 @@ class SemanticTokensLegend {
 
 }
 
+/**
+ * Server supports providing semantic tokens for a full document.
+ *
+ * Since 3.16.0
+ */
 @Beta
 @JsonRpcData
 class SemanticTokensServerFull {
@@ -4318,10 +4334,11 @@ class ServerCapabilities {
 
 	/**
 	 * The server provides Call Hierarchy support.
+	 *
+	 * Since 3.16.0
 	 */
 	@Beta
 	Either<Boolean, StaticRegistrationOptions> callHierarchyProvider
-
 
 	/**
 	 * The server provides selection range support.
@@ -6422,6 +6439,8 @@ class SemanticHighlightingInformation {
 
 /**
  * The parameter of a `textDocument/prepareCallHierarchy` request.
+ *
+ * Since 3.16.0
  */
 @Beta
 @JsonRpcData
@@ -6431,6 +6450,8 @@ class CallHierarchyPrepareParams  extends TextDocumentPositionParams {
 
 /**
  * The parameter of a `callHierarchy/incomingCalls` request.
+ *
+ * Since 3.16.0
  */
 @Beta
 @JsonRpcData
@@ -6442,12 +6463,14 @@ class CallHierarchyIncomingCallsParams {
 	}
 
 	new(@NonNull CallHierarchyItem item) {
-		this.item = item
+		this.item = Preconditions.checkNotNull(item, 'item')
 	}
 }
 
 /**
  * The parameter of a `callHierarchy/outgoingCalls` request.
+ *
+ * Since 3.16.0
  */
 @Beta
 @JsonRpcData
@@ -6459,17 +6482,18 @@ class CallHierarchyOutgoingCallsParams {
 	}
 
 	new(@NonNull CallHierarchyItem item) {
-		this.item = item
+		this.item = Preconditions.checkNotNull(item, 'item')
 	}
 }
 
 /**
  * Represents an incoming call, e.g. a caller of a method or constructor.
+ *
+ * Since 3.16.0
  */
 @Beta
 @JsonRpcData
 class CallHierarchyIncomingCall {
-
 	/**
 	 * The item that makes the call.
 	 */
@@ -6487,18 +6511,19 @@ class CallHierarchyIncomingCall {
 	}
 
 	new(@NonNull CallHierarchyItem from, @NonNull List<Range> fromRanges) {
-		this.from = from
-		this.fromRanges = fromRanges
+		this.from = Preconditions.checkNotNull(from, 'from')
+		this.fromRanges = Preconditions.checkNotNull(fromRanges, 'fromRanges')
 	}
 }
 
 /**
  * Represents an outgoing call, e.g. calling a getter from a method or a method from a constructor etc.
+ *
+ * Since 3.16.0
  */
 @Beta
 @JsonRpcData
 class CallHierarchyOutgoingCall {
-
 	/**
 	 * The item that is called.
 	 */
@@ -6517,18 +6542,19 @@ class CallHierarchyOutgoingCall {
 	}
 
 	new(@NonNull CallHierarchyItem to, @NonNull List<Range> fromRanges) {
-		this.to = to
-		this.fromRanges = fromRanges
+		this.to = Preconditions.checkNotNull(to, 'to')
+		this.fromRanges = Preconditions.checkNotNull(fromRanges, 'fromRanges')
 	}
 }
 
 /**
  * The result of a {@code textDocument/prepareCallHierarchy} request.
+ *
+ * Since 3.16.0
  */
 @Beta
 @JsonRpcData
 class CallHierarchyItem {
-
 	/**
 	 * The name of the item targeted by the call hierarchy request.
 	 */
@@ -6571,11 +6597,12 @@ class CallHierarchyItem {
 	 */
 	@NonNull
 	Range selectionRange
-
 }
 
 /**
  * A parameter literal used in selection range requests.
+ *
+ * Since 3.15.0
  */
 @JsonRpcData
 class SelectionRangeParams extends WorkDoneProgressAndPartialResultParams {
@@ -6603,6 +6630,8 @@ class SelectionRangeParams extends WorkDoneProgressAndPartialResultParams {
 /**
  * A selection range represents a part of a selection hierarchy. A selection range
  * may have a parent selection range that contains it.
+ *
+ * Since 3.15.0
  */
 @JsonRpcData
 class SelectionRange {

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/SymbolTag.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/SymbolTag.java
@@ -14,10 +14,14 @@ package org.eclipse.lsp4j;
 
 /**
  * Symbol tags are extra annotations that tweak the rendering of a symbol.
- * @since 3.15
+ * 
+ * Since 3.16
  */
 public enum SymbolTag {
 
+	/**
+	 * Render a symbol as obsolete, usually using a strike-out.
+	 */
 	Deprecated(1);
 
 	private final int value;

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/TextDocumentService.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/TextDocumentService.java
@@ -146,7 +146,7 @@ public interface TextDocumentService {
 	 * 
 	 * Registration Options: TextDocumentRegistrationOptions
 	 * 
-	 * Since version 3.14.0
+	 * Since 3.14.0
 	 */
 	@JsonRequest
 	@ResponseJsonAdapter(LocationLinkListAdapter.class)
@@ -172,7 +172,7 @@ public interface TextDocumentService {
 	 * 
 	 * Registration Options: TextDocumentRegistrationOptions
 	 * 
-	 * Since version 3.6.0
+	 * Since 3.6.0
 	 */
 	@JsonRequest
 	@ResponseJsonAdapter(LocationLinkListAdapter.class)
@@ -186,7 +186,7 @@ public interface TextDocumentService {
 	 * 
 	 * Registration Options: TextDocumentRegistrationOptions
 	 * 
-	 * Since version 3.6.0
+	 * Since 3.6.0
 	 */
 	@JsonRequest
 	@ResponseJsonAdapter(LocationLinkListAdapter.class)
@@ -256,6 +256,8 @@ public interface TextDocumentService {
 	/**
 	 * The request is sent from the client to the server to resolve additional information for a given code action. This is usually used to compute
 	 * the `edit` property of a code action to avoid its unnecessary computation during the `textDocument/codeAction` request.
+	 * 
+	 * Since 3.16.0
 	 */
 	@JsonRequest(value="codeAction/resolve", useSegment = false)
 	default CompletableFuture<CodeAction> resolveCodeAction(CodeAction unresolved) {
@@ -413,7 +415,7 @@ public interface TextDocumentService {
 	 *  - Color boxes showing the actual color next to the reference
 	 *  - Show a color picker when a color reference is edited
 	 * 
-	 * Since version 3.6.0
+	 * Since 3.6.0
 	 */
 	@JsonRequest
 	default CompletableFuture<List<ColorInformation>> documentColor(DocumentColorParams params) {
@@ -426,7 +428,7 @@ public interface TextDocumentService {
 	 *  - modify a color reference.
 	 *  - show in a color picker and let users pick one of the presentations
 	 * 
-	 * Since version 3.6.0
+	 * Since 3.6.0
 	 */
 	@JsonRequest
 	default CompletableFuture<List<ColorPresentation>> colorPresentation(ColorPresentationParams params) {
@@ -437,7 +439,7 @@ public interface TextDocumentService {
 	 * The folding range request is sent from the client to the server to return all folding
 	 * ranges found in a given text document.
 	 * 
-	 * Since version 3.10.0
+	 * Since 3.10.0
 	 */
 	@JsonRequest
 	default CompletableFuture<List<FoldingRange>> foldingRange(FoldingRangeRequestParams params) {
@@ -448,7 +450,7 @@ public interface TextDocumentService {
 	 * The prepare rename request is sent from the client to the server to setup and test the validity of a rename
 	 * operation at a given location.
 	 * 
-	 * Since version 3.12.0
+	 * Since 3.12.0
 	 */
 	@JsonRequest
 	@ResponseJsonAdapter(PrepareRenameResponseAdapter.class)
@@ -497,6 +499,8 @@ public interface TextDocumentService {
 	 * Bootstraps call hierarchy by returning the item that is denoted by the given document
 	 * and position. This item will be used as entry into the call graph. Providers should
 	 * return null when there is no item at the given location.
+	 * 
+	 * Since 3.16.0
 	 */
 	@Beta
 	@JsonRequest
@@ -508,6 +512,8 @@ public interface TextDocumentService {
 	 * Provide all incoming calls for an item, e.g all callers for a method. In graph terms this describes directed
 	 * and annotated edges inside the call graph, e.g the given item is the starting node and the result is the nodes
 	 * that can be reached.
+	 * 
+	 * Since 3.16.0
 	*/
 	@Beta
 	@JsonRequest(value="callHierarchy/incomingCalls", useSegment = false)
@@ -519,6 +525,8 @@ public interface TextDocumentService {
 	* Provide all outgoing calls for an item, e.g call calls to functions, methods, or constructors from the given item. In
 	* graph terms this describes directed and annotated edges inside the call graph, e.g the given item is the starting
 	* node and the result is the nodes that can be reached.
+	* 
+	* Since 3.16.0
 	*/
 	@Beta
 	@JsonRequest(value="callHierarchy/outgoingCalls", useSegment = false)
@@ -530,6 +538,8 @@ public interface TextDocumentService {
 	 * The {@code textDocument/selectionRange} request is sent from the client to the server to return
 	 * suggested selection ranges at an array of given positions. A selection range is a range around
 	 * the cursor position which the user might be interested in selecting.
+	 * 
+	 * Since 3.15.0
 	 */
 	@JsonRequest
 	default CompletableFuture<List<SelectionRange>> selectionRange(SelectionRangeParams params) {
@@ -539,6 +549,8 @@ public interface TextDocumentService {
 	/**
 	 * The {@code textDocument/semanticTokens/full} request is sent from the client to the server to return
 	 * the semantic tokens for a whole file.
+	 * 
+	 * Since 3.16.0
 	 */
 	@JsonRequest(value="textDocument/semanticTokens/full", useSegment = false)
 	default CompletableFuture<SemanticTokens> semanticTokensFull(SemanticTokensParams params) {
@@ -548,6 +560,8 @@ public interface TextDocumentService {
 	/**
 	 * The {@code textDocument/semanticTokens/full/delta} request is sent from the client to the server to return
 	 * the semantic tokens delta for a whole file.
+	 * 
+	 * Since 3.16.0
 	 */
 	@JsonRequest(value="textDocument/semanticTokens/full/delta", useSegment = false)
 	@ResponseJsonAdapter(SemanticTokensFullDeltaResponseAdapter.class)
@@ -565,6 +579,8 @@ public interface TextDocumentService {
 	 * this case special. Please note that if a client also announces that it will send the
 	 * textDocument/semanticTokens/range server should implement this request as well to allow for flicker free
 	 * scrolling and semantic coloring of a minimap.
+	 * 
+	 * Since 3.16.0
 	 */
 	@JsonRequest(value="textDocument/semanticTokens/range", useSegment = false)
 	default CompletableFuture<SemanticTokens> semanticTokensRange(SemanticTokensRangeParams params) {

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/TextDocumentService.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/TextDocumentService.java
@@ -254,6 +254,15 @@ public interface TextDocumentService {
 	}
 
 	/**
+	 * The request is sent from the client to the server to resolve additional information for a given code action. This is usually used to compute
+	 * the `edit` property of a code action to avoid its unnecessary computation during the `textDocument/codeAction` request.
+	 */
+	@JsonRequest(value="codeAction/resolve", useSegment = false)
+	default CompletableFuture<CodeAction> resolveCodeAction(CodeAction unresolved) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
 	 * The code lens request is sent from the client to the server to compute
 	 * code lenses for a given text document.
 	 * 
@@ -496,7 +505,7 @@ public interface TextDocumentService {
 	}
 
 	/**
-	 * Provide all incoming calls for an item, e.g all callers for a method. In graph terms this descibes directed
+	 * Provide all incoming calls for an item, e.g all callers for a method. In graph terms this describes directed
 	 * and annotated edges inside the call graph, e.g the given item is the starting node and the result is the nodes
 	 * that can be reached.
 	*/
@@ -508,7 +517,7 @@ public interface TextDocumentService {
 
 	/**
 	* Provide all outgoing calls for an item, e.g call calls to functions, methods, or constructors from the given item. In
-	* graph terms this descibes directed and annotated edges inside the call graph, e.g the given item is the starting
+	* graph terms this describes directed and annotated edges inside the call graph, e.g the given item is the starting
 	* node and the result is the nodes that can be reached.
 	*/
 	@Beta
@@ -550,7 +559,7 @@ public interface TextDocumentService {
 	 * The {@code textDocument/semanticTokens/range} request is sent from the client to the server to return
 	 * the semantic tokens delta for a range.
 	 *
-	 * When a user opens a file it can be benificial to only compute the semantic tokens for the visible range
+	 * When a user opens a file it can be beneficial to only compute the semantic tokens for the visible range
 	 * (faster rendering of the tokens in the user interface). If a server can compute these tokens faster than
 	 * for the whole file it can provide a handler for the textDocument/semanticTokens/range request to handle
 	 * this case special. Please note that if a client also announces that it will send the

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyCapabilities.java
@@ -18,6 +18,8 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
  * Capabilities specific to the {@code textDocument/prepareCallHierarchy}.
+ * 
+ * Since 3.16.0
  */
 @Beta
 @SuppressWarnings("all")

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyCapabilities.java
@@ -17,7 +17,7 @@ import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
- * Capabilities specific to the {@code textDocument/callHierarchy}.
+ * Capabilities specific to the {@code textDocument/prepareCallHierarchy}.
  */
 @Beta
 @SuppressWarnings("all")

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyIncomingCall.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyIncomingCall.java
@@ -22,6 +22,8 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
  * Represents an incoming call, e.g. a caller of a method or constructor.
+ * 
+ * Since 3.16.0
  */
 @Beta
 @SuppressWarnings("all")
@@ -43,8 +45,8 @@ public class CallHierarchyIncomingCall {
   }
   
   public CallHierarchyIncomingCall(@NonNull final CallHierarchyItem from, @NonNull final List<Range> fromRanges) {
-    this.from = from;
-    this.fromRanges = fromRanges;
+    this.from = Preconditions.<CallHierarchyItem>checkNotNull(from, "from");
+    this.fromRanges = Preconditions.<List<Range>>checkNotNull(fromRanges, "fromRanges");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyIncomingCallsParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyIncomingCallsParams.java
@@ -20,6 +20,8 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
  * The parameter of a `callHierarchy/incomingCalls` request.
+ * 
+ * Since 3.16.0
  */
 @Beta
 @SuppressWarnings("all")
@@ -31,7 +33,7 @@ public class CallHierarchyIncomingCallsParams {
   }
   
   public CallHierarchyIncomingCallsParams(@NonNull final CallHierarchyItem item) {
-    this.item = item;
+    this.item = Preconditions.<CallHierarchyItem>checkNotNull(item, "item");
   }
   
   @Pure

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyItem.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyItem.java
@@ -23,6 +23,8 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
  * The result of a {@code textDocument/prepareCallHierarchy} request.
+ * 
+ * Since 3.16.0
  */
 @Beta
 @SuppressWarnings("all")

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyItem.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyItem.java
@@ -12,10 +12,12 @@
 package org.eclipse.lsp4j;
 
 import com.google.common.annotations.Beta;
+import com.google.gson.annotations.JsonAdapter;
 import java.util.List;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.lsp4j.SymbolTag;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
@@ -71,6 +73,13 @@ public class CallHierarchyItem {
    */
   @NonNull
   private Range selectionRange;
+  
+  /**
+   * A data entry field that is preserved between a call hierarchy prepare and
+   * incoming calls or outgoing calls requests.
+   */
+  @JsonAdapter(JsonElementTypeAdapter.Factory.class)
+  private Object data;
   
   /**
    * The name of the item targeted by the call hierarchy request.
@@ -188,6 +197,23 @@ public class CallHierarchyItem {
     this.selectionRange = Preconditions.checkNotNull(selectionRange, "selectionRange");
   }
   
+  /**
+   * A data entry field that is preserved between a call hierarchy prepare and
+   * incoming calls or outgoing calls requests.
+   */
+  @Pure
+  public Object getData() {
+    return this.data;
+  }
+  
+  /**
+   * A data entry field that is preserved between a call hierarchy prepare and
+   * incoming calls or outgoing calls requests.
+   */
+  public void setData(final Object data) {
+    this.data = data;
+  }
+  
   @Override
   @Pure
   public String toString() {
@@ -199,6 +225,7 @@ public class CallHierarchyItem {
     b.add("uri", this.uri);
     b.add("range", this.range);
     b.add("selectionRange", this.selectionRange);
+    b.add("data", this.data);
     return b.toString();
   }
   
@@ -247,6 +274,11 @@ public class CallHierarchyItem {
         return false;
     } else if (!this.selectionRange.equals(other.selectionRange))
       return false;
+    if (this.data == null) {
+      if (other.data != null)
+        return false;
+    } else if (!this.data.equals(other.data))
+      return false;
     return true;
   }
   
@@ -261,6 +293,7 @@ public class CallHierarchyItem {
     result = prime * result + ((this.tags== null) ? 0 : this.tags.hashCode());
     result = prime * result + ((this.uri== null) ? 0 : this.uri.hashCode());
     result = prime * result + ((this.range== null) ? 0 : this.range.hashCode());
-    return prime * result + ((this.selectionRange== null) ? 0 : this.selectionRange.hashCode());
+    result = prime * result + ((this.selectionRange== null) ? 0 : this.selectionRange.hashCode());
+    return prime * result + ((this.data== null) ? 0 : this.data.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyItem.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyItem.java
@@ -22,7 +22,7 @@ import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
- * The result of a {@code textDocument/callHierarchy} request.
+ * The result of a {@code textDocument/prepareCallHierarchy} request.
  */
 @Beta
 @SuppressWarnings("all")

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyOutgoingCall.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyOutgoingCall.java
@@ -22,6 +22,8 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
  * Represents an outgoing call, e.g. calling a getter from a method or a method from a constructor etc.
+ * 
+ * Since 3.16.0
  */
 @Beta
 @SuppressWarnings("all")
@@ -44,8 +46,8 @@ public class CallHierarchyOutgoingCall {
   }
   
   public CallHierarchyOutgoingCall(@NonNull final CallHierarchyItem to, @NonNull final List<Range> fromRanges) {
-    this.to = to;
-    this.fromRanges = fromRanges;
+    this.to = Preconditions.<CallHierarchyItem>checkNotNull(to, "to");
+    this.fromRanges = Preconditions.<List<Range>>checkNotNull(fromRanges, "fromRanges");
   }
   
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyOutgoingCallsParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyOutgoingCallsParams.java
@@ -20,6 +20,8 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
  * The parameter of a `callHierarchy/outgoingCalls` request.
+ * 
+ * Since 3.16.0
  */
 @Beta
 @SuppressWarnings("all")
@@ -31,7 +33,7 @@ public class CallHierarchyOutgoingCallsParams {
   }
   
   public CallHierarchyOutgoingCallsParams(@NonNull final CallHierarchyItem item) {
-    this.item = item;
+    this.item = Preconditions.<CallHierarchyItem>checkNotNull(item, "item");
   }
   
   @Pure

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyPrepareParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CallHierarchyPrepareParams.java
@@ -18,6 +18,8 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
  * The parameter of a `textDocument/prepareCallHierarchy` request.
+ * 
+ * Since 3.16.0
  */
 @Beta
 @SuppressWarnings("all")

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeAction.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeAction.java
@@ -11,10 +11,14 @@
  */
 package org.eclipse.lsp4j;
 
+import com.google.common.annotations.Beta;
+import com.google.gson.annotations.JsonAdapter;
 import java.util.List;
+import org.eclipse.lsp4j.CodeActionDisabled;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
@@ -58,6 +62,26 @@ public class CodeAction {
   private Boolean isPreferred;
   
   /**
+   * Marks that the code action cannot currently be applied.
+   * 
+   * Clients should follow the following guidelines regarding disabled code actions:
+   * 
+   *   - Disabled code actions are not shown in automatic [lightbulb](https://code.visualstudio.com/docs/editor/editingevolved#_code-action)
+   *     code action menu.
+   * 
+   *   - Disabled actions are shown as faded out in the code action menu when the user request a more specific type
+   *     of code action, such as refactorings.
+   * 
+   *   - If the user has a [keybinding](https://code.visualstudio.com/docs/editor/refactoring#_keybindings-for-code-actions)
+   *     that auto applies a code action and only a disabled code actions are returned, the client should show the user an
+   *     error message with `reason` in the editor.
+   * 
+   * Since 3.16.0
+   */
+  @Beta
+  private CodeActionDisabled disabled;
+  
+  /**
    * The workspace edit this code action performs.
    */
   private WorkspaceEdit edit;
@@ -68,6 +92,16 @@ public class CodeAction {
    * executed and then the command.
    */
   private Command command;
+  
+  /**
+   * A data entry field that is preserved on a code action between
+   * a `textDocument/codeAction` and a `codeAction/resolve` request.
+   * 
+   * Since 3.16.0
+   */
+  @Beta
+  @JsonAdapter(JsonElementTypeAdapter.Factory.class)
+  private Object data;
   
   public CodeAction() {
   }
@@ -154,6 +188,49 @@ public class CodeAction {
   }
   
   /**
+   * Marks that the code action cannot currently be applied.
+   * 
+   * Clients should follow the following guidelines regarding disabled code actions:
+   * 
+   *   - Disabled code actions are not shown in automatic [lightbulb](https://code.visualstudio.com/docs/editor/editingevolved#_code-action)
+   *     code action menu.
+   * 
+   *   - Disabled actions are shown as faded out in the code action menu when the user request a more specific type
+   *     of code action, such as refactorings.
+   * 
+   *   - If the user has a [keybinding](https://code.visualstudio.com/docs/editor/refactoring#_keybindings-for-code-actions)
+   *     that auto applies a code action and only a disabled code actions are returned, the client should show the user an
+   *     error message with `reason` in the editor.
+   * 
+   * Since 3.16.0
+   */
+  @Pure
+  public CodeActionDisabled getDisabled() {
+    return this.disabled;
+  }
+  
+  /**
+   * Marks that the code action cannot currently be applied.
+   * 
+   * Clients should follow the following guidelines regarding disabled code actions:
+   * 
+   *   - Disabled code actions are not shown in automatic [lightbulb](https://code.visualstudio.com/docs/editor/editingevolved#_code-action)
+   *     code action menu.
+   * 
+   *   - Disabled actions are shown as faded out in the code action menu when the user request a more specific type
+   *     of code action, such as refactorings.
+   * 
+   *   - If the user has a [keybinding](https://code.visualstudio.com/docs/editor/refactoring#_keybindings-for-code-actions)
+   *     that auto applies a code action and only a disabled code actions are returned, the client should show the user an
+   *     error message with `reason` in the editor.
+   * 
+   * Since 3.16.0
+   */
+  public void setDisabled(final CodeActionDisabled disabled) {
+    this.disabled = disabled;
+  }
+  
+  /**
    * The workspace edit this code action performs.
    */
   @Pure
@@ -187,6 +264,27 @@ public class CodeAction {
     this.command = command;
   }
   
+  /**
+   * A data entry field that is preserved on a code action between
+   * a `textDocument/codeAction` and a `codeAction/resolve` request.
+   * 
+   * Since 3.16.0
+   */
+  @Pure
+  public Object getData() {
+    return this.data;
+  }
+  
+  /**
+   * A data entry field that is preserved on a code action between
+   * a `textDocument/codeAction` and a `codeAction/resolve` request.
+   * 
+   * Since 3.16.0
+   */
+  public void setData(final Object data) {
+    this.data = data;
+  }
+  
   @Override
   @Pure
   public String toString() {
@@ -195,8 +293,10 @@ public class CodeAction {
     b.add("kind", this.kind);
     b.add("diagnostics", this.diagnostics);
     b.add("isPreferred", this.isPreferred);
+    b.add("disabled", this.disabled);
     b.add("edit", this.edit);
     b.add("command", this.command);
+    b.add("data", this.data);
     return b.toString();
   }
   
@@ -230,6 +330,11 @@ public class CodeAction {
         return false;
     } else if (!this.isPreferred.equals(other.isPreferred))
       return false;
+    if (this.disabled == null) {
+      if (other.disabled != null)
+        return false;
+    } else if (!this.disabled.equals(other.disabled))
+      return false;
     if (this.edit == null) {
       if (other.edit != null)
         return false;
@@ -239,6 +344,11 @@ public class CodeAction {
       if (other.command != null)
         return false;
     } else if (!this.command.equals(other.command))
+      return false;
+    if (this.data == null) {
+      if (other.data != null)
+        return false;
+    } else if (!this.data.equals(other.data))
       return false;
     return true;
   }
@@ -252,7 +362,9 @@ public class CodeAction {
     result = prime * result + ((this.kind== null) ? 0 : this.kind.hashCode());
     result = prime * result + ((this.diagnostics== null) ? 0 : this.diagnostics.hashCode());
     result = prime * result + ((this.isPreferred== null) ? 0 : this.isPreferred.hashCode());
+    result = prime * result + ((this.disabled== null) ? 0 : this.disabled.hashCode());
     result = prime * result + ((this.edit== null) ? 0 : this.edit.hashCode());
-    return prime * result + ((this.command== null) ? 0 : this.command.hashCode());
+    result = prime * result + ((this.command== null) ? 0 : this.command.hashCode());
+    return prime * result + ((this.data== null) ? 0 : this.data.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeActionCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeActionCapabilities.java
@@ -11,7 +11,9 @@
  */
 package org.eclipse.lsp4j;
 
+import com.google.common.annotations.Beta;
 import org.eclipse.lsp4j.CodeActionLiteralSupportCapabilities;
+import org.eclipse.lsp4j.CodeActionResolveSupportCapabilities;
 import org.eclipse.lsp4j.DynamicRegistrationCapabilities;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -33,6 +35,33 @@ public class CodeActionCapabilities extends DynamicRegistrationCapabilities {
    * Since 3.15.0
    */
   private Boolean isPreferredSupport;
+  
+  /**
+   * Whether code action supports the `disabled` property.
+   * 
+   * Since 3.16.0
+   */
+  @Beta
+  private Boolean disabledSupport;
+  
+  /**
+   * Whether code action supports the `data` property which is
+   * preserved between a `textDocument/codeAction` and a
+   * `codeAction/resolve` request.
+   * 
+   * Since 3.16.0
+   */
+  @Beta
+  private Boolean dataSupport;
+  
+  /**
+   * Whether the client supports resolving additional code action
+   * properties via a separate `codeAction/resolve` request.
+   * 
+   * Since 3.16.0
+   */
+  @Beta
+  private CodeActionResolveSupportCapabilities resolveSupport;
   
   public CodeActionCapabilities() {
   }
@@ -87,12 +116,78 @@ public class CodeActionCapabilities extends DynamicRegistrationCapabilities {
     this.isPreferredSupport = isPreferredSupport;
   }
   
+  /**
+   * Whether code action supports the `disabled` property.
+   * 
+   * Since 3.16.0
+   */
+  @Pure
+  public Boolean getDisabledSupport() {
+    return this.disabledSupport;
+  }
+  
+  /**
+   * Whether code action supports the `disabled` property.
+   * 
+   * Since 3.16.0
+   */
+  public void setDisabledSupport(final Boolean disabledSupport) {
+    this.disabledSupport = disabledSupport;
+  }
+  
+  /**
+   * Whether code action supports the `data` property which is
+   * preserved between a `textDocument/codeAction` and a
+   * `codeAction/resolve` request.
+   * 
+   * Since 3.16.0
+   */
+  @Pure
+  public Boolean getDataSupport() {
+    return this.dataSupport;
+  }
+  
+  /**
+   * Whether code action supports the `data` property which is
+   * preserved between a `textDocument/codeAction` and a
+   * `codeAction/resolve` request.
+   * 
+   * Since 3.16.0
+   */
+  public void setDataSupport(final Boolean dataSupport) {
+    this.dataSupport = dataSupport;
+  }
+  
+  /**
+   * Whether the client supports resolving additional code action
+   * properties via a separate `codeAction/resolve` request.
+   * 
+   * Since 3.16.0
+   */
+  @Pure
+  public CodeActionResolveSupportCapabilities getResolveSupport() {
+    return this.resolveSupport;
+  }
+  
+  /**
+   * Whether the client supports resolving additional code action
+   * properties via a separate `codeAction/resolve` request.
+   * 
+   * Since 3.16.0
+   */
+  public void setResolveSupport(final CodeActionResolveSupportCapabilities resolveSupport) {
+    this.resolveSupport = resolveSupport;
+  }
+  
   @Override
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("codeActionLiteralSupport", this.codeActionLiteralSupport);
     b.add("isPreferredSupport", this.isPreferredSupport);
+    b.add("disabledSupport", this.disabledSupport);
+    b.add("dataSupport", this.dataSupport);
+    b.add("resolveSupport", this.resolveSupport);
     b.add("dynamicRegistration", getDynamicRegistration());
     return b.toString();
   }
@@ -119,6 +214,21 @@ public class CodeActionCapabilities extends DynamicRegistrationCapabilities {
         return false;
     } else if (!this.isPreferredSupport.equals(other.isPreferredSupport))
       return false;
+    if (this.disabledSupport == null) {
+      if (other.disabledSupport != null)
+        return false;
+    } else if (!this.disabledSupport.equals(other.disabledSupport))
+      return false;
+    if (this.dataSupport == null) {
+      if (other.dataSupport != null)
+        return false;
+    } else if (!this.dataSupport.equals(other.dataSupport))
+      return false;
+    if (this.resolveSupport == null) {
+      if (other.resolveSupport != null)
+        return false;
+    } else if (!this.resolveSupport.equals(other.resolveSupport))
+      return false;
     return true;
   }
   
@@ -128,6 +238,9 @@ public class CodeActionCapabilities extends DynamicRegistrationCapabilities {
     final int prime = 31;
     int result = super.hashCode();
     result = prime * result + ((this.codeActionLiteralSupport== null) ? 0 : this.codeActionLiteralSupport.hashCode());
-    return prime * result + ((this.isPreferredSupport== null) ? 0 : this.isPreferredSupport.hashCode());
+    result = prime * result + ((this.isPreferredSupport== null) ? 0 : this.isPreferredSupport.hashCode());
+    result = prime * result + ((this.disabledSupport== null) ? 0 : this.disabledSupport.hashCode());
+    result = prime * result + ((this.dataSupport== null) ? 0 : this.dataSupport.hashCode());
+    return prime * result + ((this.resolveSupport== null) ? 0 : this.resolveSupport.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeActionDisabled.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeActionDisabled.java
@@ -1,0 +1,106 @@
+/**
+ * Copyright (c) 2016-2018 TypeFox and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.lsp4j;
+
+import com.google.common.annotations.Beta;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+/**
+ * Marks that the code action cannot currently be applied.
+ * 
+ * Clients should follow the following guidelines regarding disabled code actions:
+ * 
+ *   - Disabled code actions are not shown in automatic [lightbulb](https://code.visualstudio.com/docs/editor/editingevolved#_code-action)
+ *     code action menu.
+ * 
+ *   - Disabled actions are shown as faded out in the code action menu when the user request a more specific type
+ *     of code action, such as refactorings.
+ * 
+ *   - If the user has a [keybinding](https://code.visualstudio.com/docs/editor/refactoring#_keybindings-for-code-actions)
+ *     that auto applies a code action and only a disabled code actions are returned, the client should show the user an
+ *     error message with `reason` in the editor.
+ * 
+ * Since 3.16.0
+ */
+@Beta
+@SuppressWarnings("all")
+public class CodeActionDisabled {
+  /**
+   * Human readable description of why the code action is currently disabled.
+   * 
+   * This is displayed in the code actions UI.
+   */
+  @NonNull
+  private String reason;
+  
+  public CodeActionDisabled() {
+  }
+  
+  public CodeActionDisabled(@NonNull final String reason) {
+    this.reason = Preconditions.<String>checkNotNull(reason, "reason");
+  }
+  
+  /**
+   * Human readable description of why the code action is currently disabled.
+   * 
+   * This is displayed in the code actions UI.
+   */
+  @Pure
+  @NonNull
+  public String getReason() {
+    return this.reason;
+  }
+  
+  /**
+   * Human readable description of why the code action is currently disabled.
+   * 
+   * This is displayed in the code actions UI.
+   */
+  public void setReason(@NonNull final String reason) {
+    this.reason = Preconditions.checkNotNull(reason, "reason");
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("reason", this.reason);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    CodeActionDisabled other = (CodeActionDisabled) obj;
+    if (this.reason == null) {
+      if (other.reason != null)
+        return false;
+    } else if (!this.reason.equals(other.reason))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.reason== null) ? 0 : this.reason.hashCode());
+  }
+}

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeActionOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeActionOptions.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j;
 
+import com.google.common.annotations.Beta;
 import java.util.List;
 import org.eclipse.lsp4j.AbstractWorkDoneProgressOptions;
 import org.eclipse.xtext.xbase.lib.Pure;
@@ -28,6 +29,15 @@ public class CodeActionOptions extends AbstractWorkDoneProgressOptions {
    * may list out every specific kind they provide.
    */
   private List<String> codeActionKinds;
+  
+  /**
+   * The server provides support to resolve additional
+   * information for a code action.
+   * 
+   * Since 3.16.0
+   */
+  @Beta
+  private Boolean resolveProvider;
   
   public CodeActionOptions() {
   }
@@ -57,11 +67,33 @@ public class CodeActionOptions extends AbstractWorkDoneProgressOptions {
     this.codeActionKinds = codeActionKinds;
   }
   
+  /**
+   * The server provides support to resolve additional
+   * information for a code action.
+   * 
+   * Since 3.16.0
+   */
+  @Pure
+  public Boolean getResolveProvider() {
+    return this.resolveProvider;
+  }
+  
+  /**
+   * The server provides support to resolve additional
+   * information for a code action.
+   * 
+   * Since 3.16.0
+   */
+  public void setResolveProvider(final Boolean resolveProvider) {
+    this.resolveProvider = resolveProvider;
+  }
+  
   @Override
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("codeActionKinds", this.codeActionKinds);
+    b.add("resolveProvider", this.resolveProvider);
     b.add("workDoneProgress", getWorkDoneProgress());
     return b.toString();
   }
@@ -83,12 +115,20 @@ public class CodeActionOptions extends AbstractWorkDoneProgressOptions {
         return false;
     } else if (!this.codeActionKinds.equals(other.codeActionKinds))
       return false;
+    if (this.resolveProvider == null) {
+      if (other.resolveProvider != null)
+        return false;
+    } else if (!this.resolveProvider.equals(other.resolveProvider))
+      return false;
     return true;
   }
   
   @Override
   @Pure
   public int hashCode() {
-    return 31 * super.hashCode() + ((this.codeActionKinds== null) ? 0 : this.codeActionKinds.hashCode());
+    final int prime = 31;
+    int result = super.hashCode();
+    result = prime * result + ((this.codeActionKinds== null) ? 0 : this.codeActionKinds.hashCode());
+    return prime * result + ((this.resolveProvider== null) ? 0 : this.resolveProvider.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeActionResolveSupportCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeActionResolveSupportCapabilities.java
@@ -1,0 +1,93 @@
+/**
+ * Copyright (c) 2016-2018 TypeFox and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.lsp4j;
+
+import com.google.common.annotations.Beta;
+import java.util.ArrayList;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+/**
+ * Whether the client supports resolving additional code action
+ * properties via a separate `codeAction/resolve` request.
+ * 
+ * Since 3.16.0
+ */
+@Beta
+@SuppressWarnings("all")
+public class CodeActionResolveSupportCapabilities {
+  /**
+   * The properties that a client can resolve lazily.
+   */
+  @NonNull
+  private List<String> properties;
+  
+  public CodeActionResolveSupportCapabilities() {
+    ArrayList<String> _arrayList = new ArrayList<String>();
+    this.properties = _arrayList;
+  }
+  
+  public CodeActionResolveSupportCapabilities(@NonNull final List<String> properties) {
+    this.properties = Preconditions.<List<String>>checkNotNull(properties, "properties");
+  }
+  
+  /**
+   * The properties that a client can resolve lazily.
+   */
+  @Pure
+  @NonNull
+  public List<String> getProperties() {
+    return this.properties;
+  }
+  
+  /**
+   * The properties that a client can resolve lazily.
+   */
+  public void setProperties(@NonNull final List<String> properties) {
+    this.properties = Preconditions.checkNotNull(properties, "properties");
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("properties", this.properties);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    CodeActionResolveSupportCapabilities other = (CodeActionResolveSupportCapabilities) obj;
+    if (this.properties == null) {
+      if (other.properties != null)
+        return false;
+    } else if (!this.properties.equals(other.properties))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.properties== null) ? 0 : this.properties.hashCode());
+  }
+}

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeLens.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CodeLens.java
@@ -41,7 +41,7 @@ public class CodeLens {
   private Command command;
   
   /**
-   * An data entry field that is preserved on a code lens item between a code lens and a code lens resolve request.
+   * A data entry field that is preserved on a code lens item between a code lens and a code lens resolve request.
    */
   @JsonAdapter(JsonElementTypeAdapter.Factory.class)
   private Object data;
@@ -91,7 +91,7 @@ public class CodeLens {
   }
   
   /**
-   * An data entry field that is preserved on a code lens item between a code lens and a code lens resolve request.
+   * A data entry field that is preserved on a code lens item between a code lens and a code lens resolve request.
    */
   @Pure
   public Object getData() {
@@ -99,7 +99,7 @@ public class CodeLens {
   }
   
   /**
-   * An data entry field that is preserved on a code lens item between a code lens and a code lens resolve request.
+   * A data entry field that is preserved on a code lens item between a code lens and a code lens resolve request.
    */
   public void setData(final Object data) {
     this.data = data;

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionItem.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionItem.java
@@ -135,7 +135,7 @@ public class CompletionItem {
   private Command command;
   
   /**
-   * An data entry field that is preserved on a completion item between a completion and a completion resolve request.
+   * A data entry field that is preserved on a completion item between a completion and a completion resolve request.
    */
   @JsonAdapter(JsonElementTypeAdapter.Factory.class)
   private Object data;
@@ -438,7 +438,7 @@ public class CompletionItem {
   }
   
   /**
-   * An data entry field that is preserved on a completion item between a completion and a completion resolve request.
+   * A data entry field that is preserved on a completion item between a completion and a completion resolve request.
    */
   @Pure
   public Object getData() {
@@ -446,7 +446,7 @@ public class CompletionItem {
   }
   
   /**
-   * An data entry field that is preserved on a completion item between a completion and a completion resolve request.
+   * A data entry field that is preserved on a completion item between a completion and a completion resolve request.
    */
   public void setData(final Object data) {
     this.data = data;

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionItemCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionItemCapabilities.java
@@ -11,7 +11,9 @@
  */
 package org.eclipse.lsp4j;
 
+import com.google.common.annotations.Beta;
 import java.util.List;
+import org.eclipse.lsp4j.CompletionItemResolveSupportCapabilities;
 import org.eclipse.lsp4j.CompletionItemTagSupportCapabilities;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
@@ -61,6 +63,25 @@ public class CompletionItemCapabilities {
    * Since 3.15.0
    */
   private CompletionItemTagSupportCapabilities tagSupport;
+  
+  /**
+   * Client support insert replace edit to control different behavior if a
+   * completion item is inserted in the text or should replace text.
+   * 
+   * Since 3.16.0
+   */
+  @Beta
+  private Boolean insertReplaceSupport;
+  
+  /**
+   * Indicates which properties a client can resolve lazily on a completion
+   * item. Before version 3.16.0 only the predefined properties `documentation`
+   * and `details` could be resolved lazily.
+   * 
+   * Since 3.16.0
+   */
+  @Beta
+  private CompletionItemResolveSupportCapabilities resolveSupport;
   
   public CompletionItemCapabilities() {
   }
@@ -181,6 +202,50 @@ public class CompletionItemCapabilities {
     this.tagSupport = tagSupport;
   }
   
+  /**
+   * Client support insert replace edit to control different behavior if a
+   * completion item is inserted in the text or should replace text.
+   * 
+   * Since 3.16.0
+   */
+  @Pure
+  public Boolean getInsertReplaceSupport() {
+    return this.insertReplaceSupport;
+  }
+  
+  /**
+   * Client support insert replace edit to control different behavior if a
+   * completion item is inserted in the text or should replace text.
+   * 
+   * Since 3.16.0
+   */
+  public void setInsertReplaceSupport(final Boolean insertReplaceSupport) {
+    this.insertReplaceSupport = insertReplaceSupport;
+  }
+  
+  /**
+   * Indicates which properties a client can resolve lazily on a completion
+   * item. Before version 3.16.0 only the predefined properties `documentation`
+   * and `details` could be resolved lazily.
+   * 
+   * Since 3.16.0
+   */
+  @Pure
+  public CompletionItemResolveSupportCapabilities getResolveSupport() {
+    return this.resolveSupport;
+  }
+  
+  /**
+   * Indicates which properties a client can resolve lazily on a completion
+   * item. Before version 3.16.0 only the predefined properties `documentation`
+   * and `details` could be resolved lazily.
+   * 
+   * Since 3.16.0
+   */
+  public void setResolveSupport(final CompletionItemResolveSupportCapabilities resolveSupport) {
+    this.resolveSupport = resolveSupport;
+  }
+  
   @Override
   @Pure
   public String toString() {
@@ -191,6 +256,8 @@ public class CompletionItemCapabilities {
     b.add("deprecatedSupport", this.deprecatedSupport);
     b.add("preselectSupport", this.preselectSupport);
     b.add("tagSupport", this.tagSupport);
+    b.add("insertReplaceSupport", this.insertReplaceSupport);
+    b.add("resolveSupport", this.resolveSupport);
     return b.toString();
   }
   
@@ -234,6 +301,16 @@ public class CompletionItemCapabilities {
         return false;
     } else if (!this.tagSupport.equals(other.tagSupport))
       return false;
+    if (this.insertReplaceSupport == null) {
+      if (other.insertReplaceSupport != null)
+        return false;
+    } else if (!this.insertReplaceSupport.equals(other.insertReplaceSupport))
+      return false;
+    if (this.resolveSupport == null) {
+      if (other.resolveSupport != null)
+        return false;
+    } else if (!this.resolveSupport.equals(other.resolveSupport))
+      return false;
     return true;
   }
   
@@ -247,6 +324,8 @@ public class CompletionItemCapabilities {
     result = prime * result + ((this.documentationFormat== null) ? 0 : this.documentationFormat.hashCode());
     result = prime * result + ((this.deprecatedSupport== null) ? 0 : this.deprecatedSupport.hashCode());
     result = prime * result + ((this.preselectSupport== null) ? 0 : this.preselectSupport.hashCode());
-    return prime * result + ((this.tagSupport== null) ? 0 : this.tagSupport.hashCode());
+    result = prime * result + ((this.tagSupport== null) ? 0 : this.tagSupport.hashCode());
+    result = prime * result + ((this.insertReplaceSupport== null) ? 0 : this.insertReplaceSupport.hashCode());
+    return prime * result + ((this.resolveSupport== null) ? 0 : this.resolveSupport.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionItemKindCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionItemKindCapabilities.java
@@ -16,6 +16,10 @@ import org.eclipse.lsp4j.CompletionItemKind;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
+/**
+ * The client supports the following `CompletionItemKind` specific
+ * capabilities.
+ */
 @SuppressWarnings("all")
 public class CompletionItemKindCapabilities {
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionItemResolveSupportCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/CompletionItemResolveSupportCapabilities.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) 2016-2018 TypeFox and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.lsp4j;
+
+import com.google.common.annotations.Beta;
+import java.util.ArrayList;
+import java.util.List;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+/**
+ * Indicates which properties a client can resolve lazily on a completion
+ * item. Before version 3.16.0 only the predefined properties `documentation`
+ * and `details` could be resolved lazily.
+ * 
+ * Since 3.16.0
+ */
+@Beta
+@SuppressWarnings("all")
+public class CompletionItemResolveSupportCapabilities {
+  /**
+   * The properties that a client can resolve lazily.
+   */
+  @NonNull
+  private List<String> properties;
+  
+  public CompletionItemResolveSupportCapabilities() {
+    ArrayList<String> _arrayList = new ArrayList<String>();
+    this.properties = _arrayList;
+  }
+  
+  public CompletionItemResolveSupportCapabilities(@NonNull final List<String> properties) {
+    this.properties = Preconditions.<List<String>>checkNotNull(properties, "properties");
+  }
+  
+  /**
+   * The properties that a client can resolve lazily.
+   */
+  @Pure
+  @NonNull
+  public List<String> getProperties() {
+    return this.properties;
+  }
+  
+  /**
+   * The properties that a client can resolve lazily.
+   */
+  public void setProperties(@NonNull final List<String> properties) {
+    this.properties = Preconditions.checkNotNull(properties, "properties");
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("properties", this.properties);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    CompletionItemResolveSupportCapabilities other = (CompletionItemResolveSupportCapabilities) obj;
+    if (this.properties == null) {
+      if (other.properties != null)
+        return false;
+    } else if (!this.properties.equals(other.properties))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.properties== null) ? 0 : this.properties.hashCode());
+  }
+}

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Diagnostic.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/Diagnostic.java
@@ -11,11 +11,15 @@
  */
 package org.eclipse.lsp4j;
 
+import com.google.common.annotations.Beta;
+import com.google.gson.annotations.JsonAdapter;
 import java.util.List;
+import org.eclipse.lsp4j.DiagnosticCodeDescription;
 import org.eclipse.lsp4j.DiagnosticRelatedInformation;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.DiagnosticTag;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.lsp4j.util.Preconditions;
@@ -45,6 +49,14 @@ public class Diagnostic {
   private Either<String, Number> code;
   
   /**
+   * An optional property to describe the error code.
+   * 
+   * Since 3.16.0
+   */
+  @Beta
+  private DiagnosticCodeDescription codeDescription;
+  
+  /**
    * A human-readable string describing the source of this diagnostic, e.g. 'typescript' or 'super lint'.
    */
   private String source;
@@ -69,6 +81,16 @@ public class Diagnostic {
    * Since 3.7.0
    */
   private List<DiagnosticRelatedInformation> relatedInformation;
+  
+  /**
+   * A data entry field that is preserved between a `textDocument/publishDiagnostics`
+   * notification and `textDocument/codeAction` request.
+   * 
+   * Since 3.16.0
+   */
+  @Beta
+  @JsonAdapter(JsonElementTypeAdapter.Factory.class)
+  private Object data;
   
   public Diagnostic() {
   }
@@ -154,6 +176,25 @@ public class Diagnostic {
   }
   
   /**
+   * An optional property to describe the error code.
+   * 
+   * Since 3.16.0
+   */
+  @Pure
+  public DiagnosticCodeDescription getCodeDescription() {
+    return this.codeDescription;
+  }
+  
+  /**
+   * An optional property to describe the error code.
+   * 
+   * Since 3.16.0
+   */
+  public void setCodeDescription(final DiagnosticCodeDescription codeDescription) {
+    this.codeDescription = codeDescription;
+  }
+  
+  /**
    * A human-readable string describing the source of this diagnostic, e.g. 'typescript' or 'super lint'.
    */
   @Pure
@@ -224,6 +265,27 @@ public class Diagnostic {
     this.relatedInformation = relatedInformation;
   }
   
+  /**
+   * A data entry field that is preserved between a `textDocument/publishDiagnostics`
+   * notification and `textDocument/codeAction` request.
+   * 
+   * Since 3.16.0
+   */
+  @Pure
+  public Object getData() {
+    return this.data;
+  }
+  
+  /**
+   * A data entry field that is preserved between a `textDocument/publishDiagnostics`
+   * notification and `textDocument/codeAction` request.
+   * 
+   * Since 3.16.0
+   */
+  public void setData(final Object data) {
+    this.data = data;
+  }
+  
   @Override
   @Pure
   public String toString() {
@@ -231,10 +293,12 @@ public class Diagnostic {
     b.add("range", this.range);
     b.add("severity", this.severity);
     b.add("code", this.code);
+    b.add("codeDescription", this.codeDescription);
     b.add("source", this.source);
     b.add("message", this.message);
     b.add("tags", this.tags);
     b.add("relatedInformation", this.relatedInformation);
+    b.add("data", this.data);
     return b.toString();
   }
   
@@ -263,6 +327,11 @@ public class Diagnostic {
         return false;
     } else if (!this.code.equals(other.code))
       return false;
+    if (this.codeDescription == null) {
+      if (other.codeDescription != null)
+        return false;
+    } else if (!this.codeDescription.equals(other.codeDescription))
+      return false;
     if (this.source == null) {
       if (other.source != null)
         return false;
@@ -283,6 +352,11 @@ public class Diagnostic {
         return false;
     } else if (!this.relatedInformation.equals(other.relatedInformation))
       return false;
+    if (this.data == null) {
+      if (other.data != null)
+        return false;
+    } else if (!this.data.equals(other.data))
+      return false;
     return true;
   }
   
@@ -294,9 +368,11 @@ public class Diagnostic {
     result = prime * result + ((this.range== null) ? 0 : this.range.hashCode());
     result = prime * result + ((this.severity== null) ? 0 : this.severity.hashCode());
     result = prime * result + ((this.code== null) ? 0 : this.code.hashCode());
+    result = prime * result + ((this.codeDescription== null) ? 0 : this.codeDescription.hashCode());
     result = prime * result + ((this.source== null) ? 0 : this.source.hashCode());
     result = prime * result + ((this.message== null) ? 0 : this.message.hashCode());
     result = prime * result + ((this.tags== null) ? 0 : this.tags.hashCode());
-    return prime * result + ((this.relatedInformation== null) ? 0 : this.relatedInformation.hashCode());
+    result = prime * result + ((this.relatedInformation== null) ? 0 : this.relatedInformation.hashCode());
+    return prime * result + ((this.data== null) ? 0 : this.data.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DiagnosticCodeDescription.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DiagnosticCodeDescription.java
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2016-2018 TypeFox and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ */
+package org.eclipse.lsp4j;
+
+import com.google.common.annotations.Beta;
+import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
+import org.eclipse.lsp4j.util.Preconditions;
+import org.eclipse.xtext.xbase.lib.Pure;
+import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
+
+/**
+ * Structure to capture a description for an error code.
+ * 
+ * Since 3.16.0
+ */
+@Beta
+@SuppressWarnings("all")
+public class DiagnosticCodeDescription {
+  /**
+   * A URI to open with more information about the diagnostic error.
+   */
+  @NonNull
+  private String href;
+  
+  public DiagnosticCodeDescription() {
+  }
+  
+  public DiagnosticCodeDescription(@NonNull final String href) {
+    this.href = Preconditions.<String>checkNotNull(href, "href");
+  }
+  
+  /**
+   * A URI to open with more information about the diagnostic error.
+   */
+  @Pure
+  @NonNull
+  public String getHref() {
+    return this.href;
+  }
+  
+  /**
+   * A URI to open with more information about the diagnostic error.
+   */
+  public void setHref(@NonNull final String href) {
+    this.href = Preconditions.checkNotNull(href, "href");
+  }
+  
+  @Override
+  @Pure
+  public String toString() {
+    ToStringBuilder b = new ToStringBuilder(this);
+    b.add("href", this.href);
+    return b.toString();
+  }
+  
+  @Override
+  @Pure
+  public boolean equals(final Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    DiagnosticCodeDescription other = (DiagnosticCodeDescription) obj;
+    if (this.href == null) {
+      if (other.href != null)
+        return false;
+    } else if (!this.href.equals(other.href))
+      return false;
+    return true;
+  }
+  
+  @Override
+  @Pure
+  public int hashCode() {
+    return 31 * 1 + ((this.href== null) ? 0 : this.href.hashCode());
+  }
+}

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentSymbol.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentSymbol.java
@@ -11,9 +11,11 @@
  */
 package org.eclipse.lsp4j;
 
+import com.google.common.annotations.Beta;
 import java.util.List;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.lsp4j.SymbolTag;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
@@ -60,8 +62,19 @@ public class DocumentSymbol {
   private String detail;
   
   /**
-   * Indicates if this symbol is deprecated.
+   * Tags for this document symbol.
+   * 
+   * Since 3.16.0
    */
+  @Beta
+  private List<SymbolTag> tags;
+  
+  /**
+   * Indicates if this symbol is deprecated.
+   * 
+   * @deprecated Use `tags` instead if supported.
+   */
+  @Deprecated
   private Boolean deprecated;
   
   /**
@@ -178,16 +191,41 @@ public class DocumentSymbol {
   }
   
   /**
-   * Indicates if this symbol is deprecated.
+   * Tags for this document symbol.
+   * 
+   * Since 3.16.0
    */
   @Pure
+  public List<SymbolTag> getTags() {
+    return this.tags;
+  }
+  
+  /**
+   * Tags for this document symbol.
+   * 
+   * Since 3.16.0
+   */
+  public void setTags(final List<SymbolTag> tags) {
+    this.tags = tags;
+  }
+  
+  /**
+   * Indicates if this symbol is deprecated.
+   * 
+   * @deprecated Use `tags` instead if supported.
+   */
+  @Pure
+  @Deprecated
   public Boolean getDeprecated() {
     return this.deprecated;
   }
   
   /**
    * Indicates if this symbol is deprecated.
+   * 
+   * @deprecated Use `tags` instead if supported.
    */
+  @Deprecated
   public void setDeprecated(final Boolean deprecated) {
     this.deprecated = deprecated;
   }
@@ -216,6 +254,7 @@ public class DocumentSymbol {
     b.add("range", this.range);
     b.add("selectionRange", this.selectionRange);
     b.add("detail", this.detail);
+    b.add("tags", this.tags);
     b.add("deprecated", this.deprecated);
     b.add("children", this.children);
     return b.toString();
@@ -256,6 +295,11 @@ public class DocumentSymbol {
         return false;
     } else if (!this.detail.equals(other.detail))
       return false;
+    if (this.tags == null) {
+      if (other.tags != null)
+        return false;
+    } else if (!this.tags.equals(other.tags))
+      return false;
     if (this.deprecated == null) {
       if (other.deprecated != null)
         return false;
@@ -279,6 +323,7 @@ public class DocumentSymbol {
     result = prime * result + ((this.range== null) ? 0 : this.range.hashCode());
     result = prime * result + ((this.selectionRange== null) ? 0 : this.selectionRange.hashCode());
     result = prime * result + ((this.detail== null) ? 0 : this.detail.hashCode());
+    result = prime * result + ((this.tags== null) ? 0 : this.tags.hashCode());
     result = prime * result + ((this.deprecated== null) ? 0 : this.deprecated.hashCode());
     return prime * result + ((this.children== null) ? 0 : this.children.hashCode());
   }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentSymbolCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentSymbolCapabilities.java
@@ -11,8 +11,10 @@
  */
 package org.eclipse.lsp4j;
 
+import com.google.common.annotations.Beta;
 import org.eclipse.lsp4j.DynamicRegistrationCapabilities;
 import org.eclipse.lsp4j.SymbolKindCapabilities;
+import org.eclipse.lsp4j.SymbolTagSupportCapabilities;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
@@ -30,6 +32,25 @@ public class DocumentSymbolCapabilities extends DynamicRegistrationCapabilities 
    * The client support hierarchical document symbols.
    */
   private Boolean hierarchicalDocumentSymbolSupport;
+  
+  /**
+   * The client supports tags on `SymbolInformation`. Tags are supported on
+   * `DocumentSymbol` if `hierarchicalDocumentSymbolSupport` is set to true.
+   * Clients supporting tags have to handle unknown tags gracefully.
+   * 
+   * Since 3.16.0
+   */
+  @Beta
+  private SymbolTagSupportCapabilities tagSupport;
+  
+  /**
+   * The client supports an additional label presented in the UI when
+   * registering a document symbol provider.
+   * 
+   * Since 3.16.0
+   */
+  @Beta
+  private Boolean labelSupport;
   
   public DocumentSymbolCapabilities() {
   }
@@ -83,12 +104,58 @@ public class DocumentSymbolCapabilities extends DynamicRegistrationCapabilities 
     this.hierarchicalDocumentSymbolSupport = hierarchicalDocumentSymbolSupport;
   }
   
+  /**
+   * The client supports tags on `SymbolInformation`. Tags are supported on
+   * `DocumentSymbol` if `hierarchicalDocumentSymbolSupport` is set to true.
+   * Clients supporting tags have to handle unknown tags gracefully.
+   * 
+   * Since 3.16.0
+   */
+  @Pure
+  public SymbolTagSupportCapabilities getTagSupport() {
+    return this.tagSupport;
+  }
+  
+  /**
+   * The client supports tags on `SymbolInformation`. Tags are supported on
+   * `DocumentSymbol` if `hierarchicalDocumentSymbolSupport` is set to true.
+   * Clients supporting tags have to handle unknown tags gracefully.
+   * 
+   * Since 3.16.0
+   */
+  public void setTagSupport(final SymbolTagSupportCapabilities tagSupport) {
+    this.tagSupport = tagSupport;
+  }
+  
+  /**
+   * The client supports an additional label presented in the UI when
+   * registering a document symbol provider.
+   * 
+   * Since 3.16.0
+   */
+  @Pure
+  public Boolean getLabelSupport() {
+    return this.labelSupport;
+  }
+  
+  /**
+   * The client supports an additional label presented in the UI when
+   * registering a document symbol provider.
+   * 
+   * Since 3.16.0
+   */
+  public void setLabelSupport(final Boolean labelSupport) {
+    this.labelSupport = labelSupport;
+  }
+  
   @Override
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("symbolKind", this.symbolKind);
     b.add("hierarchicalDocumentSymbolSupport", this.hierarchicalDocumentSymbolSupport);
+    b.add("tagSupport", this.tagSupport);
+    b.add("labelSupport", this.labelSupport);
     b.add("dynamicRegistration", getDynamicRegistration());
     return b.toString();
   }
@@ -115,6 +182,16 @@ public class DocumentSymbolCapabilities extends DynamicRegistrationCapabilities 
         return false;
     } else if (!this.hierarchicalDocumentSymbolSupport.equals(other.hierarchicalDocumentSymbolSupport))
       return false;
+    if (this.tagSupport == null) {
+      if (other.tagSupport != null)
+        return false;
+    } else if (!this.tagSupport.equals(other.tagSupport))
+      return false;
+    if (this.labelSupport == null) {
+      if (other.labelSupport != null)
+        return false;
+    } else if (!this.labelSupport.equals(other.labelSupport))
+      return false;
     return true;
   }
   
@@ -124,6 +201,8 @@ public class DocumentSymbolCapabilities extends DynamicRegistrationCapabilities 
     final int prime = 31;
     int result = super.hashCode();
     result = prime * result + ((this.symbolKind== null) ? 0 : this.symbolKind.hashCode());
-    return prime * result + ((this.hierarchicalDocumentSymbolSupport== null) ? 0 : this.hierarchicalDocumentSymbolSupport.hashCode());
+    result = prime * result + ((this.hierarchicalDocumentSymbolSupport== null) ? 0 : this.hierarchicalDocumentSymbolSupport.hashCode());
+    result = prime * result + ((this.tagSupport== null) ? 0 : this.tagSupport.hashCode());
+    return prime * result + ((this.labelSupport== null) ? 0 : this.labelSupport.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentSymbolOptions.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/DocumentSymbolOptions.java
@@ -11,16 +11,56 @@
  */
 package org.eclipse.lsp4j;
 
+import com.google.common.annotations.Beta;
 import org.eclipse.lsp4j.AbstractWorkDoneProgressOptions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 @SuppressWarnings("all")
 public class DocumentSymbolOptions extends AbstractWorkDoneProgressOptions {
+  /**
+   * A human-readable string that is shown when multiple outlines trees
+   * are shown for the same document.
+   * 
+   * Since 3.16.0
+   */
+  @Beta
+  private String label;
+  
+  public DocumentSymbolOptions() {
+  }
+  
+  @Beta
+  public DocumentSymbolOptions(final String label) {
+    this.label = label;
+  }
+  
+  /**
+   * A human-readable string that is shown when multiple outlines trees
+   * are shown for the same document.
+   * 
+   * Since 3.16.0
+   */
+  @Pure
+  public String getLabel() {
+    return this.label;
+  }
+  
+  /**
+   * A human-readable string that is shown when multiple outlines trees
+   * are shown for the same document.
+   * 
+   * Since 3.16.0
+   */
+  public void setLabel(final String label) {
+    this.label = label;
+  }
+  
   @Override
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
+    b.add("label", this.label);
     b.add("workDoneProgress", getWorkDoneProgress());
     return b.toString();
   }
@@ -36,12 +76,18 @@ public class DocumentSymbolOptions extends AbstractWorkDoneProgressOptions {
       return false;
     if (!super.equals(obj))
       return false;
+    DocumentSymbolOptions other = (DocumentSymbolOptions) obj;
+    if (this.label == null) {
+      if (other.label != null)
+        return false;
+    } else if (!this.label.equals(other.label))
+      return false;
     return true;
   }
   
   @Override
   @Pure
   public int hashCode() {
-    return super.hashCode();
+    return 31 * super.hashCode() + ((this.label== null) ? 0 : this.label.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/PrepareRenameResult.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/PrepareRenameResult.java
@@ -17,6 +17,10 @@ import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
+/**
+ * One of the result types of the `textDocument/prepareRename` request.
+ * Provides the range of the string to rename and a placeholder text of the string content to be renamed.
+ */
 @SuppressWarnings("all")
 public class PrepareRenameResult {
   /**

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/PublishDiagnosticsCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/PublishDiagnosticsCapabilities.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j;
 
+import com.google.common.annotations.Beta;
 import org.eclipse.lsp4j.DiagnosticsTagSupport;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.xtext.xbase.lib.Pure;
@@ -46,6 +47,24 @@ public class PublishDiagnosticsCapabilities {
    * Since 3.15.0
    */
   private Boolean versionSupport;
+  
+  /**
+   * Client supports a codeDescription property
+   * 
+   * Since 3.16.0
+   */
+  @Beta
+  private Boolean codeDescriptionSupport;
+  
+  /**
+   * Whether code action supports the `data` property which is
+   * preserved between a `textDocument/publishDiagnostics` and
+   * `textDocument/codeAction` request.
+   * 
+   * Since 3.16.0
+   */
+  @Beta
+  private Boolean dataSupport;
   
   public PublishDiagnosticsCapabilities() {
   }
@@ -147,6 +166,48 @@ public class PublishDiagnosticsCapabilities {
     this.versionSupport = versionSupport;
   }
   
+  /**
+   * Client supports a codeDescription property
+   * 
+   * Since 3.16.0
+   */
+  @Pure
+  public Boolean getCodeDescriptionSupport() {
+    return this.codeDescriptionSupport;
+  }
+  
+  /**
+   * Client supports a codeDescription property
+   * 
+   * Since 3.16.0
+   */
+  public void setCodeDescriptionSupport(final Boolean codeDescriptionSupport) {
+    this.codeDescriptionSupport = codeDescriptionSupport;
+  }
+  
+  /**
+   * Whether code action supports the `data` property which is
+   * preserved between a `textDocument/publishDiagnostics` and
+   * `textDocument/codeAction` request.
+   * 
+   * Since 3.16.0
+   */
+  @Pure
+  public Boolean getDataSupport() {
+    return this.dataSupport;
+  }
+  
+  /**
+   * Whether code action supports the `data` property which is
+   * preserved between a `textDocument/publishDiagnostics` and
+   * `textDocument/codeAction` request.
+   * 
+   * Since 3.16.0
+   */
+  public void setDataSupport(final Boolean dataSupport) {
+    this.dataSupport = dataSupport;
+  }
+  
   @Override
   @Pure
   public String toString() {
@@ -154,6 +215,8 @@ public class PublishDiagnosticsCapabilities {
     b.add("relatedInformation", this.relatedInformation);
     b.add("tagSupport", this.tagSupport);
     b.add("versionSupport", this.versionSupport);
+    b.add("codeDescriptionSupport", this.codeDescriptionSupport);
+    b.add("dataSupport", this.dataSupport);
     return b.toString();
   }
   
@@ -182,6 +245,16 @@ public class PublishDiagnosticsCapabilities {
         return false;
     } else if (!this.versionSupport.equals(other.versionSupport))
       return false;
+    if (this.codeDescriptionSupport == null) {
+      if (other.codeDescriptionSupport != null)
+        return false;
+    } else if (!this.codeDescriptionSupport.equals(other.codeDescriptionSupport))
+      return false;
+    if (this.dataSupport == null) {
+      if (other.dataSupport != null)
+        return false;
+    } else if (!this.dataSupport.equals(other.dataSupport))
+      return false;
     return true;
   }
   
@@ -192,6 +265,8 @@ public class PublishDiagnosticsCapabilities {
     int result = 1;
     result = prime * result + ((this.relatedInformation== null) ? 0 : this.relatedInformation.hashCode());
     result = prime * result + ((this.tagSupport== null) ? 0 : this.tagSupport.hashCode());
-    return prime * result + ((this.versionSupport== null) ? 0 : this.versionSupport.hashCode());
+    result = prime * result + ((this.versionSupport== null) ? 0 : this.versionSupport.hashCode());
+    result = prime * result + ((this.codeDescriptionSupport== null) ? 0 : this.codeDescriptionSupport.hashCode());
+    return prime * result + ((this.dataSupport== null) ? 0 : this.dataSupport.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/RenameCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/RenameCapabilities.java
@@ -28,6 +28,13 @@ public class RenameCapabilities extends DynamicRegistrationCapabilities {
    */
   private Boolean prepareSupport;
   
+  /**
+   * Client supports the default behavior result (`{ defaultBehavior: boolean }`).
+   * 
+   * Since 3.16.0
+   */
+  private Boolean prepareSupportDefaultBehavior;
+  
   public RenameCapabilities() {
   }
   
@@ -61,11 +68,31 @@ public class RenameCapabilities extends DynamicRegistrationCapabilities {
     this.prepareSupport = prepareSupport;
   }
   
+  /**
+   * Client supports the default behavior result (`{ defaultBehavior: boolean }`).
+   * 
+   * Since 3.16.0
+   */
+  @Pure
+  public Boolean getPrepareSupportDefaultBehavior() {
+    return this.prepareSupportDefaultBehavior;
+  }
+  
+  /**
+   * Client supports the default behavior result (`{ defaultBehavior: boolean }`).
+   * 
+   * Since 3.16.0
+   */
+  public void setPrepareSupportDefaultBehavior(final Boolean prepareSupportDefaultBehavior) {
+    this.prepareSupportDefaultBehavior = prepareSupportDefaultBehavior;
+  }
+  
   @Override
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("prepareSupport", this.prepareSupport);
+    b.add("prepareSupportDefaultBehavior", this.prepareSupportDefaultBehavior);
     b.add("dynamicRegistration", getDynamicRegistration());
     return b.toString();
   }
@@ -87,12 +114,20 @@ public class RenameCapabilities extends DynamicRegistrationCapabilities {
         return false;
     } else if (!this.prepareSupport.equals(other.prepareSupport))
       return false;
+    if (this.prepareSupportDefaultBehavior == null) {
+      if (other.prepareSupportDefaultBehavior != null)
+        return false;
+    } else if (!this.prepareSupportDefaultBehavior.equals(other.prepareSupportDefaultBehavior))
+      return false;
     return true;
   }
   
   @Override
   @Pure
   public int hashCode() {
-    return 31 * super.hashCode() + ((this.prepareSupport== null) ? 0 : this.prepareSupport.hashCode());
+    final int prime = 31;
+    int result = super.hashCode();
+    result = prime * result + ((this.prepareSupport== null) ? 0 : this.prepareSupport.hashCode());
+    return prime * result + ((this.prepareSupportDefaultBehavior== null) ? 0 : this.prepareSupportDefaultBehavior.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SelectionRange.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SelectionRange.java
@@ -20,6 +20,8 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 /**
  * A selection range represents a part of a selection hierarchy. A selection range
  * may have a parent selection range that contains it.
+ * 
+ * Since 3.15.0
  */
 @SuppressWarnings("all")
 public class SelectionRange {

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SelectionRangeParams.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SelectionRangeParams.java
@@ -22,6 +22,8 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
  * A parameter literal used in selection range requests.
+ * 
+ * Since 3.15.0
  */
 @SuppressWarnings("all")
 public class SelectionRangeParams extends WorkDoneProgressAndPartialResultParams {

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SemanticTokensLegend.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SemanticTokensLegend.java
@@ -18,6 +18,11 @@ import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
+/**
+ * The legend used by the server
+ * 
+ * Since 3.16.0
+ */
 @Beta
 @SuppressWarnings("all")
 public class SemanticTokensLegend {

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SemanticTokensServerFull.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SemanticTokensServerFull.java
@@ -15,6 +15,11 @@ import com.google.common.annotations.Beta;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
+/**
+ * Server supports providing semantic tokens for a full document.
+ * 
+ * Since 3.16.0
+ */
 @Beta
 @SuppressWarnings("all")
 public class SemanticTokensServerFull {

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ServerCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/ServerCapabilities.java
@@ -184,6 +184,8 @@ public class ServerCapabilities {
   
   /**
    * The server provides Call Hierarchy support.
+   * 
+   * Since 3.16.0
    */
   @Beta
   private Either<Boolean, StaticRegistrationOptions> callHierarchyProvider;
@@ -768,6 +770,8 @@ public class ServerCapabilities {
   
   /**
    * The server provides Call Hierarchy support.
+   * 
+   * Since 3.16.0
    */
   @Pure
   public Either<Boolean, StaticRegistrationOptions> getCallHierarchyProvider() {
@@ -776,6 +780,8 @@ public class ServerCapabilities {
   
   /**
    * The server provides Call Hierarchy support.
+   * 
+   * Since 3.16.0
    */
   public void setCallHierarchyProvider(final Either<Boolean, StaticRegistrationOptions> callHierarchyProvider) {
     this.callHierarchyProvider = callHierarchyProvider;

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureInformation.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureInformation.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j;
 
+import com.google.common.annotations.Beta;
 import java.util.List;
 import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.ParameterInformation;
@@ -41,6 +42,16 @@ public class SignatureInformation {
    * The parameters of this signature.
    */
   private List<ParameterInformation> parameters;
+  
+  /**
+   * The index of the active parameter.
+   * 
+   * If provided, this is used in place of `SignatureHelp.activeParameter`.
+   * 
+   * Since 3.16.0
+   */
+  @Beta
+  private Integer activeParameter;
   
   public SignatureInformation() {
   }
@@ -123,6 +134,29 @@ public class SignatureInformation {
     this.parameters = parameters;
   }
   
+  /**
+   * The index of the active parameter.
+   * 
+   * If provided, this is used in place of `SignatureHelp.activeParameter`.
+   * 
+   * Since 3.16.0
+   */
+  @Pure
+  public Integer getActiveParameter() {
+    return this.activeParameter;
+  }
+  
+  /**
+   * The index of the active parameter.
+   * 
+   * If provided, this is used in place of `SignatureHelp.activeParameter`.
+   * 
+   * Since 3.16.0
+   */
+  public void setActiveParameter(final Integer activeParameter) {
+    this.activeParameter = activeParameter;
+  }
+  
   @Override
   @Pure
   public String toString() {
@@ -130,6 +164,7 @@ public class SignatureInformation {
     b.add("label", this.label);
     b.add("documentation", this.documentation);
     b.add("parameters", this.parameters);
+    b.add("activeParameter", this.activeParameter);
     return b.toString();
   }
   
@@ -158,6 +193,11 @@ public class SignatureInformation {
         return false;
     } else if (!this.parameters.equals(other.parameters))
       return false;
+    if (this.activeParameter == null) {
+      if (other.activeParameter != null)
+        return false;
+    } else if (!this.activeParameter.equals(other.activeParameter))
+      return false;
     return true;
   }
   
@@ -168,6 +208,7 @@ public class SignatureInformation {
     int result = 1;
     result = prime * result + ((this.label== null) ? 0 : this.label.hashCode());
     result = prime * result + ((this.documentation== null) ? 0 : this.documentation.hashCode());
-    return prime * result + ((this.parameters== null) ? 0 : this.parameters.hashCode());
+    result = prime * result + ((this.parameters== null) ? 0 : this.parameters.hashCode());
+    return prime * result + ((this.activeParameter== null) ? 0 : this.activeParameter.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureInformationCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SignatureInformationCapabilities.java
@@ -11,6 +11,7 @@
  */
 package org.eclipse.lsp4j;
 
+import com.google.common.annotations.Beta;
 import java.util.List;
 import org.eclipse.lsp4j.ParameterInformationCapabilities;
 import org.eclipse.xtext.xbase.lib.Pure;
@@ -33,6 +34,15 @@ public class SignatureInformationCapabilities {
    * Client capabilities specific to parameter information.
    */
   private ParameterInformationCapabilities parameterInformation;
+  
+  /**
+   * The client supports the `activeParameter` property on `SignatureInformation`
+   * literal.
+   * 
+   * Since 3.16.0
+   */
+  @Beta
+  private Boolean activeParameterSupport;
   
   public SignatureInformationCapabilities() {
   }
@@ -77,12 +87,34 @@ public class SignatureInformationCapabilities {
     this.parameterInformation = parameterInformation;
   }
   
+  /**
+   * The client supports the `activeParameter` property on `SignatureInformation`
+   * literal.
+   * 
+   * Since 3.16.0
+   */
+  @Pure
+  public Boolean getActiveParameterSupport() {
+    return this.activeParameterSupport;
+  }
+  
+  /**
+   * The client supports the `activeParameter` property on `SignatureInformation`
+   * literal.
+   * 
+   * Since 3.16.0
+   */
+  public void setActiveParameterSupport(final Boolean activeParameterSupport) {
+    this.activeParameterSupport = activeParameterSupport;
+  }
+  
   @Override
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("documentationFormat", this.documentationFormat);
     b.add("parameterInformation", this.parameterInformation);
+    b.add("activeParameterSupport", this.activeParameterSupport);
     return b.toString();
   }
   
@@ -106,6 +138,11 @@ public class SignatureInformationCapabilities {
         return false;
     } else if (!this.parameterInformation.equals(other.parameterInformation))
       return false;
+    if (this.activeParameterSupport == null) {
+      if (other.activeParameterSupport != null)
+        return false;
+    } else if (!this.activeParameterSupport.equals(other.activeParameterSupport))
+      return false;
     return true;
   }
   
@@ -115,6 +152,7 @@ public class SignatureInformationCapabilities {
     final int prime = 31;
     int result = 1;
     result = prime * result + ((this.documentationFormat== null) ? 0 : this.documentationFormat.hashCode());
-    return prime * result + ((this.parameterInformation== null) ? 0 : this.parameterInformation.hashCode());
+    result = prime * result + ((this.parameterInformation== null) ? 0 : this.parameterInformation.hashCode());
+    return prime * result + ((this.activeParameterSupport== null) ? 0 : this.activeParameterSupport.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SymbolCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SymbolCapabilities.java
@@ -11,13 +11,16 @@
  */
 package org.eclipse.lsp4j;
 
+import com.google.common.annotations.Beta;
 import org.eclipse.lsp4j.DynamicRegistrationCapabilities;
 import org.eclipse.lsp4j.SymbolKindCapabilities;
+import org.eclipse.lsp4j.SymbolTagSupportCapabilities;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
  * Capabilities specific to the `workspace/symbol` request.
+ * Referred to in the spec as WorkspaceSymbolClientCapabilities.
  */
 @SuppressWarnings("all")
 public class SymbolCapabilities extends DynamicRegistrationCapabilities {
@@ -25,6 +28,15 @@ public class SymbolCapabilities extends DynamicRegistrationCapabilities {
    * Specific capabilities for the `SymbolKind` in the `workspace/symbol` request.
    */
   private SymbolKindCapabilities symbolKind;
+  
+  /**
+   * The client supports tags on `SymbolInformation`.
+   * Clients supporting tags have to handle unknown tags gracefully.
+   * 
+   * Since 3.16.0
+   */
+  @Beta
+  private SymbolTagSupportCapabilities tagSupport;
   
   public SymbolCapabilities() {
   }
@@ -57,11 +69,33 @@ public class SymbolCapabilities extends DynamicRegistrationCapabilities {
     this.symbolKind = symbolKind;
   }
   
+  /**
+   * The client supports tags on `SymbolInformation`.
+   * Clients supporting tags have to handle unknown tags gracefully.
+   * 
+   * Since 3.16.0
+   */
+  @Pure
+  public SymbolTagSupportCapabilities getTagSupport() {
+    return this.tagSupport;
+  }
+  
+  /**
+   * The client supports tags on `SymbolInformation`.
+   * Clients supporting tags have to handle unknown tags gracefully.
+   * 
+   * Since 3.16.0
+   */
+  public void setTagSupport(final SymbolTagSupportCapabilities tagSupport) {
+    this.tagSupport = tagSupport;
+  }
+  
   @Override
   @Pure
   public String toString() {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("symbolKind", this.symbolKind);
+    b.add("tagSupport", this.tagSupport);
     b.add("dynamicRegistration", getDynamicRegistration());
     return b.toString();
   }
@@ -83,12 +117,20 @@ public class SymbolCapabilities extends DynamicRegistrationCapabilities {
         return false;
     } else if (!this.symbolKind.equals(other.symbolKind))
       return false;
+    if (this.tagSupport == null) {
+      if (other.tagSupport != null)
+        return false;
+    } else if (!this.tagSupport.equals(other.tagSupport))
+      return false;
     return true;
   }
   
   @Override
   @Pure
   public int hashCode() {
-    return 31 * super.hashCode() + ((this.symbolKind== null) ? 0 : this.symbolKind.hashCode());
+    final int prime = 31;
+    int result = super.hashCode();
+    result = prime * result + ((this.symbolKind== null) ? 0 : this.symbolKind.hashCode());
+    return prime * result + ((this.tagSupport== null) ? 0 : this.tagSupport.hashCode());
   }
 }

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SymbolInformation.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SymbolInformation.java
@@ -11,9 +11,12 @@
  */
 package org.eclipse.lsp4j;
 
+import com.google.common.annotations.Beta;
 import com.google.gson.annotations.JsonAdapter;
+import java.util.List;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.lsp4j.SymbolTag;
 import org.eclipse.lsp4j.adapters.SymbolInformationTypeAdapter;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.lsp4j.util.Preconditions;
@@ -39,8 +42,19 @@ public class SymbolInformation {
   private SymbolKind kind;
   
   /**
-   * Indicates if this symbol is deprecated.
+   * Tags for this symbol.
+   * 
+   * Since 3.16.0
    */
+  @Beta
+  private List<SymbolTag> tags;
+  
+  /**
+   * Indicates if this symbol is deprecated.
+   * 
+   * @deprecated Use `tags` instead if supported.
+   */
+  @Deprecated
   private Boolean deprecated;
   
   /**
@@ -112,16 +126,41 @@ public class SymbolInformation {
   }
   
   /**
-   * Indicates if this symbol is deprecated.
+   * Tags for this symbol.
+   * 
+   * Since 3.16.0
    */
   @Pure
+  public List<SymbolTag> getTags() {
+    return this.tags;
+  }
+  
+  /**
+   * Tags for this symbol.
+   * 
+   * Since 3.16.0
+   */
+  public void setTags(final List<SymbolTag> tags) {
+    this.tags = tags;
+  }
+  
+  /**
+   * Indicates if this symbol is deprecated.
+   * 
+   * @deprecated Use `tags` instead if supported.
+   */
+  @Pure
+  @Deprecated
   public Boolean getDeprecated() {
     return this.deprecated;
   }
   
   /**
    * Indicates if this symbol is deprecated.
+   * 
+   * @deprecated Use `tags` instead if supported.
    */
+  @Deprecated
   public void setDeprecated(final Boolean deprecated) {
     this.deprecated = deprecated;
   }
@@ -185,6 +224,7 @@ public class SymbolInformation {
     ToStringBuilder b = new ToStringBuilder(this);
     b.add("name", this.name);
     b.add("kind", this.kind);
+    b.add("tags", this.tags);
     b.add("deprecated", this.deprecated);
     b.add("location", this.location);
     b.add("containerName", this.containerName);
@@ -211,6 +251,11 @@ public class SymbolInformation {
         return false;
     } else if (!this.kind.equals(other.kind))
       return false;
+    if (this.tags == null) {
+      if (other.tags != null)
+        return false;
+    } else if (!this.tags.equals(other.tags))
+      return false;
     if (this.deprecated == null) {
       if (other.deprecated != null)
         return false;
@@ -236,6 +281,7 @@ public class SymbolInformation {
     int result = 1;
     result = prime * result + ((this.name== null) ? 0 : this.name.hashCode());
     result = prime * result + ((this.kind== null) ? 0 : this.kind.hashCode());
+    result = prime * result + ((this.tags== null) ? 0 : this.tags.hashCode());
     result = prime * result + ((this.deprecated== null) ? 0 : this.deprecated.hashCode());
     result = prime * result + ((this.location== null) ? 0 : this.location.hashCode());
     return prime * result + ((this.containerName== null) ? 0 : this.containerName.hashCode());

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SymbolTagSupportCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SymbolTagSupportCapabilities.java
@@ -22,6 +22,8 @@ import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
  * Specific capabilities for the `SymbolTag`.
+ * 
+ * Since 3.16.0
  */
 @Beta
 @SuppressWarnings("all")

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SymbolTagSupportCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/SymbolTagSupportCapabilities.java
@@ -11,37 +11,34 @@
  */
 package org.eclipse.lsp4j;
 
+import com.google.common.annotations.Beta;
 import java.util.ArrayList;
 import java.util.List;
-import org.eclipse.lsp4j.CompletionItemTag;
+import org.eclipse.lsp4j.SymbolTag;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 import org.eclipse.lsp4j.util.Preconditions;
 import org.eclipse.xtext.xbase.lib.Pure;
 import org.eclipse.xtext.xbase.lib.util.ToStringBuilder;
 
 /**
- * Client supports the tag property on a completion item. Clients supporting
- * tags have to handle unknown tags gracefully. Clients especially need to
- * preserve unknown tags when sending a completion item back to the server in
- * a resolve call.
- * 
- * Since 3.15.0
+ * Specific capabilities for the `SymbolTag`.
  */
+@Beta
 @SuppressWarnings("all")
-public class CompletionItemTagSupportCapabilities {
+public class SymbolTagSupportCapabilities {
   /**
    * The tags supported by the client.
    */
   @NonNull
-  private List<CompletionItemTag> valueSet;
+  private List<SymbolTag> valueSet;
   
-  public CompletionItemTagSupportCapabilities() {
-    ArrayList<CompletionItemTag> _arrayList = new ArrayList<CompletionItemTag>();
+  public SymbolTagSupportCapabilities() {
+    ArrayList<SymbolTag> _arrayList = new ArrayList<SymbolTag>();
     this.valueSet = _arrayList;
   }
   
-  public CompletionItemTagSupportCapabilities(@NonNull final List<CompletionItemTag> valueSet) {
-    this.valueSet = Preconditions.<List<CompletionItemTag>>checkNotNull(valueSet, "valueSet");
+  public SymbolTagSupportCapabilities(@NonNull final List<SymbolTag> valueSet) {
+    this.valueSet = Preconditions.<List<SymbolTag>>checkNotNull(valueSet, "valueSet");
   }
   
   /**
@@ -49,14 +46,14 @@ public class CompletionItemTagSupportCapabilities {
    */
   @Pure
   @NonNull
-  public List<CompletionItemTag> getValueSet() {
+  public List<SymbolTag> getValueSet() {
     return this.valueSet;
   }
   
   /**
    * The tags supported by the client.
    */
-  public void setValueSet(@NonNull final List<CompletionItemTag> valueSet) {
+  public void setValueSet(@NonNull final List<SymbolTag> valueSet) {
     this.valueSet = Preconditions.checkNotNull(valueSet, "valueSet");
   }
   
@@ -77,7 +74,7 @@ public class CompletionItemTagSupportCapabilities {
       return false;
     if (getClass() != obj.getClass())
       return false;
-    CompletionItemTagSupportCapabilities other = (CompletionItemTagSupportCapabilities) obj;
+    SymbolTagSupportCapabilities other = (SymbolTagSupportCapabilities) obj;
     if (this.valueSet == null) {
       if (other.valueSet != null)
         return false;

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentClientCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentClientCapabilities.java
@@ -174,7 +174,7 @@ public class TextDocumentClientCapabilities {
   private TypeHierarchyCapabilities typeHierarchyCapabilities;
   
   /**
-   * Capabilities specific to {@code textDocument/callHierarchy}.
+   * Capabilities specific to {@code textDocument/prepareCallHierarchy}.
    */
   @Beta
   private CallHierarchyCapabilities callHierarchy;
@@ -560,7 +560,7 @@ public class TextDocumentClientCapabilities {
   }
   
   /**
-   * Capabilities specific to {@code textDocument/callHierarchy}.
+   * Capabilities specific to {@code textDocument/prepareCallHierarchy}.
    */
   @Pure
   public CallHierarchyCapabilities getCallHierarchy() {
@@ -568,7 +568,7 @@ public class TextDocumentClientCapabilities {
   }
   
   /**
-   * Capabilities specific to {@code textDocument/callHierarchy}.
+   * Capabilities specific to {@code textDocument/prepareCallHierarchy}.
    */
   public void setCallHierarchy(final CallHierarchyCapabilities callHierarchy) {
     this.callHierarchy = callHierarchy;

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentClientCapabilities.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/TextDocumentClientCapabilities.java
@@ -175,6 +175,8 @@ public class TextDocumentClientCapabilities {
   
   /**
    * Capabilities specific to {@code textDocument/prepareCallHierarchy}.
+   * 
+   * Since 3.16.0
    */
   @Beta
   private CallHierarchyCapabilities callHierarchy;
@@ -189,7 +191,7 @@ public class TextDocumentClientCapabilities {
   /**
    * Capabilities specific to {@code textDocument/semanticTokens}.
    * 
-   * @since 3.16.0
+   * Since 3.16.0
    */
   @Beta
   private SemanticTokensCapabilities semanticTokens;
@@ -561,6 +563,8 @@ public class TextDocumentClientCapabilities {
   
   /**
    * Capabilities specific to {@code textDocument/prepareCallHierarchy}.
+   * 
+   * Since 3.16.0
    */
   @Pure
   public CallHierarchyCapabilities getCallHierarchy() {
@@ -569,6 +573,8 @@ public class TextDocumentClientCapabilities {
   
   /**
    * Capabilities specific to {@code textDocument/prepareCallHierarchy}.
+   * 
+   * Since 3.16.0
    */
   public void setCallHierarchy(final CallHierarchyCapabilities callHierarchy) {
     this.callHierarchy = callHierarchy;
@@ -596,7 +602,7 @@ public class TextDocumentClientCapabilities {
   /**
    * Capabilities specific to {@code textDocument/semanticTokens}.
    * 
-   * @since 3.16.0
+   * Since 3.16.0
    */
   @Pure
   public SemanticTokensCapabilities getSemanticTokens() {
@@ -606,7 +612,7 @@ public class TextDocumentClientCapabilities {
   /**
    * Capabilities specific to {@code textDocument/semanticTokens}.
    * 
-   * @since 3.16.0
+   * Since 3.16.0
    */
   public void setSemanticTokens(final SemanticTokensCapabilities semanticTokens) {
     this.semanticTokens = semanticTokens;

--- a/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/adapters/SymbolInformationTypeAdapter.java
+++ b/org.eclipse.lsp4j/src/main/xtend-gen/org/eclipse/lsp4j/adapters/SymbolInformationTypeAdapter.java
@@ -8,11 +8,13 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonWriter;
 import java.io.IOException;
+import java.util.List;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.lsp4j.SymbolTag;
 import org.eclipse.lsp4j.generator.TypeAdapterImpl;
 
 /**
@@ -69,6 +71,8 @@ public class SymbolInformationTypeAdapter extends TypeAdapter<SymbolInformation>
     out.endObject();
   }
   
+  private static final TypeToken<List<SymbolTag>> TAGS_TYPE_TOKEN = new TypeToken<List<SymbolTag>>() {};
+  
   private final Gson gson;
   
   public SymbolInformationTypeAdapter(final Gson gson) {
@@ -91,6 +95,9 @@ public class SymbolInformationTypeAdapter extends TypeAdapter<SymbolInformation>
     		break;
     	case "kind":
     		result.setKind(readKind(in));
+    		break;
+    	case "tags":
+    		result.setTags(readTags(in));
     		break;
     	case "deprecated":
     		result.setDeprecated(readDeprecated(in));
@@ -117,6 +124,10 @@ public class SymbolInformationTypeAdapter extends TypeAdapter<SymbolInformation>
     return gson.fromJson(in, SymbolKind.class);
   }
   
+  protected List<SymbolTag> readTags(final JsonReader in) throws IOException {
+    return gson.fromJson(in, TAGS_TYPE_TOKEN.getType());
+  }
+  
   protected Boolean readDeprecated(final JsonReader in) throws IOException {
     return gson.fromJson(in, Boolean.class);
   }
@@ -140,6 +151,8 @@ public class SymbolInformationTypeAdapter extends TypeAdapter<SymbolInformation>
     writeName(out, value.getName());
     out.name("kind");
     writeKind(out, value.getKind());
+    out.name("tags");
+    writeTags(out, value.getTags());
     out.name("deprecated");
     writeDeprecated(out, value.getDeprecated());
     out.name("location");
@@ -155,6 +168,10 @@ public class SymbolInformationTypeAdapter extends TypeAdapter<SymbolInformation>
   
   protected void writeKind(final JsonWriter out, final SymbolKind value) throws IOException {
     gson.toJson(value, SymbolKind.class, out);
+  }
+  
+  protected void writeTags(final JsonWriter out, final List<SymbolTag> value) throws IOException {
+    gson.toJson(value, TAGS_TYPE_TOKEN.getType(), out);
   }
   
   protected void writeDeprecated(final JsonWriter out, final Boolean value) throws IOException {


### PR DESCRIPTION
Some of the larger proposed LSP 3.16 changes such as call hierarchy and semantic token support have already been added or are in progress. I have bundled most of the remaining changes here. They include:

* Add client capability for resolving text edits on completion items.
* Add client capability for using client default behavior on renames. (The new `prepareRename` result still needs to be implemented)
* Add support for insert and replace ranges on `CompletionItem`.
* Add support for diagnostic code descriptions.
* Add support for document symbol provider label.
* Add support for tags on `SymbolInformation` and `DocumentSymbol` and deprecated the standalone `deprecated` properties.
* Add support for call hierarchy item `data` property.
* Add support for code action `data` property.
* Add support for code action `disabled` property.
* Add support for code action resolve request.
* Add support for diagnostic `data` property.
* Add support for signature information `activeParameter` property.

There are also some minor changes to comments or format.