### PR TITLE
Fixes #567: update docs/scripts for master to main rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A brief overview of how to use LSP4J to implement a server or a client can be fo
 
  * Releases: <http://download.eclipse.org/lsp4j/updates/releases/>
  * Milestones: <http://download.eclipse.org/lsp4j/updates/milestones/>
- * Nightly: <https://download.eclipse.org/lsp4j/builds/master/>
+ * Nightly: <https://download.eclipse.org/lsp4j/builds/main/>
 
 #### Snapshots
 
@@ -57,7 +57,7 @@ The Maven Repositories, p2 Update Sites, and the Snapshots contain _signed jars_
 
 ### Building and Contributing
 
-To build and contribute to LSP4J please consult the [Contribution Guide](https://github.com/eclipse/lsp4j/blob/master/Contributing.md).
+To build and contribute to LSP4J please consult the [Contribution Guide](https://github.com/eclipse/lsp4j/blob/main/Contributing.md).
 
 ### Licenses
 

--- a/documentation/releasing.md
+++ b/documentation/releasing.md
@@ -4,38 +4,38 @@ This is the Release plan and TODO list for LSP4J release v0.13.0.
 
 Items at the beginning of development
 
-- [ ] Create an Endgame Issue to track the release. As a starting point use [documentation/releasing.md](https://github.com/eclipse/lsp4j/blob/master/documentation/releasing.md).
+- [ ] Create an Endgame Issue to track the release. As a starting point use [documentation/releasing.md](https://github.com/eclipse/lsp4j/blob/main/documentation/releasing.md).
     - [ ] Add the [Endgame](https://github.com/eclipse/lsp4j/labels/endgame) label and Milestone for the release
-    - [ ] Make sure any previous edits made to [Endgame issues](https://github.com/eclipse/lsp4j/labels/endgame) of previous releases are updated in [documentation/releasing.md](https://github.com/eclipse/lsp4j/blob/master/documentation/releasing.md)
+    - [ ] Make sure any previous edits made to [Endgame issues](https://github.com/eclipse/lsp4j/labels/endgame) of previous releases are updated in [documentation/releasing.md](https://github.com/eclipse/lsp4j/blob/main/documentation/releasing.md)
 - [ ] Ensure all previous [Endgame issues](https://github.com/eclipse/lsp4j/labels/endgame) are done.
 - [ ] Create a [New milestone](https://github.com/eclipse/lsp4j/milestones/new) for the release
 - [ ] Create release on [PMI](https://projects.eclipse.org/projects/technology.lsp4j)
-- [ ] Check [CHANGELOG.md](https://github.com/eclipse/lsp4j/blob/master/CHANGELOG.md) is up to date. The changelog should have a version entry, release date, API Breakages and other information consistent with current entries in the changelog.
-- [ ] Check [README.md](https://github.com/eclipse/lsp4j/blob/master/README.md) is up to date. In particular that the planned release and which versions of DAP and LSP are support is listed.
-- [ ] Increment version of all feature.xml, pom.xml and any other place full version is used. (Easiest way is global find and replace, e.g. `s/0.12.0/0.13.0/g` and review changes.) Ensure that `-SNAPSHOT` is restored in the [gradle/versions.gradle](https://github.com/eclipse/lsp4j/blob/master/gradle/versions.gradle) and  [releng/pom.xml](https://github.com/eclipse/lsp4j/blob/master/releng/pom.xml)
-- [ ] Enable `sh './releng/deploy-build.sh'` in [releng/build.Jenkinsfile](https://github.com/eclipse/lsp4j/blob/master/releng/build.Jenkinsfile) 
-- [ ] Ensure [the CI build](https://ci.eclipse.org/lsp4j/job/lsp4j-multi-build/job/master/) is stable - it is always better to release a "Green Dot" build
+- [ ] Check [CHANGELOG.md](https://github.com/eclipse/lsp4j/blob/main/CHANGELOG.md) is up to date. The changelog should have a version entry, release date, API Breakages and other information consistent with current entries in the changelog.
+- [ ] Check [README.md](https://github.com/eclipse/lsp4j/blob/main/README.md) is up to date. In particular that the planned release and which versions of DAP and LSP are support is listed.
+- [ ] Increment version of all feature.xml, pom.xml and any other place full version is used. (Easiest way is global find and replace, e.g. `s/0.12.0/0.13.0/g` and review changes.) Ensure that `-SNAPSHOT` is restored in the [gradle/versions.gradle](https://github.com/eclipse/lsp4j/blob/main/gradle/versions.gradle) and  [releng/pom.xml](https://github.com/eclipse/lsp4j/blob/main/releng/pom.xml)
+- [ ] Enable `sh './releng/deploy-build.sh'` in [releng/build.Jenkinsfile](https://github.com/eclipse/lsp4j/blob/main/releng/build.Jenkinsfile) 
+- [ ] Ensure [the CI build](https://ci.eclipse.org/lsp4j/job/lsp4j-multi-build/job/main/) is stable - it is always better to release a "Green Dot" build
 
 Items in the days ahead of Release day:
 
 - [ ] Schedule the release and if needed schedule a release review on the [PMI](https://projects.eclipse.org/projects/technology.lsp4j). A release review is needed every 12 months, not with each release.
-- [ ] Check [CHANGELOG.md](https://github.com/eclipse/lsp4j/blob/master/CHANGELOG.md) is up to date. The changelog should have a version entry, release date, API Breakages and other information consistent with current entries in the changelog.
-- [ ] Check [README.md](https://github.com/eclipse/lsp4j/blob/master/README.md) is up to date. In particular that the planned release and which versions of DAP and LSP are support is listed.
+- [ ] Check [CHANGELOG.md](https://github.com/eclipse/lsp4j/blob/main/CHANGELOG.md) is up to date. The changelog should have a version entry, release date, API Breakages and other information consistent with current entries in the changelog.
+- [ ] Check [README.md](https://github.com/eclipse/lsp4j/blob/main/README.md) is up to date. In particular that the planned release and which versions of DAP and LSP are support is listed.
 - [ ] Check all closed PRs and Issues to make sure their milestone is set. (*Note:* this was not until after 0.10.0 release so many old PRs and Issues have no milestone, therefore only consider items back to approx 5 Nov 2020). [This search may be useful to identify such closed issues](https://github.com/eclipse/lsp4j/issues?q=is%3Aclosed+no%3Amilestone+updated%3A%3E%3D2020-11-06)
 
 Items on Release day:
 
 - [ ] Prepare the repo for release by:
-    - [ ] removing `-SNAPSHOT` from [gradle/versions.gradle](https://github.com/eclipse/lsp4j/blob/master/gradle/versions.gradle)
-    - [ ] removing `-SNAPSHOT` from [releng/pom.xml](https://github.com/eclipse/lsp4j/blob/master/releng/pom.xml) entries in `<dependencies>` section.
-    - [ ] disabling `sh './releng/deploy-build.sh'` in [releng/build.Jenkinsfile](https://github.com/eclipse/lsp4j/blob/master/releng/build.Jenkinsfile) 
+    - [ ] removing `-SNAPSHOT` from [gradle/versions.gradle](https://github.com/eclipse/lsp4j/blob/main/gradle/versions.gradle)
+    - [ ] removing `-SNAPSHOT` from [releng/pom.xml](https://github.com/eclipse/lsp4j/blob/main/releng/pom.xml) entries in `<dependencies>` section.
+    - [ ] disabling `sh './releng/deploy-build.sh'` in [releng/build.Jenkinsfile](https://github.com/eclipse/lsp4j/blob/main/releng/build.Jenkinsfile) 
     - see commit https://github.com/eclipse/lsp4j/commit/328ce8a4c89b0cd84fb62118f459b6cf79b09e90 for a past example
 - [ ] Push the above change
-- [ ] Run [the CI build](https://ci.eclipse.org/lsp4j/job/lsp4j-multi-build/job/master/)
+- [ ] Run [the CI build](https://ci.eclipse.org/lsp4j/job/lsp4j-multi-build/job/main/)
 - [ ] Mark the build as Keep Forever and add to the description `v0.13.0`
 - [ ] Deploy the release by running [the Release CI job](https://ci.eclipse.org/lsp4j/job/lsp4j-release-eclipse) with parameters:
     - `LSP4J_PUBLISH_LOCATION` -> `updates/releases/0.13.0` ( <-- check version number)
-    - `PROJECT` -> `lsp4j-multi-build/job/master`
+    - `PROJECT` -> `lsp4j-multi-build/job/main`
     - `LSP4J_BUILD_NUMBER` -> the build that was just run above
 - [ ] Add to the deploy job description `v0.13.0`
 - [ ] Promote the staged repository to maven central
@@ -51,5 +51,5 @@ Items on Release day:
 - [ ] Contribute to Simrel. See [Simrel contribution example](https://git.eclipse.org/r/#/c/158624/)
 - [ ] Create a [release page on github](https://github.com/eclipse/lsp4j/releases/new)
 - [ ] Make an announcement on lsp4j-dev based on the [release page on github](https://github.com/eclipse/lsp4j/releases/tag/v0.13.0). [Example on lsp4j-dev archives](https://www.eclipse.org/lists/lsp4j-dev/msg00063.html)
-- [ ] Update [documentation/releasing.md](https://github.com/eclipse/lsp4j/blob/master/documentation/releasing.md) with any changes that may have been made to the release process.
+- [ ] Update [documentation/releasing.md](https://github.com/eclipse/lsp4j/blob/main/documentation/releasing.md) with any changes that may have been made to the release process.
 - [ ] Create the endgame for the next release right away, especially as version numbers and restoring `-SNAPSHOT` need to be done right away.

--- a/releng/deploy-build.sh
+++ b/releng/deploy-build.sh
@@ -29,7 +29,7 @@ $SSH mv ${DOWNLOAD_MOUNT}-new ${DOWNLOAD_MOUNT}
 
 # Only maven deploy specific branches
 case $BRANCH_NAME in
-    master | release_*)
+    main | release_*)
         # GPG Sign and Deploy to Maven Central snapshot
         find build/maven-repository -name '*.pom' | while read i
         do
@@ -52,6 +52,6 @@ case $BRANCH_NAME in
         done
         ;;
     *)
-        echo "Maven deployments only done on master and release branches"
+        echo "Maven deployments only done on main and release branches"
         ;;
 esac

--- a/releng/release-eclipse.Jenkinsfile
+++ b/releng/release-eclipse.Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
   parameters {
     booleanParam(defaultValue: true, description: 'Do a dry run of the build. All commands will be echoed. First run with this on, then when you are sure it is right, choose rebuild in the passing job and uncheck this box', name: 'DRY_RUN')
     string(defaultValue: 'updates/milestones/S201911261515', description: 'The relative path in LSP4J downloads area to publish promoted build to (e.g. updates/milestones/S201911261515, updates/releases/0.13.0)', name: 'LSP4J_PUBLISH_LOCATION')
-    string(defaultValue: 'lsp4j-multi-build/job/master', description: 'The LSP4J project name being promoted from (e.g. lsp4j-multi-build/job/master or lsp4j-multi-build/job/release_0.13.0).', name: 'PROJECT')
+    string(defaultValue: 'lsp4j-multi-build/job/main', description: 'The LSP4J project name being promoted from (e.g. lsp4j-multi-build/job/main or lsp4j-multi-build/job/release_0.13.0).', name: 'PROJECT')
     string(defaultValue: '12345', description: 'The CI build number being promoted from', name: 'LSP4J_BUILD_NUMBER')
   }
   stages {


### PR DESCRIPTION
This is the changes needed in the repo - some changes needed in the CI config has been done already:

- https://ci.eclipse.org/lsp4j/job/lsp4j-github-pullrequests/jobConfigHistory/showDiffFiles?timestamp1=2021-03-27_05-19-54&timestamp2=2021-09-16_16-32-45
- https://ci.eclipse.org/lsp4j/job/lsp4j-release-eclipse/jobConfigHistory/showDiffFiles?timestamp1=2021-04-02_09-36-57&timestamp2=2021-09-16_16-33-20