### PR TITLE
Fix sporadic failure of `DebugIntegrationTest.testCancellation`

### DIFF
--- a/org.eclipse.lsp4j.jsonrpc.debug/src/test/java/org/eclipse/lsp4j/jsonrpc/debug/test/DebugIntegrationTest.java
+++ b/org.eclipse.lsp4j.jsonrpc.debug/src/test/java/org/eclipse/lsp4j/jsonrpc/debug/test/DebugIntegrationTest.java
@@ -200,7 +200,7 @@ public class DebugIntegrationTest {
 			if (System.currentTimeMillis() - startTime > TIMEOUT)
 				Assert.fail("Timeout waiting for client to start computing.");
 		}
-		future.cancel(true);
+		boolean cancelled = future.cancel(true);
 
 		startTime = System.currentTimeMillis();
 		while (!cancellationHappened[0]) {
@@ -211,7 +211,13 @@ public class DebugIntegrationTest {
 		try {
 			future.get(TIMEOUT, TimeUnit.MILLISECONDS);
 			Assert.fail("Expected cancellation.");
-		} catch (CancellationException e) {
+		} catch (CancellationException | ExecutionException e) {
+			if (e instanceof ExecutionException) {
+				Assert.assertFalse(cancelled);
+				Assert.assertEquals("org.eclipse.lsp4j.jsonrpc.ResponseErrorException: The request (id: 1, method: 'askClient') has been cancelled", e.getMessage());
+			} else {
+				Assert.assertTrue(cancelled);
+			}
 		}
 	}
 

--- a/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/IntegrationTest.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/IntegrationTest.java
@@ -336,7 +336,7 @@ public class IntegrationTest {
 			if (System.currentTimeMillis() - startTime > TIMEOUT)
 				Assert.fail("Timeout waiting for client to start computing.");
 		}
-		future.cancel(true);
+		boolean cancelled = future.cancel(true);
 
 		startTime = System.currentTimeMillis();
 		while (!cancellationHappened[0]) {
@@ -347,7 +347,13 @@ public class IntegrationTest {
 		try {
 			future.get(TIMEOUT, TimeUnit.MILLISECONDS);
 			Assert.fail("Expected cancellation.");
-		} catch (CancellationException e) {
+		} catch (CancellationException | ExecutionException e) {
+			if (e instanceof ExecutionException) {
+				Assert.assertFalse(cancelled);
+				Assert.assertEquals("org.eclipse.lsp4j.jsonrpc.ResponseErrorException: The request (id: 1, method: 'askClient') has been cancelled", e.getMessage());
+			} else {
+				Assert.assertTrue(cancelled);
+			}
 		}
 	}
 	


### PR DESCRIPTION
This PR fixes sporadic failure of `DebugIntegrationTest.testCancellation`, which happened when merging #907:
https://github.com/eclipse-lsp4j/lsp4j/actions/runs/18980903518/job/54212884068

The test expected that `CancellationException` would be thrown when calling `future.get` after calling `future.cancel`, without checking that `future.cancel` actually returned `true`.

However, `future.cancel` can also return `false` if the future has already completed, which may happen concurrently with the `future.cancel` call. Attempting to cancel a future is inherently racy with the future completion.

In this specific case, the test should expect not only `CancellationException` (when `future.cancel` returns `true`), but also `ExecutionException` caused by `ResponseErrorException` with message "The request (id: 1, method: 'askClient') has been cancelled" (when `future.cancel` returns `false`).

See also  https://github.com/eclipse-lsp4j/lsp4j/pull/907#issuecomment-3474336380 and later comments in the conversation.