### PR TITLE
Update DAP version to 1.70.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Implemented LSP version 3.18.0 (specification is not finalized yet)
 * Implemented [LSP proposal](https://github.com/microsoft/language-server-protocol/pull/2003) for `SymbolTag` [#856](https://github.com/eclipse-lsp4j/lsp4j/pull/856)
 * Removed `@Deprecated` annotations on members deprecated in the LSP/DAP protocol [#895](https://github.com/eclipse-lsp4j/lsp4j/issues/895)
+* Implemented DAP version 1.70.0
 
 Fixed issues: <https://github.com/eclipse-lsp4j/lsp4j/milestone/37?closed=1>
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The Maven Repositories, p2 Update Sites, and the Snapshots contain _signed jars_
 
 ### Supported DAP Versions
 
- * LSP4J 1.0.&ast; _(Next release)_ &rarr; DAP 1.69.0
+ * LSP4J 1.0.&ast; _(Next release)_ &rarr; DAP 1.70.0
  * LSP4J 0.24.&ast; &rarr; DAP 1.69.0
  * LSP4J 0.23.&ast; &rarr; DAP 1.65.0
  * LSP4J 0.22.&ast; &rarr; DAP 1.60.0

--- a/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/DebugProtocol.xtend
+++ b/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/DebugProtocol.xtend
@@ -30,7 +30,7 @@ class DebugProtocol {
 	/**
 	 * Version of Debug Protocol
 	 */
-	public static final String SCHEMA_VERSION = "1.69.0";
+	public static final String SCHEMA_VERSION = "1.70.0";
 
 	/**
 	 * Refer to the Debug Adapter Protocol's
@@ -392,6 +392,9 @@ enum OutputEventArgumentsGroup {
 
 /**
  * The event indicates that some information about a breakpoint has changed.
+ * While debug adapters may notify the clients of `changed` breakpoints using this
+ * event, clients should continue to use the breakpoint's original properties when
+ * updating a source's breakpoints in the `breakpoint` request."
  * <p>
  * Represents the {@code body} of {@code BreakpointEvent} defined in spec.
  */
@@ -1641,7 +1644,8 @@ class StackTraceArguments {
 	 */
 	Integer levels;
 	/**
-	 * Specifies details on how to format the stack frames.
+	 * Specifies details on how to format the returned `StackFrame.name`. The debug adapter may format
+	 * requested details in any way that would make sense to a developer.
 	 * <p>
 	 * The attribute is only honored by a debug adapter if the corresponding capability
 	 * {@link Capabilities#getSupportsValueFormattingOptions} is true.
@@ -2686,8 +2690,10 @@ class Capabilities {
 	 */
 	Boolean supportsCompletionsRequest;
 	/**
-	 * The set of characters that should trigger completion in a REPL. If not specified, the UI should assume the '.'
-	 * character.
+	 * he set of characters that should automatically trigger a completion request
+	 * in a REPL. If not specified, the client should assume the `.` character. The
+	 * client may trigger additional completion requests on characters such as ones
+	 * that make up common identifiers, or as otherwise requested by a user.
 	 * <p>
 	 * This is an optional property.
 	 */

--- a/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/services/IDebugProtocolClient.java
+++ b/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/services/IDebugProtocolClient.java
@@ -48,7 +48,7 @@ public interface IDebugProtocolClient {
 	/**
 	 * Version of Debug Protocol
 	 */
-	String SCHEMA_VERSION = "1.69.0";
+	String SCHEMA_VERSION = "1.70.0";
 
 	/**
 	 * This event indicates that the debug adapter is ready to accept configuration

--- a/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/services/IDebugProtocolServer.java
+++ b/org.eclipse.lsp4j.debug/src/main/java/org/eclipse/lsp4j/debug/services/IDebugProtocolServer.java
@@ -94,7 +94,7 @@ public interface IDebugProtocolServer {
 	/**
 	 * Version of Debug Protocol
 	 */
-	String SCHEMA_VERSION = "1.69.0";
+	String SCHEMA_VERSION = "1.70.0";
 
 	/**
 	 * The 'cancel' request is used by the client in two situations:


### PR DESCRIPTION
1.70.0 release of DAP is a documentation only change which clarifies a few fields in the DAP.

Fixes https://github.com/eclipse-lsp4j/lsp4j/issues/940