### PR TITLE
Fix ResponseErrorCode casing in shutdown method example

### DIFF
--- a/documentation/jsonrpc.md
+++ b/documentation/jsonrpc.md
@@ -45,7 +45,7 @@ For example:
    @Override
    public CompletableFuture<Object> shutdown() {
       if (!isInitialized()) {
-         ResponseError error = new ResponseError(ResponseErrorCode.serverNotInitialized, "Server was not initialized", null);
+         ResponseError error = new ResponseError(ResponseErrorCode.ServerNotInitialized, "Server was not initialized", null);
          throw new ResponseErrorException(error);
       }
       return doShutdown();


### PR DESCRIPTION
This should be uppercase, matching: https://github.com/eclipse-lsp4j/lsp4j/blob/5486d6fc35c87b22afd0a241154ca27f204dd9da/org.eclipse.lsp4j.jsonrpc/src/main/java/org/eclipse/lsp4j/jsonrpc/messages/ResponseErrorCode.java#L57-L61