### PR TITLE
Add utility method for request cancellation

### DIFF
--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/CompletableFutures.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/CompletableFutures.java
@@ -20,6 +20,32 @@ public final class CompletableFutures {
 	private CompletableFutures() {}
 
 	/**
+	 * A utility method to cancel the JSON-RPC request associated with the given future.
+	 * <p>
+	 * If the given future does not pertain to a JSON-RPC request or is <code>null</code>,
+	 * this method has no effect.
+	 *
+	 * @param future a {@link CompletableFuture}, or <code>null</code>
+	 * @param cancelRootFuture if <code>false</code>, this method will only ensure that a cancel
+	 *  notification has been sent for the pending request to the remote endpoint, without attempting
+	 *  to cancel any future pertaining to the request; if <code>true</code>, this method will
+	 *  also attempt to cancel the root future for the request
+	 * @return <code>false</code> if the given future does not pertain to a JSON-RPC request
+	 *  or is <code>null</code>; <code>true</code> otherwise
+	 */
+	public static boolean cancelRequest(CompletableFuture<?> future, boolean cancelRootFuture) {
+		if (future instanceof JsonRpcRequestFuture) {
+			if (cancelRootFuture) {
+				((JsonRpcRequestFuture<?>) future).getRoot().cancel(true);
+			} else {
+				((JsonRpcRequestFuture<?>) future).cancelRequest();
+			}
+			return true;
+		}
+		return false;
+	}
+
+	/**
 	 * A utility method to create a {@link CompletableFuture} with cancellation support.
 	 *
 	 * @param code a function that accepts a {@link CancelChecker} and returns the to be computed value


### PR DESCRIPTION
This PR adds a utility method to cancel the JSON-RPC request associated with a `CompletableFuture`. It shall allow clients to avoid downcasts to `JsonRpcRequestFuture` in their code.

It is a follow-up to #907.

cc @sebthom