### PR TITLE
Use 0.19.0 as API baseline

### DIFF
--- a/releng/runjapicmp.sh
+++ b/releng/runjapicmp.sh
@@ -5,7 +5,7 @@ set -e # error out on any failed commands
 #set -x # echo all commands used for debugging purposes
 
 
-BASELINE=0.18.0
+BASELINE=0.19.0
 
 JAPICMP_VERSION=0.15.7
 WD=$(mktemp -d)


### PR DESCRIPTION
There should be no changes at all in 0.19.x compared to 0.19.0

Part of #719