### PR TITLE
fix(tracing): stop 'Unmatched response message' logs for non-stream IO

### DIFF
--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/TracingMessageConsumer.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/TracingMessageConsumer.java
@@ -12,7 +12,6 @@
 package org.eclipse.lsp4j.jsonrpc;
 
 import org.eclipse.lsp4j.jsonrpc.json.MessageJsonHandler;
-import org.eclipse.lsp4j.jsonrpc.json.StreamMessageConsumer;
 import org.eclipse.lsp4j.jsonrpc.messages.Message;
 import org.eclipse.lsp4j.jsonrpc.messages.NotificationMessage;
 import org.eclipse.lsp4j.jsonrpc.messages.RequestMessage;
@@ -102,13 +101,12 @@ public class TracingMessageConsumer implements MessageConsumer {
 		final String date = dateTimeFormatter.format(now);
 		final String logString;
 
-		if (messageConsumer instanceof StreamMessageConsumer) {
-			logString = consumeMessageSending(message, now, date);
-		} else if (messageConsumer instanceof RemoteEndpoint) {
+		if (messageConsumer instanceof RemoteEndpoint) {
 			logString = consumeMessageReceiving(message, now, date);
 		} else {
-			LOG.log(WARNING, String.format("Unknown MessageConsumer type: %s", messageConsumer));
-			logString = null;
+			// Treat any non-RemoteEndpoint consumer as an outgoing transport (sending),
+			// so tracing works for WebSocket and other non-stream consumers as well.
+			logString = consumeMessageSending(message, now, date);
 		}
 
 		if (logString != null) {


### PR DESCRIPTION
This PR addresses #593

Previously only StreamMessageConsumer was treated as "sending". With WebSocket and other non-stream transports, sentRequests stayed empty, so every incoming response looked unmatched, emitted a warning, and produced no trace.

Now any consumer that is not a RemoteEndpoint is treated as "sending", ensuring sentRequests is populated regardless of transport and responses are matched correctly. Removed the "Unknown MessageConsumer type" branch to avoid misclassification and improve compatibility with custom/non-stream transports.