### PR TITLE
Fixes #531: Remove race condition from integration tests

### DIFF
--- a/org.eclipse.lsp4j.jsonrpc.debug/src/test/java/org/eclipse/lsp4j/jsonrpc/debug/test/DebugIntegrationTest.java
+++ b/org.eclipse.lsp4j.jsonrpc.debug/src/test/java/org/eclipse/lsp4j/jsonrpc/debug/test/DebugIntegrationTest.java
@@ -311,7 +311,7 @@ public class DebugIntegrationTest {
 				}
 			};
 			Launcher<MyClient> serverSideLauncher = DebugLauncher.createLauncher(server, MyClient.class, in, out);
-			serverSideLauncher.startListening();
+			serverSideLauncher.startListening().get(TIMEOUT, TimeUnit.MILLISECONDS);
 
 			logMessages.await(Level.WARNING, "Unsupported notification method: foo1");
 			logMessages.await(Level.WARNING, "Unsupported request method: foo2");
@@ -354,7 +354,7 @@ public class DebugIntegrationTest {
 				}
 			};
 			Launcher<MyClient> serverSideLauncher = DebugLauncher.createLauncher(server, MyClient.class, in, out);
-			serverSideLauncher.startListening();
+			serverSideLauncher.startListening().get(TIMEOUT, TimeUnit.MILLISECONDS);
 
 			logMessages.await(Level.INFO, "Unsupported notification method: $/foo1");
 			logMessages.await(Level.INFO, "Unsupported request method: $/foo2");

--- a/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/IntegrationTest.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/IntegrationTest.java
@@ -421,7 +421,7 @@ public class IntegrationTest {
 			ByteArrayOutputStream out = new ByteArrayOutputStream();
 			MyServer server = new MyServerImpl();
 			Launcher<MyClient> serverSideLauncher = Launcher.createLauncher(server, MyClient.class, in, out);
-			serverSideLauncher.startListening();
+			serverSideLauncher.startListening().get(TIMEOUT, TimeUnit.MILLISECONDS);
 			
 			logMessages.await(Level.WARNING, "Unsupported notification method: foo1");
 			logMessages.await(Level.WARNING, "Unsupported request method: foo2");
@@ -459,7 +459,7 @@ public class IntegrationTest {
 			ByteArrayOutputStream out = new ByteArrayOutputStream();
 			MyServer server = new MyServerImpl();
 			Launcher<MyClient> serverSideLauncher = Launcher.createLauncher(server, MyClient.class, in, out);
-			serverSideLauncher.startListening();
+			serverSideLauncher.startListening().get(TIMEOUT, TimeUnit.MILLISECONDS);
 			
 			logMessages.await(Level.INFO, "Unsupported notification method: $/foo1");
 			logMessages.await(Level.INFO, "Unsupported request method: $/foo2");
@@ -561,7 +561,7 @@ public class IntegrationTest {
 			ByteArrayOutputStream out = new ByteArrayOutputStream();
 			MyServer server = new MyServerImpl();
 			Launcher<MyClient> serverSideLauncher = Launcher.createLauncher(server, MyClient.class, in, out);
-			serverSideLauncher.startListening();
+			serverSideLauncher.startListening().get(TIMEOUT, TimeUnit.MILLISECONDS);
 			
 			logMessages.await(Level.SEVERE, "com.google.gson.stream.MalformedJsonException: Expected value at line 2 column 22 path $.params.value");
 			Assert.assertEquals("Content-Length: 51" + CRLF + CRLF


### PR DESCRIPTION
Some of the tests were checking for output which is produced on another
thread but with no synchronization to make sure the output has
finished being written by that thread.

By adding the "get" to startListening the test does not process
the output (or log message) until the other end has shutdown.

The reason this worked of the time is that there was partial synchronization
by having the logMessages.await - it caused the main thread to wait
long enough most of the time. However as the log messages are generated
before the tested output, there was still a small window for failure.

This was tested by adding a Thread.sleep(100) to StreamMessageConsumer.consume
and StreamMessageProducer.listen to check if the tests still passed.

A sleep longer than a few hundred milliseconds causes the tests to simply
timeout.