### PR TITLE
Update version range for Gson to '[2.9.1,2.11)'

### DIFF
--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -15,9 +15,7 @@ version = '0.20.1-SNAPSHOT'
 ext.versions = [
 	'xtend_lib': '2.28.0',
 	'guava': '[30.1,31)',
-	'guava_orbit': '30.1.0.v20221112-0806',
-	'gson': '[2.10.1,2.11)',
-	'gson_orbit': '2.10.1.v20230109-0753',
+	'gson': '[2.9.1,2.11)',
 	'websocket_jakarta': '2.0.0',
 	'websocket': '1.0',
 	'junit': '4.13.2'

--- a/releng/lsp4j-feature/feature.xml
+++ b/releng/lsp4j-feature/feature.xml
@@ -31,7 +31,7 @@
    </license>
 
    <requires>
-      <import plugin="com.google.gson" version="2.10.1" match="equivalent"/>
+      <import plugin="com.google.gson" version="2.9.1" match="compatible"/>
       <import plugin="org.eclipse.xtend.lib" version="2.10.0" match="compatible"/>
    </requires>
 


### PR DESCRIPTION
As suggested by @jonahgraham in https://github.com/eclipse-m2e/m2e-core/pull/1146#issuecomment-1362278527 this updates Gson version range to include the latest Gson releases 2.10 and 2.10.1:

- https://github.com/google/gson/releases/tag/gson-parent-2.10
- https://github.com/google/gson/releases/tag/gson-parent-2.10.1