### PR TITLE
Add two more symbol tags: Overrides and Implements

### DIFF
--- a/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/SymbolTag.java
+++ b/org.eclipse.lsp4j/src/main/java/org/eclipse/lsp4j/SymbolTag.java
@@ -178,7 +178,26 @@ public enum SymbolTag {
 	 * <p>This is an LSP <b>proposal</b>. See <a href="https://github.com/microsoft/language-server-protocol/pull/2003">PR</a></p>
 	 */
 	@ProtocolDraft
-	ReadOnly(20);
+	ReadOnly(20),
+	
+	/**
+	 * <p>Render a symbol as "overriding", e.g. a Java method replaces the implementation from an
+	 * equally named method (with same signature) from a parent class.</p>
+	 * 
+	 * <p>This is an LSP <b>proposal</b>. See <a href="https://github.com/microsoft/language-server-protocol/pull/2003">PR</a></p>
+	 */
+	@ProtocolDraft
+	Overrides(21),
+	
+	/**
+	 * <p>Render a symbol as "implementing", e.g. a Java method implements a method with same signature declared in an
+	 * interface or implements an abstract method (with same signature) from an abstract parent class.</p>
+	 * 
+	 * <p>This is an LSP <b>proposal</b>. See <a href="https://github.com/microsoft/language-server-protocol/pull/2003">PR</a></p>
+	 */
+	@ProtocolDraft
+	Implements(22);
+
 
 	private final int value;
 	


### PR DESCRIPTION
This is a follow-up to PR #856.

I added two more symbol tags in my LSP spec. PR and I would like to also add them in LSP4J in order to comply with the other PR.
See https://github.com/microsoft/language-server-protocol/pull/2003

My goal is to offer LSP4E and other tools a way to show if a method is implementing or overriding another method from a parent class or interface, similar to JDT using implements / overrides overlay icons in the outline view.