### PR TITLE
Add WorkspaceSymbol resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Breaking API changes:
 
  * Method `LanguageClient.setTrace` moved to `LanguageServer`, where it should
    have been according to the specification
+ * Return type of `workspace/symbol` changed from `List<? extends SymbolInformation>` to
+   `Either<List<? extends SymbolInformation>, List<? extends WorkspaceSymbol>>`
+
+Deprecated API changes:
+
+  * `SymbolInformation` is deprecated in favor of `DocumentSymbol` or `WorkspaceSymbol`
 
 ### v0.12.0 (Apr. 2021)
 

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -147,7 +147,7 @@ class DidChangeWatchedFilesCapabilities extends DynamicRegistrationCapabilities 
 
 /**
  * The client support partial workspace symbols. The client will send the
- * request `workspaceSymbol/resolve` to the server to resolve additional
+ * request {@code workspaceSymbol/resolve} to the server to resolve additional
  * properties.
  * <p>
  * Since 3.17.0
@@ -172,15 +172,14 @@ class WorkspaceSymbolResolveSupportCapabilities {
 }
 
 /**
- * Capabilities specific to the `workspace/symbol` request.
+ * Capabilities specific to the {@code workspace/symbol} request.
  * <p>
  * Referred to in the spec as {@code WorkspaceSymbolClientCapabilities}.
  */
 @JsonRpcData
 class SymbolCapabilities extends DynamicRegistrationCapabilities {
-
 	/**
-	 * Specific capabilities for the {@link SymbolKind} in the `workspace/symbol` request.
+	 * Specific capabilities for the {@link SymbolKind} in the {@code workspace/symbol} request.
 	 */
 	SymbolKindCapabilities symbolKind
 
@@ -193,8 +192,8 @@ class SymbolCapabilities extends DynamicRegistrationCapabilities {
 	SymbolTagSupportCapabilities tagSupport
 
 	/**
-	 * The client support partial workspace symbols. The client will send the
-	 * request `workspaceSymbol/resolve` to the server to resolve additional
+	 * The client supports partial workspace symbols. The client will send the
+	 * request {@code workspaceSymbol/resolve} to the server to resolve additional
 	 * properties.
 	 * <p>
 	 * Since 3.17.0
@@ -5988,7 +5987,7 @@ class DocumentSymbol {
 /**
  * Represents information about programming constructs like variables, classes, interfaces etc.
  *
- * @deprecated Use {@link DocumentSymbol} or {@link WorkspaceSymbol} instead
+ * @deprecated Use {@link DocumentSymbol} or {@link WorkspaceSymbol} instead if supported.
  */
 @Deprecated
 @JsonRpcData
@@ -6106,7 +6105,9 @@ class WorkspaceSymbol {
 	List<SymbolTag> tags
 
 	/**
-	 * The location of this symbol.
+	 * The location of this symbol. Whether a server is allowed to
+	 * return a location without a range depends on the client
+	 * capability {@link SymbolCapabilities#resolveSupport}.
 	 * <p>
 	 * See also {@link SymbolInformation#location}.
 	 */

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/adapters/DocumentSymbolResponseAdapter.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/adapters/DocumentSymbolResponseAdapter.java
@@ -25,6 +25,7 @@ import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
 import com.google.gson.reflect.TypeToken;
 
+@SuppressWarnings("deprecation")
 public class DocumentSymbolResponseAdapter implements TypeAdapterFactory {
 	
 	private static final TypeToken<Either<SymbolInformation, DocumentSymbol>> ELEMENT_TYPE

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/adapters/WorkspaceSymbolLocationTypeAdapter.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/adapters/WorkspaceSymbolLocationTypeAdapter.java
@@ -1,0 +1,37 @@
+/******************************************************************************
+ * Copyright (c) 2020 TypeFox and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ ******************************************************************************/
+
+package org.eclipse.lsp4j.adapters;
+
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.WorkspaceSymbolLocation;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.EitherTypeAdapter;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.EitherTypeAdapter.PropertyChecker;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+
+public class WorkspaceSymbolLocationTypeAdapter implements TypeAdapterFactory {
+	private static final TypeToken<Either<Location, WorkspaceSymbolLocation>> ELEMENT_TYPE
+			= new TypeToken<Either<Location, WorkspaceSymbolLocation>>() {};
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+		PropertyChecker leftChecker = new PropertyChecker("range");
+		PropertyChecker rightChecker = new PropertyChecker("uri");
+		return (TypeAdapter<T>) new EitherTypeAdapter<>(gson, ELEMENT_TYPE, leftChecker, rightChecker);
+	}
+}

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/adapters/WorkspaceSymbolLocationTypeAdapter.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/adapters/WorkspaceSymbolLocationTypeAdapter.java
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2020 TypeFox and others.
+ * Copyright (c) 2022 KamasamaK and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/adapters/WorkspaceSymbolResponseAdapter.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/adapters/WorkspaceSymbolResponseAdapter.java
@@ -1,0 +1,41 @@
+/******************************************************************************
+ * Copyright (c) 2018 TypeFox and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.lsp4j.adapters;
+
+import java.util.List;
+
+import org.eclipse.lsp4j.WorkspaceSymbol;
+import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.EitherTypeAdapter;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.EitherTypeAdapter.ListChecker;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.EitherTypeAdapter.PropertyChecker;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+
+public class WorkspaceSymbolResponseAdapter implements TypeAdapterFactory {
+
+	private static final TypeToken<Either<List<? extends SymbolInformation>, List<? extends WorkspaceSymbol>>> EITHER_TYPE
+			= new TypeToken<Either<List<? extends SymbolInformation>, List<? extends WorkspaceSymbol>>>() {};
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+		ListChecker leftChecker = new ListChecker(new PropertyChecker("deprecated"), false);
+		ListChecker rightChecker = new ListChecker(new PropertyChecker("name"), true);
+		return (TypeAdapter<T>) new EitherTypeAdapter<>(gson, EITHER_TYPE, leftChecker, rightChecker);
+	}
+	
+}

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/adapters/WorkspaceSymbolResponseAdapter.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/adapters/WorkspaceSymbolResponseAdapter.java
@@ -1,5 +1,5 @@
 /******************************************************************************
- * Copyright (c) 2018 TypeFox and others.
+ * Copyright (c) 2022 KamasamaK and others.
  * 
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,8 +13,8 @@ package org.eclipse.lsp4j.adapters;
 
 import java.util.List;
 
-import org.eclipse.lsp4j.WorkspaceSymbol;
 import org.eclipse.lsp4j.SymbolInformation;
+import org.eclipse.lsp4j.WorkspaceSymbol;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.EitherTypeAdapter;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.EitherTypeAdapter.ListChecker;
 import org.eclipse.lsp4j.jsonrpc.json.adapters.EitherTypeAdapter.PropertyChecker;
@@ -25,6 +25,7 @@ import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
 import com.google.gson.reflect.TypeToken;
 
+@SuppressWarnings("deprecation")
 public class WorkspaceSymbolResponseAdapter implements TypeAdapterFactory {
 
 	private static final TypeToken<Either<List<? extends SymbolInformation>, List<? extends WorkspaceSymbol>>> EITHER_TYPE

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/TextDocumentService.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/TextDocumentService.java
@@ -95,9 +95,9 @@ import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import org.eclipse.lsp4j.jsonrpc.services.JsonSegment;
 
+@SuppressWarnings("deprecation")
 @JsonSegment("textDocument")
 public interface TextDocumentService {
-
 	/**
 	 * The Completion request is sent from the client to the server to compute
 	 * completion items at a given cursor position. Completion items are

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/WorkspaceService.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/WorkspaceService.java
@@ -32,6 +32,7 @@ import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import org.eclipse.lsp4j.jsonrpc.services.JsonSegment;
 
+@SuppressWarnings("deprecation")
 @JsonSegment("workspace")
 public interface WorkspaceService {
 	/**

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/WorkspaceService.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/WorkspaceService.java
@@ -23,7 +23,11 @@ import org.eclipse.lsp4j.ExecuteCommandParams;
 import org.eclipse.lsp4j.RenameFilesParams;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.WorkspaceEdit;
+import org.eclipse.lsp4j.WorkspaceSymbol;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
+import org.eclipse.lsp4j.adapters.WorkspaceSymbolResponseAdapter;
+import org.eclipse.lsp4j.jsonrpc.json.ResponseJsonAdapter;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import org.eclipse.lsp4j.jsonrpc.services.JsonSegment;
@@ -36,8 +40,8 @@ public interface WorkspaceService {
 	 * server creates a WorkspaceEdit structure and applies the changes to the
 	 * workspace using the request workspace/applyEdit which is sent from the
 	 * server to the client.
-	 *
-	 * Registration Options: ExecuteCommandRegistrationOptions
+	 * <p>
+	 * Registration Options: {@link org.eclipse.lsp4j.ExecuteCommandRegistrationOptions}
 	 */
 	@JsonRequest
 	default CompletableFuture<Object> executeCommand(ExecuteCommandParams params) {
@@ -47,11 +51,23 @@ public interface WorkspaceService {
 	/**
 	 * The workspace symbol request is sent from the client to the server to
 	 * list project-wide symbols matching the query string.
-	 *
-	 * Registration Options: void
+	 * <p>
+	 * Registration Options: {@link org.eclipse.lsp4j.WorkspaceSymbolRegistrationOptions}
 	 */
 	@JsonRequest
-	default CompletableFuture<List<? extends SymbolInformation>> symbol(WorkspaceSymbolParams params) {
+	@ResponseJsonAdapter(WorkspaceSymbolResponseAdapter.class)
+	default CompletableFuture<Either<List<? extends SymbolInformation>, List<? extends WorkspaceSymbol>>> symbol(WorkspaceSymbolParams params) {
+		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * The request is sent from the client to the server to resolve additional information
+	 * for a given workspace symbol.
+	 * <p>
+	 * Since 3.17.0
+	 */
+	@JsonRequest(value="workspaceSymbol/resolve", useSegment=false)
+	default CompletableFuture<WorkspaceSymbol> resolveWorkspaceSymbol(WorkspaceSymbol workspaceSymbol) {
 		throw new UnsupportedOperationException();
 	}
 
@@ -75,7 +91,7 @@ public interface WorkspaceService {
 	 * The notification is sent by default if both ServerCapabilities/workspaceFolders
 	 * and ClientCapabilities/workspace/workspaceFolders are true; or if the server has
 	 * registered to receive this notification it first.
-	 * 
+	 * <p>
 	 * Since 3.6.0
 	 */
 	@JsonNotification
@@ -90,7 +106,7 @@ public interface WorkspaceService {
 	 * before the files are created. Please note that clients might drop results if computing
 	 * the edit took too long or if a server constantly fails on this request. This is
 	 * done to keep creates fast and reliable.
-	 *
+	 * <p>
 	 * Since 3.16.0
 	 */
 	@JsonRequest
@@ -101,7 +117,7 @@ public interface WorkspaceService {
 	/**
 	 * The did create files notification is sent from the client to the server when files
 	 * were created from within the client.
-	 * 
+	 * <p>
 	 * Since 3.16.0
 	 */
 	@JsonNotification
@@ -116,7 +132,7 @@ public interface WorkspaceService {
 	 * before the files are renamed. Please note that clients might drop results if computing
 	 * the edit took too long or if a server constantly fails on this request. This is
 	 * done to keep renames fast and reliable.
-	 *
+	 * <p>
 	 * Since 3.16.0
 	 */
 	@JsonRequest
@@ -127,7 +143,7 @@ public interface WorkspaceService {
 	/**
 	 * The did rename files notification is sent from the client to the server when files
 	 * were renamed from within the client.
-	 * 
+	 * <p>
 	 * Since 3.16.0
 	 */
 	@JsonNotification
@@ -142,7 +158,7 @@ public interface WorkspaceService {
 	 * before the files are deleted. Please note that clients might drop results if computing
 	 * the edit took too long or if a server constantly fails on this request. This is
 	 * done to keep deletes fast and reliable.
-	 *
+	 * <p>
 	 * Since 3.16.0
 	 */
 	@JsonRequest
@@ -153,7 +169,7 @@ public interface WorkspaceService {
 	/**
 	 * The did delete files notification is sent from the client to the server when files
 	 * were deleted from within the client.
-	 * 
+	 * <p>
 	 * Since 3.16.0
 	 */
 	@JsonNotification


### PR DESCRIPTION
- Add `resolveWorkspaceSymbol`
- Change return type for `symbol` (Breaking change)
- Deprecate `SymbolInformation`