### PR TITLE
Generalize processing of doc-annotations in `JsonRpcDataProcessor`

### DIFF
--- a/org.eclipse.lsp4j.generator/src/main/java/org/eclipse/lsp4j/generator/JsonRpcDataProcessor.xtend
+++ b/org.eclipse.lsp4j.generator/src/main/java/org/eclipse/lsp4j/generator/JsonRpcDataProcessor.xtend
@@ -12,9 +12,7 @@
 package org.eclipse.lsp4j.generator
 
 import com.google.gson.annotations.JsonAdapter
-import org.eclipse.lsp4j.jsonrpc.ProtocolDeprecated
-import org.eclipse.lsp4j.jsonrpc.ProtocolDraft
-import org.eclipse.lsp4j.jsonrpc.ProtocolSince
+import java.lang.annotation.Documented
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull
 import org.eclipse.xtend.lib.annotations.AccessorsProcessor
 import org.eclipse.xtend.lib.annotations.EqualsHashCodeProcessor
@@ -61,23 +59,17 @@ class JsonRpcDataProcessor extends AbstractClassProcessor {
 			!static
 		].forEach [ field |
 			val accessorsUtil = new AccessorsProcessor.Util(context)
-			val protocolDraft = field.findAnnotation(ProtocolDraft.newTypeReference.type)
-			val protocolSince = field.findAnnotation(ProtocolSince.newTypeReference.type)
-			val protocolDeprecated = field.findAnnotation(ProtocolDeprecated.newTypeReference.type)
-			val deprecated = field.findAnnotation(Deprecated.newTypeReference.type)
+			val docAnnotations = field.annotations.filter [ annotation |
+				annotation.annotationTypeDeclaration.findAnnotation(Documented.newTypeReference.type) !== null
+			]
 			val hasNonNull = field.findAnnotation(NonNull.newTypeReference.type) !== null
 			val hasJsonAdapter = field.findAnnotation(JsonAdapter.newTypeReference.type) !== null
 			accessorsUtil.addGetter(field, Visibility.PUBLIC)
 			impl.findDeclaredMethod(accessorsUtil.getGetterName(field)) => [
 				docComment = field.docComment
-				if (protocolDraft !== null)
-					addAnnotation(protocolDraft)
-				if (protocolSince !== null)
-					addAnnotation(protocolSince)
-				if (protocolDeprecated !== null)
-					addAnnotation(protocolDeprecated)
-				if (deprecated !== null)
-					addAnnotation(deprecated)
+				docAnnotations.forEach [ annotation |
+					addAnnotation(annotation)
+				]
 				if (hasNonNull) {
 					addAnnotation(newAnnotationReference(NonNull))
 				}
@@ -88,14 +80,9 @@ class JsonRpcDataProcessor extends AbstractClassProcessor {
 				val setterName = accessorsUtil.getSetterName(field)
 				impl.findDeclaredMethod(setterName, field.type) => [
 					docComment = field.docComment
-					if (protocolDraft !== null)
-						addAnnotation(protocolDraft)
-					if (protocolSince !== null)
-						addAnnotation(protocolSince)
-					if (protocolDeprecated !== null)
-						addAnnotation(protocolDeprecated)
-					if (deprecated !== null)
-						addAnnotation(deprecated)
+					docAnnotations.forEach [ annotation |
+						addAnnotation(annotation)
+					]
 					if (hasNonNull) {
 						val parameter = parameters.head
 						parameter.addAnnotation(newAnnotationReference(NonNull))


### PR DESCRIPTION
Currently, `JsonRpcDataProcessor` copies the doc-comment and selected annotations such as `@ProtocolDeprecated`, `@ProtocolDraft`, `@ProtocolSince`, and `@Deprecated` from a field of a protocol class to the generated getter and setter for the field.

I think that this processing can and should be generalized to include all doc-annotations (i.e. all annotations annotated with `@Documented`), since by definition all doc-annotations are considered part of the element's public contract and, therefore, should be copied to the generated getter and setter along with the doc-comment they essentially part of.

If `JsonRpcDataProcessor` were implemented in this way, we would not need to modify it to add special processing for the `@ProtocolDeprecated`, `@ProtocolDraft`, and `@ProtocolSince` annotations introduced recently. It would just work.