### PR TITLE
Add missing type adapters

### DIFF
--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -17,14 +17,17 @@ import java.util.Arrays
 import java.util.LinkedHashMap
 import java.util.List
 import java.util.Map
+import org.eclipse.lsp4j.adapters.CompletionItemDefaultsEditRangeTypeAdapter
 import org.eclipse.lsp4j.adapters.CompletionItemTextEditTypeAdapter
 import org.eclipse.lsp4j.adapters.DocumentChangeListAdapter
+import org.eclipse.lsp4j.adapters.DocumentDiagnosticReportTypeAdapter
 import org.eclipse.lsp4j.adapters.HoverTypeAdapter
 import org.eclipse.lsp4j.adapters.InitializeParamsTypeAdapter
 import org.eclipse.lsp4j.adapters.ProgressNotificationAdapter
 import org.eclipse.lsp4j.adapters.ResourceOperationTypeAdapter
 import org.eclipse.lsp4j.adapters.SymbolInformationTypeAdapter
 import org.eclipse.lsp4j.adapters.VersionedTextDocumentIdentifierTypeAdapter
+import org.eclipse.lsp4j.adapters.WorkspaceDocumentDiagnosticReportTypeAdapter
 import org.eclipse.lsp4j.adapters.WorkspaceSymbolLocationTypeAdapter
 import org.eclipse.lsp4j.generator.JsonRpcData
 import org.eclipse.lsp4j.jsonrpc.json.adapters.JsonElementTypeAdapter
@@ -34,7 +37,6 @@ import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode
 import org.eclipse.lsp4j.jsonrpc.messages.Tuple
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull
 import org.eclipse.lsp4j.util.Preconditions
