### PR TITLE
Fix #522: Change the field type 'matches' of 'FileOperationPattern' to be String

### DIFF
--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -7053,10 +7053,9 @@ class FileOperationPattern {
 	/**
 	 * Whether to match files or folders with this pattern.
 	 *
-	 * The match kind could be <code>FileOperationPatternKind.File</code>,
-	 * <code>FileOperationPatternKind.Folder</code> and undefined.
-	 *
 	 * Matches both if undefined.
+	 *
+	 * See {@link FileOperationPatternKind} for allowed values.
 	 */
 	String matches
 

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -7053,9 +7053,12 @@ class FileOperationPattern {
 	/**
 	 * Whether to match files or folders with this pattern.
 	 *
+	 * The match kind could be <code>FileOperationPatternKind.File</code>,
+	 * <code>FileOperationPatternKind.Folder</code> and undefined.
+	 *
 	 * Matches both if undefined.
 	 */
-	FileOperationPatternKind matches
+	String matches
 
 	/**
 	 * Additional options used during matching.


### PR DESCRIPTION

Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>