### PR TITLE
Handle methods with Void return types properly

### DIFF
--- a/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/adapters/DebugMessageTypeAdapter.java
+++ b/org.eclipse.lsp4j.jsonrpc.debug/src/main/java/org/eclipse/lsp4j/jsonrpc/debug/adapters/DebugMessageTypeAdapter.java
@@ -389,7 +389,7 @@ public class DebugMessageTypeAdapter extends MessageTypeAdapter {
 								if (typeAdapter != null)
 									body = typeAdapter.fromJsonTree(jsonElement);
 								else
-									body = gson.fromJson(jsonElement, returnType);
+									body = fromJson(jsonElement, returnType);
 							}
 						}
 					}


### PR DESCRIPTION
The DAP part of LSP4J was being too strict and failing to parse response objects for methods with Void return type. With Java 17 (or some version since Java 11) turning on more strict reflection rules, the "An illegal reflective access operation has occurred" that used to be a warning is now an exception like "Failed making constructor 'java.lang.Void#Void()' accessible"

This change makes the code work and compatible with how LSP4J handles LSP Void return types.

Fixes #674