### PR TITLE
#632: send messages with a queue each after each

### DIFF
--- a/org.eclipse.lsp4j.websocket.jakarta/src/test/java/org/eclipse/lsp4j/websocket/jakarta/test/MockConnectionTest.java
+++ b/org.eclipse.lsp4j.websocket.jakarta/src/test/java/org/eclipse/lsp4j/websocket/jakarta/test/MockConnectionTest.java
@@ -69,6 +69,15 @@ public class MockConnectionTest {
 	}
 	
 	@Test
+	public void testManyConcurrentNotifications() throws Exception {
+		for (int i = 0; i < 10; i ++) {
+			client.server.notify(String.valueOf(i));
+		}
+		await(() -> server.result.length() == 10);
+		Assert.assertEquals("0123456789", server.result);
+	}
+	
+	@Test
 	public void testChunkedNotification() throws Exception {
 		StringBuilder messageBuilder = new StringBuilder();
 		Random random = new Random(1);

--- a/org.eclipse.lsp4j.websocket.jakarta/src/test/java/org/eclipse/lsp4j/websocket/jakarta/test/MockConnectionTest.java
+++ b/org.eclipse.lsp4j.websocket.jakarta/src/test/java/org/eclipse/lsp4j/websocket/jakarta/test/MockConnectionTest.java
@@ -70,11 +70,14 @@ public class MockConnectionTest {
 	
 	@Test
 	public void testManyConcurrentNotifications() throws Exception {
-		for (int i = 0; i < 10; i ++) {
+		String expectedResult = "";
+		for (int i = 0; i < 20; i ++) {
 			client.server.notify(String.valueOf(i));
+			expectedResult += i;
 		}
-		await(() -> server.result.length() == 10);
-		Assert.assertEquals("0123456789", server.result);
+		int expectedResultLenght = expectedResult.length();
+		await(() -> server.result.length() == expectedResultLenght);
+		Assert.assertEquals(expectedResult, server.result);
 	}
 	
 	@Test

--- a/org.eclipse.lsp4j.websocket.jakarta/src/test/java/org/eclipse/lsp4j/websocket/jakarta/test/MockConnectionTest.java
+++ b/org.eclipse.lsp4j.websocket.jakarta/src/test/java/org/eclipse/lsp4j/websocket/jakarta/test/MockConnectionTest.java
@@ -71,12 +71,17 @@ public class MockConnectionTest {
 	@Test
 	public void testManyConcurrentNotifications() throws Exception {
 		String expectedResult = "";
-		for (int i = 0; i < 20; i ++) {
-			client.server.notify(String.valueOf(i));
-			expectedResult += i;
+		for (char i = 'a'; i <= 'z'; i ++) {
+			String x = Character.toString(i);
+			client.server.notify(x);
+			expectedResult += x;
 		}
 		int expectedResultLenght = expectedResult.length();
-		await(() -> server.result.length() == expectedResultLenght);
+		try {
+			await(() -> server.result.length() == expectedResultLenght);
+		} catch (Error e) {
+			// discard this error so that the nice error displays in the assertEquals
+		}
 		Assert.assertEquals(expectedResult, server.result);
 	}
 	

--- a/org.eclipse.lsp4j.websocket/src/main/java/org/eclipse/lsp4j/websocket/WebSocketMessageConsumer.java
+++ b/org.eclipse.lsp4j.websocket/src/main/java/org/eclipse/lsp4j/websocket/WebSocketMessageConsumer.java
@@ -75,7 +75,7 @@ public class WebSocketMessageConsumer implements MessageConsumer {
 		}
 	}
 	
-	class WebSocketSendHandler implements SendHandler {
+	private class WebSocketSendHandler implements SendHandler {
 		private final AtomicBoolean isSending = new AtomicBoolean();
 		
 		@Override
@@ -84,7 +84,7 @@ public class WebSocketMessageConsumer implements MessageConsumer {
 			handleNextMessage();
 		}
 		
-		private void handleNextMessage() {
+		void handleNextMessage() {
 			if (session.isOpen() && !messageQueue.isEmpty() && isSending.compareAndSet(false, true)) {
 				session.getAsyncRemote().sendText(messageQueue.poll(), this);
 			}

--- a/org.eclipse.lsp4j.websocket/src/main/java/org/eclipse/lsp4j/websocket/WebSocketMessageConsumer.java
+++ b/org.eclipse.lsp4j.websocket/src/main/java/org/eclipse/lsp4j/websocket/WebSocketMessageConsumer.java
@@ -91,5 +91,4 @@ public class WebSocketMessageConsumer implements MessageConsumer {
 		}
 	}
 	
-	
 }

--- a/org.eclipse.lsp4j.websocket/src/test/java/org/eclipse/lsp4j/websocket/test/MockConnectionTest.java
+++ b/org.eclipse.lsp4j.websocket/src/test/java/org/eclipse/lsp4j/websocket/test/MockConnectionTest.java
@@ -69,6 +69,15 @@ public class MockConnectionTest {
 	}
 	
 	@Test
+	public void testManyConcurrentNotifications() throws Exception {
+		for (int i = 0; i < 10; i ++) {
+			client.server.notify(String.valueOf(i));
+		}
+		await(() -> server.result.length() == 10);
+		Assert.assertEquals("0123456789", server.result);
+	}
+	
+	@Test
 	public void testChunkedNotification() throws Exception {
 		StringBuilder messageBuilder = new StringBuilder();
 		Random random = new Random(1);

--- a/org.eclipse.lsp4j.websocket/src/test/java/org/eclipse/lsp4j/websocket/test/MockConnectionTest.java
+++ b/org.eclipse.lsp4j.websocket/src/test/java/org/eclipse/lsp4j/websocket/test/MockConnectionTest.java
@@ -70,11 +70,14 @@ public class MockConnectionTest {
 	
 	@Test
 	public void testManyConcurrentNotifications() throws Exception {
-		for (int i = 0; i < 10; i ++) {
+		String expectedResult = "";
+		for (int i = 0; i < 20; i ++) {
 			client.server.notify(String.valueOf(i));
+			expectedResult += i;
 		}
-		await(() -> server.result.length() == 10);
-		Assert.assertEquals("0123456789", server.result);
+		int expectedResultLenght = expectedResult.length();
+		await(() -> server.result.length() == expectedResultLenght);
+		Assert.assertEquals(expectedResult, server.result);
 	}
 	
 	@Test

--- a/org.eclipse.lsp4j.websocket/src/test/java/org/eclipse/lsp4j/websocket/test/MockConnectionTest.java
+++ b/org.eclipse.lsp4j.websocket/src/test/java/org/eclipse/lsp4j/websocket/test/MockConnectionTest.java
@@ -71,12 +71,17 @@ public class MockConnectionTest {
 	@Test
 	public void testManyConcurrentNotifications() throws Exception {
 		String expectedResult = "";
-		for (int i = 0; i < 20; i ++) {
-			client.server.notify(String.valueOf(i));
-			expectedResult += i;
+		for (char i = 'a'; i <= 'z'; i ++) {
+			String x = Character.toString(i);
+			client.server.notify(x);
+			expectedResult += x;
 		}
 		int expectedResultLenght = expectedResult.length();
-		await(() -> server.result.length() == expectedResultLenght);
+		try {
+			await(() -> server.result.length() == expectedResultLenght);
+		} catch (Error e) {
+			// discard this error so that the nice error displays in the assertEquals
+		}
 		Assert.assertEquals(expectedResult, server.result);
 	}
 	


### PR DESCRIPTION
Fix for: https://github.com/eclipse/lsp4j/issues/632

I tried to implement a queue for sending messages over WebSocket.
I used a SendHandler to define a callback, where the next message is get from the queue and sent to the client.

With this change messages are sent each after another. So also the new test I've added work. Without the queue this test fails with a random order of the numbers.

Also if I now run my tests against a such patched LSP4J lib, I don't receive the `TEXT_FULL_WRITING` exception any longer from Tomcat, and the tests are much more stable.

What do you think? Do you have any concerns or improvements?