### PR TITLE
Remove `throws IOException` from methods that do not need to throw it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ Breaking API changes:
     * Type of `Diagnostic.message` changed from `String` to `Either<String, MarkupContent>`
     * Type of `DocumentFilter.pattern` changed from `String` to `Either<String, RelativePattern>`
     * Type of `NotebookDocumentFilter.pattern` changed from `String` to `Either<String, RelativePattern>`
+ * Removed `throws IOException` from methods that do not need to throw it [#934](https://github.com/eclipse-lsp4j/lsp4j/issues/934)
+    * `EitherTypeAdapter.createLeft`
+    * `EitherTypeAdapter.createRight`
+    * `EitherTypeAdapter.EitherTypeArgument.read(JsonElement)`
+    * `StreamMessageProducer.handleMessage`
 
 japicmp report: <https://download.eclipse.org/lsp4j/builds/main/japicmp-report/>
 

--- a/org.eclipse.lsp4j.jsonrpc/src/jmh/java/org/eclipse/lsp4j/jsonrpc/jmh/StreamMessageConsumerBenchmark.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/jmh/java/org/eclipse/lsp4j/jsonrpc/jmh/StreamMessageConsumerBenchmark.java
@@ -42,7 +42,6 @@ public class StreamMessageConsumerBenchmark {
 	private StreamMessageConsumer consumer;
 	private RequestMessage message;
 
-	@SuppressWarnings("resource")
 	@Setup
 	public void setup() {
 		consumer = new StreamMessageConsumer(OutputStream.nullOutputStream(), new MessageJsonHandler(emptyMap()));

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/StreamMessageProducer.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/StreamMessageProducer.java
@@ -179,7 +179,7 @@ public class StreamMessageProducer implements MessageProducer, Closeable, Messag
 	 *
 	 * @return {@code true} if we should continue reading from the input stream, {@code false} if we should stop
 	 */
-	protected boolean handleMessage(InputStream input, Headers headers) throws IOException {
+	protected boolean handleMessage(InputStream input, Headers headers) {
 		if (callback == null)
 			callback = message -> LOG.log(Level.INFO, "Received message: " + message);
 

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/adapters/EitherTypeAdapter.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/adapters/EitherTypeAdapter.java
@@ -211,14 +211,14 @@ public class EitherTypeAdapter<L, R> extends TypeAdapter<Either<L, R>> {
 	}
 
 	@SuppressWarnings("unchecked")
-	protected Either<L, R> createLeft(L obj) throws IOException {
+	protected Either<L, R> createLeft(L obj) {
 		if (Either3.class.isAssignableFrom(typeToken.getRawType()))
 			return (Either<L, R>) Either3.forLeft3(obj);
 		return Either.forLeft(obj);
 	}
 
 	@SuppressWarnings("unchecked")
-	protected Either<L, R> createRight(R obj) throws IOException {
+	protected Either<L, R> createRight(R obj) {
 		if (Either3.class.isAssignableFrom(typeToken.getRawType()))
 			return (Either<L, R>) Either3.forRight3((Either<?, ?>) obj);
 		return Either.forRight(obj);
@@ -275,7 +275,7 @@ public class EitherTypeAdapter<L, R> extends TypeAdapter<Either<L, R>> {
 			return this.adapter.read(in);
 		}
 
-		public T read(JsonElement element) throws IOException {
+		public T read(JsonElement element) {
 			return this.adapter.fromJsonTree(element);
 		}
 

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/adapters/DocumentDiagnosticReportTypeAdapter.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/adapters/DocumentDiagnosticReportTypeAdapter.java
@@ -11,8 +11,6 @@
  ******************************************************************************/
 package org.eclipse.lsp4j.adapters;
 
-import java.io.IOException;
-
 import org.eclipse.lsp4j.DocumentDiagnosticReport;
 import org.eclipse.lsp4j.RelatedFullDocumentDiagnosticReport;
 import org.eclipse.lsp4j.RelatedUnchangedDocumentDiagnosticReport;
@@ -37,13 +35,12 @@ public class DocumentDiagnosticReportTypeAdapter implements TypeAdapterFactory {
 				gson, ELEMENT_TYPE, leftChecker, rightChecker) {
 
 			@Override
-			protected DocumentDiagnosticReport createLeft(RelatedFullDocumentDiagnosticReport obj) throws IOException {
+			protected DocumentDiagnosticReport createLeft(RelatedFullDocumentDiagnosticReport obj) {
 				return new DocumentDiagnosticReport(obj);
 			}
 
 			@Override
-			protected DocumentDiagnosticReport createRight(RelatedUnchangedDocumentDiagnosticReport obj)
-					throws IOException {
+			protected DocumentDiagnosticReport createRight(RelatedUnchangedDocumentDiagnosticReport obj) {
 				return new DocumentDiagnosticReport(obj);
 			}
 		};

--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/adapters/WorkspaceDocumentDiagnosticReportListAdapter.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/adapters/WorkspaceDocumentDiagnosticReportListAdapter.java
@@ -11,7 +11,6 @@
  ******************************************************************************/
 package org.eclipse.lsp4j.adapters;
 
-import java.io.IOException;
 import java.util.ArrayList;
 
 import org.eclipse.lsp4j.WorkspaceDocumentDiagnosticReport;
@@ -37,12 +36,12 @@ public class WorkspaceDocumentDiagnosticReportListAdapter implements TypeAdapter
 		final var rightChecker = new PropertyChecker("kind", "unchanged");
 		final var elementTypeAdapter = new EitherTypeAdapter<>(gson, ELEMENT_TYPE, leftChecker, rightChecker) {
 			@Override
-			protected WorkspaceDocumentDiagnosticReport createLeft(WorkspaceFullDocumentDiagnosticReport obj) throws IOException {
+			protected WorkspaceDocumentDiagnosticReport createLeft(WorkspaceFullDocumentDiagnosticReport obj) {
 				return new WorkspaceDocumentDiagnosticReport(obj);
 			}
 
 			@Override
-			protected WorkspaceDocumentDiagnosticReport createRight(WorkspaceUnchangedDocumentDiagnosticReport obj) throws IOException {
+			protected WorkspaceDocumentDiagnosticReport createRight(WorkspaceUnchangedDocumentDiagnosticReport obj) {
 				return new WorkspaceDocumentDiagnosticReport(obj);
 			}
 		};


### PR DESCRIPTION
Closes #934.

Also removes `@SuppressWarnings("resource")` on `StreamMessageConsumerBenchmark.setup`, which is no longer necessary and caused `At least one of the problems in category 'resource' is not analysed due to a compiler option being ignored` info.

This PR should fix all remaining problems (warnings/infos) in LSP4J workspace.