### PR TITLE
Move runInTerminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Breaking API changes:
 
  * Method `LanguageClient.setTrace` moved to `LanguageServer`, where it should
    have been according to the specification
+ * Method `IDebugProtocolServer.runInTerminal` moved to `IDebugProtocolClient`, where it should
+   have been according to the specification
  * Removed `RenameOptions.id` as it was already deprecated and never specified for `StaticRegistrationOptions`
  * Removed `SemanticTokenTypes.Member` as it was already deprecated and not specified
  * Removed `TraceValue.Message` as it was already deprecated and not specified

--- a/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/services/IDebugProtocolClient.java
+++ b/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/services/IDebugProtocolClient.java
@@ -12,6 +12,8 @@
 
 package org.eclipse.lsp4j.debug.services;
 
+import java.util.concurrent.CompletableFuture;
+
 import org.eclipse.lsp4j.debug.BreakpointEventArguments;
 import org.eclipse.lsp4j.debug.CapabilitiesEventArguments;
 import org.eclipse.lsp4j.debug.ContinuedEventArguments;
@@ -26,10 +28,13 @@ import org.eclipse.lsp4j.debug.ProcessEventArguments;
 import org.eclipse.lsp4j.debug.ProgressEndEventArguments;
 import org.eclipse.lsp4j.debug.ProgressStartEventArguments;
 import org.eclipse.lsp4j.debug.ProgressUpdateEventArguments;
+import org.eclipse.lsp4j.debug.RunInTerminalRequestArguments;
+import org.eclipse.lsp4j.debug.RunInTerminalResponse;
 import org.eclipse.lsp4j.debug.StoppedEventArguments;
 import org.eclipse.lsp4j.debug.TerminatedEventArguments;
 import org.eclipse.lsp4j.debug.ThreadEventArguments;
 import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
+import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 
 /**
  * Declaration of client notifications for the
@@ -248,5 +253,21 @@ public interface IDebugProtocolClient {
 	 */
 	@JsonNotification
 	default void memory(MemoryEventArguments args) {
+	}
+
+	/**
+	 * This optional request is sent from the debug adapter to the client to run a
+	 * command in a terminal.
+	 * <p>
+	 * This is typically used to launch the debuggee in a terminal provided by the
+	 * client.
+	 * <p>
+	 * This request should only be called if the client has passed the value true
+	 * for the 'supportsRunInTerminalRequest' capability of the 'initialize'
+	 * request.
+	 */
+	@JsonRequest
+	default CompletableFuture<RunInTerminalResponse> runInTerminal(RunInTerminalRequestArguments args) {
+		throw new UnsupportedOperationException();
 	}
 }

--- a/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/services/IDebugProtocolServer.java
+++ b/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/services/IDebugProtocolServer.java
@@ -48,8 +48,6 @@ import org.eclipse.lsp4j.debug.ReadMemoryResponse;
 import org.eclipse.lsp4j.debug.RestartArguments;
 import org.eclipse.lsp4j.debug.RestartFrameArguments;
 import org.eclipse.lsp4j.debug.ReverseContinueArguments;
-import org.eclipse.lsp4j.debug.RunInTerminalRequestArguments;
-import org.eclipse.lsp4j.debug.RunInTerminalResponse;
 import org.eclipse.lsp4j.debug.ScopesArguments;
 import org.eclipse.lsp4j.debug.ScopesResponse;
 import org.eclipse.lsp4j.debug.SetBreakpointsArguments;
@@ -132,22 +130,6 @@ public interface IDebugProtocolServer {
 	 */
 	@JsonRequest
 	default CompletableFuture<Void> cancel(CancelArguments args) {
-		throw new UnsupportedOperationException();
-	}
-
-	/**
-	 * This optional request is sent from the debug adapter to the client to run a
-	 * command in a terminal.
-	 * <p>
-	 * This is typically used to launch the debuggee in a terminal provided by the
-	 * client.
-	 * <p>
-	 * This request should only be called if the client has passed the value true
-	 * for the 'supportsRunInTerminalRequest' capability of the 'initialize'
-	 * request.
-	 */
-	@JsonRequest
-	default CompletableFuture<RunInTerminalResponse> runInTerminal(RunInTerminalRequestArguments args) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/org.eclipse.lsp4j.debug/src/test/java/org/eclipse/lsp4j/debug/test/TestDebugServer.java
+++ b/org.eclipse.lsp4j.debug/src/test/java/org/eclipse/lsp4j/debug/test/TestDebugServer.java
@@ -33,8 +33,6 @@ import org.eclipse.lsp4j.debug.ReadMemoryResponse;
 import org.eclipse.lsp4j.debug.RestartArguments;
 import org.eclipse.lsp4j.debug.RestartFrameArguments;
 import org.eclipse.lsp4j.debug.ReverseContinueArguments;
-import org.eclipse.lsp4j.debug.RunInTerminalRequestArguments;
-import org.eclipse.lsp4j.debug.RunInTerminalResponse;
 import org.eclipse.lsp4j.debug.ScopesArguments;
 import org.eclipse.lsp4j.debug.ScopesResponse;
 import org.eclipse.lsp4j.debug.SetBreakpointsArguments;
@@ -68,11 +66,6 @@ import org.eclipse.lsp4j.debug.WriteMemoryResponse;
 import org.eclipse.lsp4j.debug.services.IDebugProtocolServer;
 
 public class TestDebugServer implements IDebugProtocolServer {
-	@Override
-	public CompletableFuture<RunInTerminalResponse> runInTerminal(RunInTerminalRequestArguments args) {
-		return CompletableFuture.completedFuture(null);
-	}
-
 	@Override
 	public CompletableFuture<Capabilities> initialize(InitializeRequestArguments args) {
 		return CompletableFuture.completedFuture(null);


### PR DESCRIPTION
Fixes #551

**Breaking API change**: Method `IDebugProtocolServer.runInTerminal` moved to `IDebugProtocolClient`, where it should have been according to the specification