### PR TITLE
Bug #199: Move .gitignore out of temporary directory

### DIFF
--- a/org.eclipse.lsp4j/src/test/.gitignore
+++ b/org.eclipse.lsp4j/src/test/.gitignore
@@ -1,0 +1,1 @@
+/xtend-gen/

--- a/org.eclipse.lsp4j/src/test/xtend-gen/.gitignore
+++ b/org.eclipse.lsp4j/src/test/xtend-gen/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
The xtend-gen directory is deleted as part of normal build process
which leaves git status returning non-empty after a ./gradew build