-import org.eclipse.lsp4j.adapters.CompletionItemDefaultsEditRangeTypeAdapter
 
 @JsonRpcData
 class DynamicRegistrationCapabilities {
@@ -10084,6 +10086,7 @@ class DocumentDiagnosticParams extends WorkDoneProgressAndPartialResultParams {
  * Since 3.17.0
  */
 @JsonRpcData
+@JsonAdapter(DocumentDiagnosticReportTypeAdapter)
 class DocumentDiagnosticReport extends Either<RelatedFullDocumentDiagnosticReport, RelatedUnchangedDocumentDiagnosticReport> {
 	new(@NonNull RelatedFullDocumentDiagnosticReport relatedFullDocumentDiagnosticReport) {
 		super(Preconditions.checkNotNull(relatedFullDocumentDiagnosticReport, 'relatedFullDocumentDiagnosticReport'), null)
@@ -10415,6 +10418,7 @@ class WorkspaceUnchangedDocumentDiagnosticReport extends UnchangedDocumentDiagno
  * Since 3.17.0
  */
 @JsonRpcData
+@JsonAdapter(WorkspaceDocumentDiagnosticReportTypeAdapter)
 class WorkspaceDocumentDiagnosticReport extends Either<WorkspaceFullDocumentDiagnosticReport, WorkspaceUnchangedDocumentDiagnosticReport> {
 	new(@NonNull WorkspaceFullDocumentDiagnosticReport workspaceFullDocumentDiagnosticReport) {
 		super(Preconditions.checkNotNull(workspaceFullDocumentDiagnosticReport, 'workspaceFullDocumentDiagnosticReport'), null)

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/adapters/DocumentDiagnosticReportTypeAdapter.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/adapters/DocumentDiagnosticReportTypeAdapter.java
@@ -1,0 +1,53 @@
+/******************************************************************************
+ * Copyright (c) 2022 1C-Soft LLC and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.lsp4j.adapters;
+
+import java.io.IOException;
+import java.util.function.Predicate;
+
+import org.eclipse.lsp4j.DocumentDiagnosticReport;
+import org.eclipse.lsp4j.RelatedFullDocumentDiagnosticReport;
+import org.eclipse.lsp4j.RelatedUnchangedDocumentDiagnosticReport;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.EitherTypeAdapter;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.EitherTypeAdapter.PropertyChecker;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+
+public class DocumentDiagnosticReportTypeAdapter implements TypeAdapterFactory {
+
+	private static final TypeToken<DocumentDiagnosticReport> ELEMENT_TYPE = TypeToken.get(DocumentDiagnosticReport.class);
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+		Predicate<JsonElement> leftChecker = new PropertyChecker("kind", "full");
+		Predicate<JsonElement> rightChecker = new PropertyChecker("kind", "unchanged");
+		return (TypeAdapter<T>) new EitherTypeAdapter<RelatedFullDocumentDiagnosticReport, RelatedUnchangedDocumentDiagnosticReport>(
+				gson, ELEMENT_TYPE, leftChecker, rightChecker) {
+
+			@Override
+			protected DocumentDiagnosticReport createLeft(RelatedFullDocumentDiagnosticReport obj) throws IOException {
+				return new DocumentDiagnosticReport(obj);
+			}
+
+			@Override
+			protected DocumentDiagnosticReport createRight(RelatedUnchangedDocumentDiagnosticReport obj)
+					throws IOException {
+				return new DocumentDiagnosticReport(obj);
+			}
+		};
+	}
+}

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/adapters/WorkspaceDocumentDiagnosticReportTypeAdapter.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/adapters/WorkspaceDocumentDiagnosticReportTypeAdapter.java
@@ -1,0 +1,52 @@
+/******************************************************************************
+ * Copyright (c) 2022 1C-Soft LLC and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.lsp4j.adapters;
+
+import java.io.IOException;
+import java.util.function.Predicate;
+
+import org.eclipse.lsp4j.WorkspaceDocumentDiagnosticReport;
+import org.eclipse.lsp4j.WorkspaceFullDocumentDiagnosticReport;
+import org.eclipse.lsp4j.WorkspaceUnchangedDocumentDiagnosticReport;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.EitherTypeAdapter;
+import org.eclipse.lsp4j.jsonrpc.json.adapters.EitherTypeAdapter.PropertyChecker;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+
+public class WorkspaceDocumentDiagnosticReportTypeAdapter implements TypeAdapterFactory {
+
+	private static final TypeToken<WorkspaceDocumentDiagnosticReport> ELEMENT_TYPE = TypeToken.get(WorkspaceDocumentDiagnosticReport.class);
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+		Predicate<JsonElement> leftChecker = new PropertyChecker("kind", "full");
+		Predicate<JsonElement> rightChecker = new PropertyChecker("kind", "unchanged");
+		return (TypeAdapter<T>) new EitherTypeAdapter<WorkspaceFullDocumentDiagnosticReport, WorkspaceUnchangedDocumentDiagnosticReport>(
+				gson, ELEMENT_TYPE, leftChecker, rightChecker) {
+
+			@Override
+			protected WorkspaceDocumentDiagnosticReport createLeft(WorkspaceFullDocumentDiagnosticReport obj) throws IOException {
+				return new WorkspaceDocumentDiagnosticReport(obj);
+			}
+
+			@Override
+			protected WorkspaceDocumentDiagnosticReport createRight(WorkspaceUnchangedDocumentDiagnosticReport obj) throws IOException {
+				return new WorkspaceDocumentDiagnosticReport(obj);
+			}
+		};
+	}
+}

--- a/org.eclipse.lsp4j/src/test/java/org/eclipse/lsp4j/test/adapters/DocumentDiagnosticReportTypeAdapterTest.java
+++ b/org.eclipse.lsp4j/src/test/java/org/eclipse/lsp4j/test/adapters/DocumentDiagnosticReportTypeAdapterTest.java
@@ -1,0 +1,29 @@
+/******************************************************************************
+ * Copyright (c) 2022 1C-Soft LLC and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.lsp4j.test.adapters;
+
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.lsp4j.DocumentDiagnosticReport;
+import org.junit.Test;
+
+import com.google.gson.Gson;
+
+public class DocumentDiagnosticReportTypeAdapterTest {
+
+	@Test
+	public void test() {
+		Gson gson = new Gson();
+		assertTrue(gson.fromJson("{'kind': 'full', 'items': []}", DocumentDiagnosticReport.class).isLeft());
+		assertTrue(gson.fromJson("{'kind': 'unchanged'}", DocumentDiagnosticReport.class).isRight());
+	}
+}

--- a/org.eclipse.lsp4j/src/test/java/org/eclipse/lsp4j/test/adapters/WorkspaceDocumentDiagnosticReportTypeAdapterTest.java
+++ b/org.eclipse.lsp4j/src/test/java/org/eclipse/lsp4j/test/adapters/WorkspaceDocumentDiagnosticReportTypeAdapterTest.java
@@ -1,0 +1,31 @@
+/******************************************************************************
+ * Copyright (c) 2022 1C-Soft LLC and others.
+ * 
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0,
+ * or the Eclipse Distribution License v. 1.0 which is available at
+ * http://www.eclipse.org/org/documents/edl-v10.php.
+ * 
+ * SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+ ******************************************************************************/
+package org.eclipse.lsp4j.test.adapters;
+
+import static org.junit.Assert.assertTrue;
+
+import org.eclipse.lsp4j.WorkspaceDocumentDiagnosticReport;
+import org.junit.Test;
+
+import com.google.gson.Gson;
+
+public class WorkspaceDocumentDiagnosticReportTypeAdapterTest {
+
+	@Test
+	public void test() {
+		Gson gson = new Gson();
+		assertTrue(gson.fromJson("{'kind': 'full', 'items': [], 'uri': '/file:///tmp/foo'}",
+				WorkspaceDocumentDiagnosticReport.class).isLeft());
+		assertTrue(gson.fromJson("{'kind': 'unchanged', 'uri': '/file:///tmp/bar'}",
+				WorkspaceDocumentDiagnosticReport.class).isRight());
+	}
+}


### PR DESCRIPTION
Adds type adapters for `DocumentDiagnosticReport` and `WorkspaceDocumentDiagnosticReport`.

Fixes #668.