### PR TITLE
Don't annotate SymbolInformation as Deprecated

### DIFF
--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/Protocol.xtend
@@ -6679,9 +6679,12 @@ class DocumentSymbol {
 /**
  * Represents information about programming constructs like variables, classes, interfaces etc.
  *
- * @deprecated Use {@link DocumentSymbol} or {@link WorkspaceSymbol} instead if supported.
+ * Deprecated Use {@link DocumentSymbol} or {@link WorkspaceSymbol} instead if supported.
+ *
+ * This class is deprecated in the LSP specification. It is not annotated with Deprecated
+ * annotation because the {@link org.eclipse.lsp4j.services.TextDocumentService.documentSymbol(DocumentSymbolParams)}
+ * method requires it and causes deprecated warning in the code of all users of that API.
  */
-@Deprecated
 @JsonRpcData
 @JsonAdapter(SymbolInformationTypeAdapter.Factory)
 class SymbolInformation {
@@ -6689,12 +6692,14 @@ class SymbolInformation {
 	 * The name of this symbol.
 	 */
 	@NonNull
+	@Deprecated
 	String name
 
 	/**
 	 * The kind of this symbol.
 	 */
 	@NonNull
+	@Deprecated
 	SymbolKind kind
 
 	/**
@@ -6702,6 +6707,7 @@ class SymbolInformation {
 	 * <p>
 	 * Since 3.16.0
 	 */
+	@Deprecated
 	List<SymbolTag> tags
 
 	/**
@@ -6726,6 +6732,7 @@ class SymbolInformation {
 	 * the symbols.
 	 */
 	@NonNull
+	@Deprecated
 	Location location
 
 	/**
@@ -6734,17 +6741,21 @@ class SymbolInformation {
 	 * if necessary). It can't be used to re-infer a hierarchy for the document
 	 * symbols.
 	 */
+	@Deprecated
 	String containerName
 
+	@Deprecated
 	new() {
 	}
 
+	@Deprecated
 	new(@NonNull String name, @NonNull SymbolKind kind, @NonNull Location location) {
 		this.name = Preconditions.checkNotNull(name, 'name')
 		this.kind = Preconditions.checkNotNull(kind, 'kind')
 		this.location = Preconditions.checkNotNull(location, 'location')
 	}
 
+	@Deprecated
 	new(@NonNull String name, @NonNull SymbolKind kind, @NonNull Location location, String containerName) {
 		this(name, kind, location)
 		this.containerName = containerName

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/adapters/DocumentSymbolResponseAdapter.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/adapters/DocumentSymbolResponseAdapter.java
@@ -25,7 +25,6 @@ import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
 import com.google.gson.reflect.TypeToken;
 
-@SuppressWarnings("deprecation")
 public class DocumentSymbolResponseAdapter implements TypeAdapterFactory {
 	
 	private static final TypeToken<Either<SymbolInformation, DocumentSymbol>> ELEMENT_TYPE

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/adapters/WorkspaceSymbolResponseAdapter.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/adapters/WorkspaceSymbolResponseAdapter.java
@@ -25,7 +25,6 @@ import com.google.gson.TypeAdapter;
 import com.google.gson.TypeAdapterFactory;
 import com.google.gson.reflect.TypeToken;
 
-@SuppressWarnings("deprecation")
 public class WorkspaceSymbolResponseAdapter implements TypeAdapterFactory {
 
 	private static final TypeToken<Either<List<? extends SymbolInformation>, List<? extends WorkspaceSymbol>>> EITHER_TYPE

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/TextDocumentService.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/TextDocumentService.java
@@ -103,7 +103,6 @@ import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import org.eclipse.lsp4j.jsonrpc.services.JsonSegment;
 
-@SuppressWarnings("deprecation")
 @JsonSegment("textDocument")
 public interface TextDocumentService {
 	/**

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/WorkspaceService.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/WorkspaceService.java
@@ -34,7 +34,6 @@ import org.eclipse.lsp4j.jsonrpc.services.JsonNotification;
 import org.eclipse.lsp4j.jsonrpc.services.JsonRequest;
 import org.eclipse.lsp4j.jsonrpc.services.JsonSegment;
 
-@SuppressWarnings("deprecation")
 @JsonSegment("workspace")
 public interface WorkspaceService {
 	/**


### PR DESCRIPTION
While SymbolInformation class is deprecated in the LSP specification. It is not annotated with Deprecated annotation because the TextDocumentService.documentSymbol method requires it and causes deprecated warning in the code of all users of that API.

Instead we mark all the methods/constructors as
@Deprecated so that consumers that are actually using instances of SymbolInformation get deprecated warnings, while avoiding deprecated warnings for just referring to the type.

Fixes #697