### PR TITLE
Don't throw UOE from `LanguageServer.getNotebookDocumentService()`

### DIFF
--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/services/GenericEndpoint.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/services/GenericEndpoint.java
@@ -77,7 +77,7 @@ public class GenericEndpoint implements Endpoint {
 				if (delegate != null) {
 					recursiveFindRpcMethods(delegate, visited, visitedForDelegate);
 				} else {
-					LOG.log(Level.SEVERE, "A delegate object is null, jsonrpc methods of '" + method + "' are ignored");
+					LOG.fine("A delegate object is null, jsonrpc methods of '" + method + "' are ignored");
 				}
 			} catch (InvocationTargetException | IllegalAccessException e) {
 				throw new RuntimeException(e);

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/LanguageServer.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/LanguageServer.java
@@ -90,7 +90,7 @@ public interface LanguageServer {
 	 */
 	@JsonDelegate
 	default NotebookDocumentService getNotebookDocumentService() {
-		throw new UnsupportedOperationException();
+		return null;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #658