### PR TITLE
Missing fields

### DIFF
--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/ResponseError.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/ResponseError.java
@@ -20,7 +20,7 @@ import com.google.gson.annotations.JsonAdapter;
 public class ResponseError {
 
 	/**
-	 * A number indicating the error type that occured.
+	 * A number indicating the error type that occurred.
 	 */
 	@NonNull
 	private int code;
@@ -39,7 +39,7 @@ public class ResponseError {
 	}
 
 	/**
-	 * A string providing a short decription of the error.
+	 * A string providing a short description of the error.
 	 */
 	@NonNull
 	private String message;

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/ResponseErrorCode.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/ResponseErrorCode.java
@@ -41,7 +41,12 @@ public enum ResponseErrorCode {
 	@Deprecated
 	serverErrorStart(-32099),
 	
-	/** Should be {@code ServerNotInitialized} */
+	/**
+	 * Error code indicating that a server received a notification or
+	 * request before the server has received the {@code initialize} request.
+	 * 
+	 * Should be {@code ServerNotInitialized}
+	 */
 	serverNotInitialized(-32002),
 	
 	UnknownErrorCode(-32001),

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/ResponseErrorCode.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/ResponseErrorCode.java
@@ -26,15 +26,71 @@ public enum ResponseErrorCode {
 	
 	InternalError(-32603),
 	
+	/**
+	 * This is the start range of JSON RPC reserved error codes.
+	 * It doesn't denote a real error code. No LSP error codes should
+	 * be defined between the start and end range. For backwards
+	 * compatibility the {@link #serverNotInitialized} and the
+	 * {@link #UnknownErrorCode} are left in the range.
+	 *
+	 * Since 3.16.0
+	 */
+	jsonrpcReservedErrorRangeStart(-32099),
+	
+	/** @deprecated use {@link #jsonrpcReservedErrorRangeStart} */
+	@Deprecated
 	serverErrorStart(-32099),
 	
-	serverErrorEnd(-32000),
-	
+	/** Should be {@code ServerNotInitialized} */
 	serverNotInitialized(-32002),
 	
 	UnknownErrorCode(-32001),
 	
-	RequestCancelled(-32800);
+	/**
+	 * This is the start range of JSON RPC reserved error codes.
+	 * It doesn't denote a real error code.
+	 * 
+	 * Since 3.16.0
+	 */
+	jsonrpcReservedErrorRangeEnd(-32000),
+	
+	/** @deprecated use {@link #jsonrpcReservedErrorRangeEnd} */
+	@Deprecated
+	serverErrorEnd(-32000),
+	
+	/**
+	 * This is the start range of LSP reserved error codes.
+	 * It doesn't denote a real error code.
+	 *
+	 * Since 3.16.0
+	 */
+	lspReservedErrorRangeStart(-32899),
+	
+	/**
+	 * The server detected that the content of a document got
+	 * modified outside normal conditions. A server should
+	 * NOT send this error code if it detects a content change
+	 * in it unprocessed messages. The result even computed
+	 * on an older state might still be useful for the client.
+	 *
+	 * If a client decides that a result is not of any use anymore
+	 * the client should cancel the request.
+	 */
+	ContentModified(-32801),
+	
+	/**
+	 * The client has canceled a request and a server as detected
+	 * the cancel.
+	 */
+	RequestCancelled(-32800),
+	
+	/**
+	 * This is the end range of LSP reserved error codes.
+	 * It doesn't denote a real error code.
+	 *
+	 * Since 3.16.0
+	 */
+	lspReservedErrorRangeEnd(-32800);
 	
 	private final int value;
 	

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -6642,6 +6642,19 @@ class CompletionRegistrationOptions extends AbstractTextDocumentRegistrationAndW
 	 */
 	Boolean resolveProvider
 
+	/**
+	 * The list of all possible characters that commit a completion. This field
+	 * can be used if clients don't support individual commit characters per
+	 * completion item. See client capability
+	 * {@link CompletionItemCapabilities#commitCharactersSupport}.
+	 *
+	 * If a server provides both {@code allCommitCharacters} and commit characters on
+	 * an individual completion item the ones on the completion item win.
+	 *
+	 * Since 3.2.0
+	 */
+	List<String> allCommitCharacters
+
 	new() {
 	}
 

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -2534,6 +2534,19 @@ class CompletionOptions extends AbstractWorkDoneProgressOptions {
 	 */
 	List<String> triggerCharacters
 
+	/**
+	 * The list of all possible characters that commit a completion. This field
+	 * can be used if clients don't support individual commit characters per
+	 * completion item. See client capability
+	 * {@link CompletionItemCapabilities#commitCharactersSupport}.
+	 *
+	 * If a server provides both {@code allCommitCharacters} and commit characters on
+	 * an individual completion item the ones on the completion item win.
+	 *
+	 * Since 3.2.0
+	 */
+	List<String> allCommitCharacters
+
 	new() {
 	}
 


### PR DESCRIPTION
Adds some error code changes from 3.16 and earlier. Also adds `allCommitCharacters` from 3.2.