### PR TITLE
Update version qualifier for guava

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -15,7 +15,7 @@ version = '0.19.0-SNAPSHOT'
 ext.versions = [
 	'xtend_lib': '2.28.0',
 	'guava': '[30.1,31)',
-	'guava_orbit': '30.1.0.v20210127-2300',
+	'guava_orbit': '30.1.0.v20221112-0806',
 	'gson': '[2.9.1,2.10)',
 	'gson_orbit': '2.9.1.v20220915-1632',
 	'websocket_jakarta': '2.0.0',

--- a/releng/releng-target/lsp4j.target.target
+++ b/releng/releng-target/lsp4j.target.target
@@ -6,8 +6,8 @@
 			<repository location="https://download.eclipse.org/tools/orbit/downloads/2022-12"/>
 			<unit id="com.google.gson" version="2.9.1.v20220915-1632"/>
 			<unit id="com.google.gson.source" version="2.9.1.v20220915-1632"/>
-			<unit id="com.google.guava" version="30.1.0.v20210127-2300"/>
-			<unit id="com.google.guava.source" version="30.1.0.v20210127-2300"/>
+			<unit id="com.google.guava" version="30.1.0.v20221112-0806"/>
+			<unit id="com.google.guava.source" version="30.1.0.v20221112-0806"/>
 			<unit id="jakarta.websocket" version="0.0.0"/>
 			<unit id="jakarta.websocket.source" version="0.0.0"/>
 		</location>


### PR DESCRIPTION
Version qualifier for `com.google.guava 30.1.0` has changed in the latest Orbit repository `S20221115203712` from `v20210127-2300` to `v20221112-0806`, which causes LSP4J CI build to fail.