### PR TITLE
Replace method toProxy() with toServiceObject()

### DIFF
--- a/documentation/jsonrpc.md
+++ b/documentation/jsonrpc.md
@@ -98,7 +98,7 @@ public interface MyService {
 }
 
 Endpoint endpoint = ...
-MyService proxy = ServiceEndpoints.toProxy(endpoint, MyService.class);
+MyService proxy = ServiceEndpoints.toServiceObject(endpoint, MyService.class);
 ```
 
 Of course you can use the same interface, as is done with the [interfaces](../org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/services/LanguageServer.java) defining the messages of the LSP.


### PR DESCRIPTION
- Fix #912
- Replace the method `toProxy()` with `toServiceObject()` from jsonrpc.md documentation