### PR TITLE
Fix closing bug

### DIFF
--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/MessageProducer.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/MessageProducer.java
@@ -11,7 +11,9 @@
  ******************************************************************************/
 package org.eclipse.lsp4j.jsonrpc;
 
-public interface MessageProducer {
+import java.io.Closeable;
+
+public interface MessageProducer extends Closeable {
 	
 	/**
 	 * Listen to a message source and forward all messages to the given consumer. Typically this method

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/ConcurrentMessageProcessor.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/ConcurrentMessageProcessor.java
@@ -52,7 +52,7 @@ public class ConcurrentMessageProcessor implements Runnable {
 			public boolean cancel(boolean mayInterruptIfRunning) {
 				if (mayInterruptIfRunning && messageProducer instanceof Closeable) {
 					try {
-						((Closeable) messageProducer).close();
+						messageProducer.close();
 					} catch (IOException e) {
 						throw new RuntimeException(e);
 					}

--- a/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/StreamMessageProducer.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/json/StreamMessageProducer.java
@@ -31,7 +31,7 @@ import org.eclipse.lsp4j.jsonrpc.util.LimitedInputStream;
 /**
  * A message producer that reads from an input stream and parses messages from JSON.
  */
-public class StreamMessageProducer implements MessageProducer, Closeable, MessageConstants {
+public class StreamMessageProducer implements MessageProducer, MessageConstants {
 
 	private static final Logger LOG = Logger.getLogger(StreamMessageProducer.class.getName());
 
@@ -204,8 +204,9 @@ public class StreamMessageProducer implements MessageProducer, Closeable, Messag
 	}
 
 	@Override
-	public void close() {
+	public void close() throws IOException {
 		keepRunning = false;
+        input.close();
 	}
 
 }

--- a/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/json/MessageProducerTest.java
+++ b/org.eclipse.lsp4j.jsonrpc/src/test/java/org/eclipse/lsp4j/jsonrpc/test/json/MessageProducerTest.java
@@ -69,7 +69,9 @@ public class MessageProducerTest {
 			MessageJsonHandler jsonHandler = new MessageJsonHandler(Collections.emptyMap());
 			try (StreamMessageProducer messageProducer = new StreamMessageProducer(input, jsonHandler)) {
 				messageProducer.listen(message -> {});
-			}
+			}catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
 		}).get(TIMEOUT, TimeUnit.MILLISECONDS);
 	}
 
@@ -85,7 +87,9 @@ public class MessageProducerTest {
 			MessageJsonHandler jsonHandler = new MessageJsonHandler(Collections.emptyMap());
 			try (StreamMessageProducer messageProducer = new StreamMessageProducer(input, jsonHandler)) {
 				messageProducer.listen(message -> {});
-			}
+			}catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
 		}).get(TIMEOUT, TimeUnit.MILLISECONDS);
 	}
 
@@ -101,7 +105,9 @@ public class MessageProducerTest {
 			MessageJsonHandler jsonHandler = new MessageJsonHandler(Collections.emptyMap());
 			try (StreamMessageProducer messageProducer = new StreamMessageProducer(input, jsonHandler)) {
 				messageProducer.listen(message -> {});
-			}
+			}catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
 		}).get(TIMEOUT, TimeUnit.MILLISECONDS);
 	}
 
@@ -118,7 +124,9 @@ public class MessageProducerTest {
 				MessageJsonHandler jsonHandler = new MessageJsonHandler(Collections.emptyMap());
 				try (StreamMessageProducer messageProducer = new StreamMessageProducer(input, jsonHandler)) {
 					messageProducer.listen(message -> {});
-				}
+				}catch (IOException e) {
+                    throw new IllegalStateException(e);
+                }
 			}).get(TIMEOUT, TimeUnit.MILLISECONDS);
 		} catch (ExecutionException e) {
 			throw e.getCause();
@@ -149,11 +157,13 @@ public class MessageProducerTest {
 			}
 
 			var jsonHandler = new MessageJsonHandler(Collections.emptyMap());
-			try (var producer = new TestProducer( new ByteArrayInputStream(inputStr.getBytes()), jsonHandler)) {
-				var received = new ArrayList<>();
-				producer.listen(received::add);
-				assertEquals("Both messages should be delivered", 2, received.size());
-			}
+            try (var producer = new TestProducer(new ByteArrayInputStream(inputStr.getBytes()), jsonHandler)) {
+                var received = new ArrayList<>();
+                producer.listen(received::add);
+                assertEquals("Both messages should be delivered", 2, received.size());
+            } catch (IOException e) {
+                throw new IllegalStateException(e);
+            }
 		}).get(TIMEOUT, TimeUnit.MILLISECONDS);
 	}
 


### PR DESCRIPTION
The close method of StreamMessageProducer only sets the keepRunning to false.
In case the loop is already blocking in l.82 this will never actually close the Producer, because it keeps blocking waiting on input.