### PR TITLE
Add Either.map(...)

### DIFF
--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/Either.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/Either.java
@@ -15,6 +15,7 @@ import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.function.Function;
 
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 
@@ -24,11 +25,11 @@ import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 public class Either<L, R> {
 
 	public static <L, R> Either<L, R> forLeft(@NonNull L left) {
-		return new Either<L, R>(left, null);
+		return new Either<>(left, null);
 	}
 
 	public static <L, R> Either<L, R> forRight(@NonNull R right) {
-		return new Either<L, R>(null, right);
+		return new Either<>(null, right);
 	}
 
 	private final L left;
@@ -63,7 +64,17 @@ public class Either<L, R> {
 	public boolean isRight() {
 		return right != null;
 	}
-	
+
+	public <T> T map(@NonNull Function<? super L, ? extends T> mapLeft, @NonNull Function <? super R, ? extends T> mapRight) {
+		if (isLeft()) {
+			return mapLeft.apply(getLeft());
+		}
+		if (isRight()) {
+			return mapRight.apply(getRight());
+		}
+		return null;
+	}
+
 	@Override
 	public boolean equals(Object obj) {
 		if (obj instanceof Either<?, ?>) {

--- a/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/json/EitherTest.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/json/EitherTest.java
@@ -11,6 +11,10 @@
  ******************************************************************************/
 package org.eclipse.lsp4j.jsonrpc.test.json;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import java.util.Objects;
 
 import org.eclipse.lsp4j.jsonrpc.json.adapters.EitherTypeAdapter;
@@ -22,9 +26,6 @@ import org.junit.Test;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
-
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 
 public class EitherTest {
@@ -105,6 +106,18 @@ public class EitherTest {
 		Either<Object, String> either2 = Either.forRight("Testing");
 
 		assertFalse(either1.equals(either2));
+	}
+
+	@Test
+	public void testMap() {
+		Either<byte[], String> either =Either.forLeft(new byte[] { 'f', 'o', 'o'});
+		assertEquals("foo", either.map(
+				String::new,
+				String::toUpperCase));
+		either = Either.forRight("barlol");
+		assertEquals("BARLOL", either.map(
+				String::new,
+				String::toUpperCase));
 	}
 
 	protected static class MyObjectA {


### PR DESCRIPTION
Many case of usage of Either in LSP4E involve turning Either into a
value. That requires some boilerplate: declare variable, if/else.

This constructs can allow for instance replacing

	Either<TextEdit, InsertReplaceEdit> textEdit = item.getTextEdit();
	if (textEdit.isLeft())
		return offset ==
LSPEclipseUtils.toOffset(textEdit.getLeft().getRange().getStart(),
document);
	else {
		Position replace = textEdit.getRight().getReplace().getStart();
		Position insert = textEdit.getRight().getInsert().getStart();
		Position start = replace;
		if (replace.getLine() > insert.getLine() || replace.getCharacter() >
insert.getCharacter()) start = insert;
			return offset == LSPEclipseUtils.toOffset(start, document);
		}

by

	return offset == LSPEclipseUtils.toOffset(
		textEdit.map(
			edit -> edit.getRange().getStart(),
			insertReplaceEdit -> {
				Position replace = insertReplaceEdit.getReplace().getStart();
				Position insert = insertReplaceEdit.getInsert().getStart();
				Position start = replace;
				if (replace.getLine() > insert.getLine() || replace.getCharacter() >
insert.getCharacter()) start = insert;
			}), document);

which better captures the logic.