### PR TITLE
Update xtend_lib version and remove guava version rule

### DIFF
--- a/gradle/java-compiler-settings.gradle
+++ b/gradle/java-compiler-settings.gradle
@@ -80,12 +80,6 @@ signJar.dependsOn jar, sourcesJar, javadocJar
 
 artifacts.archives sourcesJar, javadocJar
 
-configurations.all {
-	resolutionStrategy {
-		force "com.google.guava:guava:18.0"
-	}
-}
-
 if (findProperty('ignoreTestFailures') == 'true') {
 	tasks.withType(Test) {
 		ignoreFailures = true

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -14,7 +14,7 @@ version = '0.17.0-SNAPSHOT'
 
 ext.versions = [
 	'xtend_lib': '2.28.0',
-	'guava': '[14.0,31)',
+	'guava': '[30.1,31)',
 	'guava_orbit': '30.1.0.v20210127-2300',
 	'gson': '[2.9.1,2.10)',
 	'gson_orbit': '2.9.1.v20220915-1632',

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -13,7 +13,7 @@
 version = '0.17.0-SNAPSHOT'
 
 ext.versions = [
-	'xtend_lib': '2.24.0',
+	'xtend_lib': '2.28.0',
 	'guava': '[14.0,31)',
 	'guava_orbit': '30.1.0.v20210127-2300',
 	'gson': '[2.9.1,2.10)',


### PR DESCRIPTION
Fixes #672 

By updating the xtend_lib version to `2.28.0`, the guava version used in the transitive dependencies is updated to a `30.0`+ version that does not contain the CVE-2020-8908 vulnerability. In order to get the build to pass locally, I also had to remove the rule that was forcing an older guava version.