### PR TITLE
Update CHANGELOG and README w.r.t. LSP 3.18 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 ### v1.0.0 (TBD)
 
+* Implemented LSP version 3.18.0 (specification is not finalized yet)
 * Implemented [LSP proposal](https://github.com/microsoft/language-server-protocol/pull/2003) for `SymbolTag` [#856](https://github.com/eclipse-lsp4j/lsp4j/pull/856)
+* Removed `@Deprecated` annotations on members deprecated in the LSP/DAP protocol [#895](https://github.com/eclipse-lsp4j/lsp4j/issues/895)
 
 Fixed issues: <https://github.com/eclipse-lsp4j/lsp4j/milestone/37?closed=1>
-
-* Removed `@Deprecated` annotations on members deprecated in the LSP/DAP protocol [#895](https://github.com/eclipse-lsp4j/lsp4j/issues/895)
 
 Breaking API changes:
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The Maven Repositories, p2 Update Sites, and the Snapshots contain _signed jars_
 
 ### Supported LSP Versions
 
- * LSP4J 1.0.&ast; _(Next release)_ &rarr; LSP 3.17.0 (plus [SymbolTag proposal](https://github.com/microsoft/language-server-protocol/pull/2003))
+ * LSP4J 1.0.&ast; _(Next release)_ &rarr; LSP 3.18.0 (specification is not finalized yet) plus [SymbolTag proposal](https://github.com/microsoft/language-server-protocol/pull/2003)
  * LSP4J 0.24.&ast; &rarr; LSP 3.17.0
  * LSP4J 0.23.&ast; &rarr; LSP 3.17.0
  * LSP4J 0.22.&ast; &rarr; LSP 3.17.0


### PR DESCRIPTION
This is a follow-up to https://github.com/eclipse-lsp4j/lsp4j/pull/893#issuecomment-3571186528.