### PR TITLE
switch to orbit 2022-09 and widen version range for gson. See #611

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -33,7 +33,7 @@ The project maintains the following source code repositories:
 
 This project leverages the following third party content.
 
-Google Gson (2.8.9)
+Google Gson (2.9.0)
 
 * License: Apache License, 2.0
 * Project: https://github.com/google/gson

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -16,8 +16,8 @@ ext.versions = [
 	'xtend_lib': '2.24.0',
 	'guava': '[14.0,31)',
 	'guava_orbit': '30.1.0.v20210127-2300',
-	'gson': '[2.8.9,2.9)',
-	'gson_orbit': '2.8.9.v20220111-1409',
+	'gson': '[2.9.0,2.10)',
+	'gson_orbit': '2.9.0.v20220704-0629',
 	'websocket_jakarta': '2.0.0',
 	'websocket': '1.0',
 	'junit': '4.12'

--- a/releng/lsp4j-feature/feature.xml
+++ b/releng/lsp4j-feature/feature.xml
@@ -31,7 +31,7 @@
    </license>
 
    <requires>
-      <import plugin="com.google.gson" version="2.8.9" match="equivalent"/>
+      <import plugin="com.google.gson" version="2.9.0" match="equivalent"/>
       <import plugin="org.eclipse.xtend.lib" version="2.10.0" match="compatible"/>
    </requires>
 

--- a/releng/p2/category.xml
+++ b/releng/p2/category.xml
@@ -3,8 +3,8 @@
 	<feature id="org.eclipse.lsp4j.sdk" version="0.15.0.qualifier">
 		<category name="lsp4j"/>
 	</feature>
-	<bundle id="com.google.gson" version="2.8.9.qualifier"/>
-	<bundle id="com.google.gson.source" version="2.8.9.qualifier"/>
+	<bundle id="com.google.gson" version="2.9.0.qualifier"/>
+	<bundle id="com.google.gson.source" version="2.9.0.qualifier"/>
 	<bundle id="com.google.guava" version="30.1.0.qualifier"/>
 	<bundle id="com.google.guava.source" version="30.1.0.qualifier"/>
 	<bundle id="jakarta.websocket" version="0.0.0"/>

--- a/releng/releng-target/lsp4j.target.target
+++ b/releng/releng-target/lsp4j.target.target
@@ -3,13 +3,19 @@
 <target name="org.eclipse.xtext.helios.target" sequenceNumber="0">
 	<locations>
 		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
-			<repository location="https://download.eclipse.org/tools/orbit/downloads/2022-03"/>
-			<unit id="com.google.gson" version="2.8.9.v20220111-1409"/>
-			<unit id="com.google.gson.source" version="2.8.9.v20220111-1409"/>
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/drops/I20220718151716/repository/"/>
+			<!--
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2022-09"/>
+			-->
+			<unit id="com.google.gson" version="2.9.0.v20220704-0629"/>
+			<unit id="com.google.gson.source" version="2.9.0.v20220704-0629"/>
 			<unit id="com.google.guava" version="30.1.0.v20210127-2300"/>
 			<unit id="com.google.guava.source" version="30.1.0.v20210127-2300"/>
 			<unit id="jakarta.websocket" version="0.0.0"/>
 			<unit id="jakarta.websocket.source" version="0.0.0"/>
+		</location>
+		<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+			<repository location="https://download.eclipse.org/tools/orbit/downloads/2022-03"/>
 			<unit id="javax.websocket" version="0.0.0"/>
 			<unit id="javax.websocket.source" version="0.0.0"/>
 		</location>


### PR DESCRIPTION
switch to orbit 2022-09 and widen version range for gson. See #611

unfortunately gson 2.9 is still not available in an orbit milestone. so i have to keep the 2.8.9 on p2 and the lower bound